### PR TITLE
feat: add dark mode with theme toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ A WCAG-compliant, multi-tenant web application for butterfly houses to track shi
 - **Language**: TypeScript
 - **Package Manager**: pnpm
 - **Styling**: Tailwind CSS 4
-- **UI**: Shadcn/UI (Radix-based), Lucide icons, Sonner toasts
+- **UI**: Shadcn/UI (Radix-based), Lucide icons, Sonner toasts, next-themes
 - **Forms**: React Hook Form + Zod validation
 - **Charts**: Recharts
 - **Auth**: NextAuth 5 (credentials provider, JWT sessions)
@@ -55,9 +55,9 @@ src/
 │   ├── admin/              # Admin-specific components
 │   ├── auth/               # Auth-specific components
 │   ├── nav/                # Navigation components (top-nav, mobile-nav, footer)
-│   ├── providers/          # Context providers (session, institution data)
+│   ├── providers/          # Context providers (session, institution data, theme)
 │   ├── public/             # Public-facing components (gallery, home, species detail)
-│   ├── shared/             # Shared components used across public/admin
+│   ├── shared/             # Shared components used across public/admin (theme toggle)
 │   └── ui/                 # 55 Shadcn/UI primitives
 ├── hooks/                  # Custom React hooks
 │   ├── use-institution.ts  # Institution slug/basePath from URL params

--- a/src/__test__/theme-toggle.test.ts
+++ b/src/__test__/theme-toggle.test.ts
@@ -1,4 +1,4 @@
-import { getNextTheme, getThemeLabel } from "@/components/shared/theme-toggle";
+import { getNextTheme, getThemeLabel } from "@/lib/theme-utils";
 
 describe("getNextTheme", () => {
   it('returns "light" when current theme is "dark"', () => {

--- a/src/__test__/theme-toggle.test.ts
+++ b/src/__test__/theme-toggle.test.ts
@@ -1,0 +1,34 @@
+import { getNextTheme, getThemeLabel } from "@/components/shared/theme-toggle";
+
+describe("getNextTheme", () => {
+  it('returns "light" when current theme is "dark"', () => {
+    expect(getNextTheme("dark")).toBe("light");
+  });
+
+  it('returns "dark" when current theme is "light"', () => {
+    expect(getNextTheme("light")).toBe("dark");
+  });
+
+  it('returns "dark" when current theme is undefined (SSR)', () => {
+    expect(getNextTheme(undefined)).toBe("dark");
+  });
+
+  it('returns "dark" for any unrecognized theme value', () => {
+    expect(getNextTheme("system")).toBe("dark");
+  });
+});
+
+describe("getThemeLabel", () => {
+  it('returns "Switch to light mode" when mounted and dark', () => {
+    expect(getThemeLabel(true, true)).toBe("Switch to light mode");
+  });
+
+  it('returns "Switch to dark mode" when mounted and light', () => {
+    expect(getThemeLabel(true, false)).toBe("Switch to dark mode");
+  });
+
+  it('returns generic "Toggle theme" when not mounted', () => {
+    expect(getThemeLabel(false, false)).toBe("Toggle theme");
+    expect(getThemeLabel(false, true)).toBe("Toggle theme");
+  });
+});

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useSession, signOut } from "next-auth/react";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
+import { ThemeToggle } from "@/components/shared/theme-toggle";
 
 export default function PlatformLayout({ children }: { children: React.ReactNode }) {
   const { data: session } = useSession();
@@ -30,7 +31,9 @@ export default function PlatformLayout({ children }: { children: React.ReactNode
           >
             <span className="text-lg font-bold tracking-tight">Flutr</span>
           </Link>
-          <nav aria-label="Platform navigation"></nav>
+          <nav aria-label="Platform navigation">
+            <ThemeToggle />
+          </nav>
         </div>
       </header>
       <main id="main-content" className="flex flex-1 flex-col">

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -20,7 +20,7 @@ export default function PlatformLayout({ children }: { children: React.ReactNode
         className={cn(
           "sticky top-0 z-50 border-b",
           isLoginPage
-            ? "bg-white supports-backdrop-filter:bg-white"
+            ? "bg-background supports-backdrop-filter:bg-background"
             : "bg-background/95 supports-backdrop-filter:bg-background/60 backdrop-blur",
         )}
       >

--- a/src/app/(home)/login/page.tsx
+++ b/src/app/(home)/login/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
+import { z } from "zod/v4";
 import { toast } from "sonner";
 import { logger } from "@/lib/logger";
 import { ROUTES } from "@/lib/routes";

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,19 +87,19 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: oklch(0.185 0 0);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
+  --card: oklch(0.23 0 0);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
+  --popover: oklch(0.23 0 0);
   --popover-foreground: oklch(0.985 0 0);
   --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
+  --primary-foreground: oklch(0.23 0 0);
+  --secondary: oklch(0.28 0 0);
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
+  --muted: oklch(0.28 0 0);
   --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
+  --accent: oklch(0.28 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --success: oklch(0.696 0.17 162.48);
   --success-foreground: oklch(0.985 0 0);
@@ -112,11 +112,11 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
+  --sidebar: oklch(0.23 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent: oklch(0.28 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
       >
         <a
           href="#main-content"
-          className="bg-background text-foreground focus:ring-ring sr-only rounded-md px-4 py-2 font-medium focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:ring-2"
+          className="bg-background text-foreground focus:ring-ring sr-only rounded-md px-4 py-2 font-medium focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-100 focus:ring-2"
         >
           Skip to main content
         </a>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
 import { SessionProvider } from "@/components/providers/session-provider";
+import { ThemeProvider } from "@/components/providers/theme-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,7 +26,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} flex min-h-screen flex-col antialiased`}
       >
@@ -35,10 +36,12 @@ export default function RootLayout({
         >
           Skip to main content
         </a>
-        <SessionProvider>
-          {children}
-          <Toaster position="bottom-right" />
-        </SessionProvider>
+        <ThemeProvider>
+          <SessionProvider>
+            {children}
+            <Toaster position="bottom-right" />
+          </SessionProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/nav/mobile-nav.tsx
+++ b/src/components/nav/mobile-nav.tsx
@@ -2,18 +2,35 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { EllipsisVertical } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useInstitution } from "@/hooks/use-institution";
 import type { NavLink } from "./nav-links";
+import { MobileThemeToggle } from "@/components/shared/theme-toggle";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface MobileNavProps {
   links: NavLink[];
+  menuLinks: NavLink[];
   className?: string;
 }
 
-export function MobileNav({ links, className }: MobileNavProps) {
+const navItemClass = cn(
+  "flex flex-col items-center gap-1 rounded-md px-3 py-2 text-xs font-medium transition-colors",
+  "hover:text-primary hover:font-bold",
+  "focus-visible:ring-ring/50 focus-visible:ring-2 focus-visible:outline-none",
+);
+
+export function MobileNav({ links, menuLinks, className }: MobileNavProps) {
   const { basePath } = useInstitution();
   const pathname = usePathname();
+
+  const hasMenu = menuLinks.length > 0;
 
   return (
     <nav
@@ -31,9 +48,8 @@ export function MobileNav({ links, className }: MobileNavProps) {
               key={link.label}
               href={href}
               className={cn(
-                "flex flex-col items-center gap-1 rounded-md px-3 py-2 text-xs font-medium transition-colors",
-                "hover:text-primary hover:font-bold",
-                "focus-visible:ring-ring/50 focus-visible:ring-2 focus-visible:outline-none",
+                navItemClass,
+                "flex-1",
                 isActive ? "text-primary font-bold" : "text-muted-foreground",
               )}
               aria-current={isActive ? "page" : undefined}
@@ -43,6 +59,33 @@ export function MobileNav({ links, className }: MobileNavProps) {
             </Link>
           );
         })}
+
+        {hasMenu && (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              className="text-muted-foreground hover:text-primary focus-visible:ring-ring/50 flex items-center justify-center rounded-md px-3 py-3 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+              aria-label="More options"
+            >
+              <EllipsisVertical className="size-6" aria-hidden="true" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" side="top" sideOffset={12} collisionPadding={8}>
+              {menuLinks.map((link) => {
+                const href = `${basePath}${link.href}`;
+                const Icon = link.icon;
+
+                return (
+                  <DropdownMenuItem key={link.label} asChild>
+                    <Link href={href} className="flex items-center gap-2">
+                      <Icon className="size-4" aria-hidden="true" />
+                      <span>{link.label}</span>
+                    </Link>
+                  </DropdownMenuItem>
+                );
+              })}
+              <MobileThemeToggle />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
     </nav>
   );

--- a/src/components/nav/mobile-nav.tsx
+++ b/src/components/nav/mobile-nav.tsx
@@ -30,7 +30,7 @@ export function MobileNav({ links, menuLinks, className }: MobileNavProps) {
   const { basePath } = useInstitution();
   const pathname = usePathname();
 
-  const hasMenu = menuLinks.length > 0;
+  const hasMenuLinks = menuLinks.length > 0;
 
   return (
     <nav
@@ -60,32 +60,36 @@ export function MobileNav({ links, menuLinks, className }: MobileNavProps) {
           );
         })}
 
-        {hasMenu && (
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              className="text-muted-foreground hover:text-primary focus-visible:ring-ring/50 flex items-center justify-center rounded-md px-3 py-3 transition-colors focus-visible:ring-2 focus-visible:outline-none"
-              aria-label="More options"
-            >
-              <EllipsisVertical className="size-6" aria-hidden="true" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" side="top" sideOffset={12} collisionPadding={8}>
-              {menuLinks.map((link) => {
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            className="text-muted-foreground hover:text-primary focus-visible:ring-ring/50 flex items-center justify-center rounded-md px-3 py-3 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+            aria-label="More options"
+          >
+            <EllipsisVertical className="size-6" aria-hidden="true" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" side="top" sideOffset={12} collisionPadding={8}>
+            {hasMenuLinks &&
+              menuLinks.map((link) => {
                 const href = `${basePath}${link.href}`;
+                const isActive = pathname.startsWith(href);
                 const Icon = link.icon;
 
                 return (
                   <DropdownMenuItem key={link.label} asChild>
-                    <Link href={href} className="flex items-center gap-2">
+                    <Link
+                      href={href}
+                      className="flex items-center gap-2"
+                      aria-current={isActive ? "page" : undefined}
+                    >
                       <Icon className="size-4" aria-hidden="true" />
                       <span>{link.label}</span>
                     </Link>
                   </DropdownMenuItem>
                 );
               })}
-              <MobileThemeToggle />
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+            <MobileThemeToggle />
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </nav>
   );

--- a/src/components/nav/nav-links.ts
+++ b/src/components/nav/nav-links.ts
@@ -23,6 +23,16 @@ export const PUBLIC_LINKS: NavLink[] = [
   { label: "Contact", href: "/contact", icon: Mail },
 ];
 
+export const PUBLIC_MOBILE_LINKS: NavLink[] = [
+  { label: "Home", href: "", icon: Home },
+  { label: "Gallery", href: "/gallery", icon: Image },
+  { label: "Stats", href: "/stats", icon: BarChart3 },
+];
+
+export const PUBLIC_MOBILE_MENU_LINKS: NavLink[] = [
+  { label: "Contact", href: "/contact", icon: Mail },
+];
+
 export const AUTH_LINKS: NavLink[] = [
   { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { label: "Shipments", href: "/shipments", icon: Package },

--- a/src/components/nav/nav.tsx
+++ b/src/components/nav/nav.tsx
@@ -7,6 +7,7 @@ import {
   PUBLIC_MOBILE_LINKS,
   PUBLIC_MOBILE_MENU_LINKS,
   AUTH_LINKS,
+  type NavLink,
 } from "./nav-links";
 
 interface NavbarProps {
@@ -16,7 +17,7 @@ interface NavbarProps {
 export function Navbar({ isAuthenticated }: NavbarProps) {
   const links = isAuthenticated ? AUTH_LINKS : PUBLIC_LINKS;
   const mobileLinks = isAuthenticated ? AUTH_LINKS : PUBLIC_MOBILE_LINKS;
-  const mobileMenuLinks = isAuthenticated ? [] : PUBLIC_MOBILE_MENU_LINKS;
+  const mobileMenuLinks = isAuthenticated ? ([] as NavLink[]) : PUBLIC_MOBILE_MENU_LINKS;
 
   return (
     <>

--- a/src/components/nav/nav.tsx
+++ b/src/components/nav/nav.tsx
@@ -2,7 +2,12 @@
 
 import { TopNav } from "./top-nav";
 import { MobileNav } from "./mobile-nav";
-import { PUBLIC_LINKS, AUTH_LINKS } from "./nav-links";
+import {
+  PUBLIC_LINKS,
+  PUBLIC_MOBILE_LINKS,
+  PUBLIC_MOBILE_MENU_LINKS,
+  AUTH_LINKS,
+} from "./nav-links";
 
 interface NavbarProps {
   isAuthenticated: boolean;
@@ -10,11 +15,13 @@ interface NavbarProps {
 
 export function Navbar({ isAuthenticated }: NavbarProps) {
   const links = isAuthenticated ? AUTH_LINKS : PUBLIC_LINKS;
+  const mobileLinks = isAuthenticated ? AUTH_LINKS : PUBLIC_MOBILE_LINKS;
+  const mobileMenuLinks = isAuthenticated ? [] : PUBLIC_MOBILE_MENU_LINKS;
 
   return (
     <>
       <TopNav links={links} isAuthenticated={isAuthenticated} className="hidden md:block" />
-      <MobileNav links={links} className="md:hidden" />
+      <MobileNav links={mobileLinks} menuLinks={mobileMenuLinks} className="md:hidden" />
     </>
   );
 }

--- a/src/components/nav/top-nav.tsx
+++ b/src/components/nav/top-nav.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { useInstitution } from "@/hooks/use-institution";
 import { useInstitutionData } from "@/components/providers/institution-provider";
 import type { NavLink } from "./nav-links";
+import { ThemeToggle } from "@/components/shared/theme-toggle";
 
 interface TopNavProps {
   links: NavLink[];
@@ -68,6 +69,10 @@ export function TopNav({ links, isAuthenticated, className }: TopNavProps) {
             );
           })}
         </nav>
+
+        <div className="z-10 ml-auto">
+          <ThemeToggle />
+        </div>
       </div>
     </header>
   );

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/public/root-home/institution-card.tsx
+++ b/src/components/public/root-home/institution-card.tsx
@@ -65,7 +65,7 @@ export function InstitutionCard({
               <div
                 className={cn(
                   "flex size-10 shrink-0 items-center justify-center rounded-full",
-                  logo_url ? "bg-white" : "bg-muted",
+                  logo_url ? "bg-background" : "bg-muted",
                 )}
               >
                 {logo_url ? (

--- a/src/components/shared/back-button.tsx
+++ b/src/components/shared/back-button.tsx
@@ -21,7 +21,7 @@ export function BackButton({ fallbackHref = "/" }: BackButtonProps) {
   };
 
   return (
-    <Button variant="outline" onClick={handleClick}>
+    <Button variant="secondary" onClick={handleClick} className="shadow-md">
       <ArrowLeft className="size-4" aria-hidden="true" />
       Go back
     </Button>

--- a/src/components/shared/theme-toggle.tsx
+++ b/src/components/shared/theme-toggle.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+
+const emptySubscribe = () => () => {};
+const getTrue = () => true;
+const getFalse = () => false;
+
+export function MobileThemeToggle() {
+  const mounted = useSyncExternalStore(emptySubscribe, getTrue, getFalse);
+  const { resolvedTheme, setTheme } = useTheme();
+
+  const isDark = mounted && resolvedTheme === "dark";
+  const toggle = () => setTheme(isDark ? "light" : "dark");
+  const label = mounted ? `Switch to ${isDark ? "light" : "dark"} mode` : "Toggle theme";
+
+  return (
+    <DropdownMenuItem onClick={toggle} aria-label={label} className="flex items-center gap-2">
+      {isDark ? (
+        <Moon className="size-4" aria-hidden="true" />
+      ) : (
+        <Sun className="size-4" aria-hidden="true" />
+      )}
+      <span>{isDark ? "Light mode" : "Dark mode"}</span>
+    </DropdownMenuItem>
+  );
+}
+
+export function ThemeToggle() {
+  const mounted = useSyncExternalStore(emptySubscribe, getTrue, getFalse);
+  const { resolvedTheme, setTheme } = useTheme();
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" size="icon" aria-label="Toggle theme" disabled>
+        <Sun className="size-5" />
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+      aria-label={`Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode`}
+    >
+      <Sun className="size-5 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+      <Moon className="absolute size-5 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+    </Button>
+  );
+}

--- a/src/components/shared/theme-toggle.tsx
+++ b/src/components/shared/theme-toggle.tsx
@@ -6,19 +6,11 @@ import { Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 
+import { getNextTheme, getThemeLabel } from "@/lib/theme-utils";
+
 const emptySubscribe = () => () => {};
 const getTrue = () => true;
 const getFalse = () => false;
-
-/** Returns the opposite theme. Exported for testing. */
-export function getNextTheme(current: string | undefined): "light" | "dark" {
-  return current === "dark" ? "light" : "dark";
-}
-
-/** Returns an accessible label describing the toggle action. */
-export function getThemeLabel(mounted: boolean, isDark: boolean): string {
-  return mounted ? `Switch to ${isDark ? "light" : "dark"} mode` : "Toggle theme";
-}
 
 export function MobileThemeToggle() {
   const mounted = useSyncExternalStore(emptySubscribe, getTrue, getFalse);
@@ -56,11 +48,18 @@ export function ThemeToggle() {
     <Button
       variant="ghost"
       size="icon"
+      className="relative"
       onClick={() => setTheme(getNextTheme(resolvedTheme))}
       aria-label={getThemeLabel(true, resolvedTheme === "dark")}
     >
-      <Sun className="size-5 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-      <Moon className="absolute size-5 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+      <Sun
+        className="size-5 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90"
+        aria-hidden="true"
+      />
+      <Moon
+        className="absolute size-5 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0"
+        aria-hidden="true"
+      />
     </Button>
   );
 }

--- a/src/components/shared/theme-toggle.tsx
+++ b/src/components/shared/theme-toggle.tsx
@@ -10,13 +10,23 @@ const emptySubscribe = () => () => {};
 const getTrue = () => true;
 const getFalse = () => false;
 
+/** Returns the opposite theme. Exported for testing. */
+export function getNextTheme(current: string | undefined): "light" | "dark" {
+  return current === "dark" ? "light" : "dark";
+}
+
+/** Returns an accessible label describing the toggle action. */
+export function getThemeLabel(mounted: boolean, isDark: boolean): string {
+  return mounted ? `Switch to ${isDark ? "light" : "dark"} mode` : "Toggle theme";
+}
+
 export function MobileThemeToggle() {
   const mounted = useSyncExternalStore(emptySubscribe, getTrue, getFalse);
   const { resolvedTheme, setTheme } = useTheme();
 
   const isDark = mounted && resolvedTheme === "dark";
-  const toggle = () => setTheme(isDark ? "light" : "dark");
-  const label = mounted ? `Switch to ${isDark ? "light" : "dark"} mode` : "Toggle theme";
+  const toggle = () => setTheme(getNextTheme(resolvedTheme));
+  const label = getThemeLabel(mounted, isDark);
 
   return (
     <DropdownMenuItem onClick={toggle} aria-label={label} className="flex items-center gap-2">
@@ -46,8 +56,8 @@ export function ThemeToggle() {
     <Button
       variant="ghost"
       size="icon"
-      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-      aria-label={`Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode`}
+      onClick={() => setTheme(getNextTheme(resolvedTheme))}
+      aria-label={getThemeLabel(true, resolvedTheme === "dark")}
     >
       <Sun className="size-5 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
       <Moon className="absolute size-5 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -26,7 +26,7 @@ function Slider({
       min={min}
       max={max}
       className={cn(
-        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        "relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
         className,
       )}
       {...props}
@@ -48,7 +48,7 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className="border-primary ring-ring/50 bg-background block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}
     </SliderPrimitive.Root>

--- a/src/lib/theme-utils.ts
+++ b/src/lib/theme-utils.ts
@@ -1,0 +1,9 @@
+/** Returns the opposite theme. */
+export function getNextTheme(current: string | undefined): "light" | "dark" {
+  return current === "dark" ? "light" : "dark";
+}
+
+/** Returns an accessible label describing the toggle action. */
+export function getThemeLabel(mounted: boolean, isDark: boolean): string {
+  return mounted ? `Switch to ${isDark ? "light" : "dark"} mode` : "Toggle theme";
+}


### PR DESCRIPTION
## Summary
- Add system-aware dark mode via `next-themes` with light/dark toggle across all viewports
- Introduce overflow menu on mobile nav to house theme toggle and secondary links (Contact)
- Tune dark theme CSS variables for improved contrast while maintaining AA compliance

## Changes
- **ThemeProvider** (`providers/theme-provider.tsx`): wraps app with `next-themes`, defaults to system preference
- **ThemeToggle** (`shared/theme-toggle.tsx`): desktop icon button with sun/moon animation; mobile variant as dropdown menu item
- **Mobile nav**: always-visible overflow menu ensures authenticated users can access the theme toggle; adds `aria-current` to overflow menu links
- **Nav links**: split public mobile links into primary bar + overflow menu for cleaner layout
- **Dark theme CSS**: bumped background/card/accent lightness values for better readability
- **Tests**: unit tests for `getNextTheme()` and `getThemeLabel()` helpers
- **Docs**: updated `AGENTS.md` Tech Stack and Project Structure

## Test plan
- [ ] Toggle theme on desktop (top nav button) — verify light/dark switches correctly
- [ ] Toggle theme on mobile (menu) — verify toggle appears for both public and authenticated users
- [ ] Refresh page — verify selected theme persists (localStorage)
- [ ] Set OS to dark mode, load fresh session — verify system preference is respected
- [ ] Verify `muted-foreground` text is readable on dark backgrounds (cards, muted sections)
- [ ] Keyboard-navigate to theme toggle — verify focus ring and activation via Enter/Space
- [ ] Run `pnpm test` — 7 new theme-toggle tests pass