### PR TITLE
feat: add platform admin dashboard and institution management flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 *.pem
 .idea
 .claude/settings.local.json
+/sessions
 
 # seed data
 scripts/data/*.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,13 @@ A WCAG-compliant, multi-tenant web application for butterfly houses to track shi
 ```
 src/
 ├── app/                    # Next.js pages and API routes
+│   ├── (admin)/            # Superuser platform admin panel
+│   │   └── platform/       # Platform admin routes (/platform/*)
+│   │       ├── layout.tsx  # Admin shell (sidebar + header + footer)
+│   │       ├── page.tsx    # Dashboard (nav cards)
+│   │       ├── institutions/ # Institutions management
+│   │       ├── species/    # Butterfly species management
+│   │       └── suppliers/  # Suppliers management
 │   ├── (platform)/         # Platform-level routes (landing, login)
 │   │   ├── page.tsx        # Root public landing page
 │   │   └── login/          # Login page
@@ -39,6 +46,12 @@ src/
 │       ├── tenant/         # Tenant-scoped authenticated API routes
 │       ├── platform/       # Platform/SUPERUSER API routes
 ├── components/             # React components by feature
+│   ├── platform/           # Superuser platform admin components
+│   │   ├── layout/         # PlatformSidebar, PlatformHeader, PlatformFooter, nav items
+│   │   ├── dashboard/      # PlatformNavCard
+│   │   ├── institutions/   # InstitutionsTable and related
+│   │   ├── species/        # SpeciesTable, SpeciesGalleryCard, toolbar, row, utils
+│   │   └── suppliers/      # SuppliersTable, toolbar, row, utils
 │   ├── admin/              # Admin-specific components
 │   ├── auth/               # Auth-specific components
 │   ├── nav/                # Navigation components (top-nav, mobile-nav, footer)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -123,7 +123,7 @@ All tenant routes use `x-tenant-slug` for tenant context:
 - `GET/POST /api/platform/institutions` — list & create institutions
 - `GET/PATCH/DELETE /api/platform/institutions/[id]` — institution detail, update, delete
 - `GET/POST /api/platform/species` — list and create global species
-- `PATCH /api/platform/species/[id]` — update a global species record
+- `GET/PATCH/DELETE /api/platform/species/[id]` — species detail, update, delete
 - `GET/POST /api/platform/suppliers` — list & create suppliers (cross-tenant)
 - `GET/PATCH/DELETE /api/platform/suppliers/[id]` — supplier detail, update, delete
 

--- a/docs/rules/api-routes.md
+++ b/docs/rules/api-routes.md
@@ -21,15 +21,27 @@ return internalError(); // 500
 
 Error paths use bracket notation for array indices (e.g. `items[0].field`).
 
-## Required Checks
+## Route vs Service responsibilities
 
-Every protected API route must follow this order:
+### Route layer
 
-1. **Authenticate**: `const session = await auth(); const user = requireUser(session);`
+Routes handle HTTP concerns only — they must not call `auth()`, perform role checks, or call queries directly.
+
+Every route handler must:
+
+1. **Read tenant header** (tenant routes only): read `x-tenant-slug`; return `400` if missing
+2. **Validate input**: Zod schemas with `.strict()` for params, body, and query
+3. **Call the service**: pass validated input (including slug) to the service function
+4. **Map errors to HTTP**: catch sentinel strings (`"UNAUTHORIZED"` → 401, `"FORBIDDEN"` → 403, `"NOT_FOUND"` → 404, `"CONFLICT"` → 409); for tenant routes also call `handleTenantError`
+
+### Service layer
+
+Services own all auth, authorization, and tenant resolution:
+
+1. **Authenticate**: `const user = requireUser(await auth());`
 2. **Authorize**: Use `canX(user)` helpers from `@/lib/authz` — never raw role checks
-3. **Validate input**: Zod schemas with `.strict()` for body, params, and query
-4. **Sanitize**: Required text fields use `sanitizedNonEmpty(maxLen)`, optional fields use `.transform(sanitizeText)`
-5. **Tenant resolution**: read `x-tenant-slug` header, call `resolveTenantBySlug(user, slug)` in the service layer; return `400` if header is missing
+3. **Resolve tenant** (tenant routes): `const tenantId = await resolveTenantBySlug(user, slug);`
+4. **Strip slug** before passing data to the query layer
 
 ## Validation Rules
 

--- a/src/__test__/api/platform/institutions.route.test.ts
+++ b/src/__test__/api/platform/institutions.route.test.ts
@@ -340,7 +340,7 @@ describe("Platform Institutions API", () => {
     });
 
     it("returns 404 when institution not found", async () => {
-      mockDeletePlatformInstitution.mockRejectedValueOnce(new Error("Institution not found"));
+      mockDeletePlatformInstitution.mockRejectedValueOnce(new Error("NOT_FOUND"));
 
       const response = (await deleteInstitutionById(
         makeDeleteRequest("999"),

--- a/src/__test__/api/platform/species.route.test.ts
+++ b/src/__test__/api/platform/species.route.test.ts
@@ -1,42 +1,32 @@
 import { NextRequest } from "next/server";
-import type { Session } from "next-auth";
 
-jest.mock("@/auth", () => ({
-  auth: jest.fn(),
+jest.mock("@/lib/services/platform-species", () => ({
+  getPlatformSpecies: jest.fn(),
+  getPlatformSpeciesById: jest.fn(),
+  createPlatformSpecies: jest.fn(),
+  updatePlatformSpecies: jest.fn(),
+  deletePlatformSpecies: jest.fn(),
 }));
 
-jest.mock("@/lib/queries/species", () => ({
-  listSpeciesGlobal: jest.fn(),
-  createSpecies: jest.fn(),
-  getSpeciesById: jest.fn(),
-  updateSpecies: jest.fn(),
-}));
-
-import { auth } from "@/auth";
 import {
-  listSpeciesGlobal,
-  createSpecies,
-  getSpeciesById,
-  updateSpecies,
-} from "@/lib/queries/species";
+  getPlatformSpecies,
+  getPlatformSpeciesById,
+  createPlatformSpecies,
+  updatePlatformSpecies,
+  deletePlatformSpecies,
+} from "@/lib/services/platform-species";
 import { GET as getSpecies, POST as postSpecies } from "@/app/api/platform/species/route";
-import { PATCH as patchSpeciesById } from "@/app/api/platform/species/[id]/route";
+import {
+  GET as getSpeciesById,
+  PATCH as patchSpeciesById,
+  DELETE as deleteSpeciesById,
+} from "@/app/api/platform/species/[id]/route";
 
-const mockAuth = auth as jest.Mock;
-const mockListSpeciesGlobal = listSpeciesGlobal as jest.Mock;
-const mockCreateSpecies = createSpecies as jest.Mock;
-const mockGetSpeciesById = getSpeciesById as jest.Mock;
-const mockUpdateSpecies = updateSpecies as jest.Mock;
-
-function makeSession(
-  overrides: Partial<{ id: string; role: string; institutionId: number | null }> = {},
-): Session {
-  const { id = "1", role = "SUPERUSER", institutionId = 1 } = overrides;
-  return {
-    expires: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
-    user: { id, role, institutionId } as Session["user"],
-  };
-}
+const mockGetPlatformSpecies = getPlatformSpecies as jest.Mock;
+const mockGetPlatformSpeciesById = getPlatformSpeciesById as jest.Mock;
+const mockCreatePlatformSpecies = createPlatformSpecies as jest.Mock;
+const mockUpdatePlatformSpecies = updatePlatformSpecies as jest.Mock;
+const mockDeletePlatformSpecies = deletePlatformSpecies as jest.Mock;
 
 function makeGetRequest() {
   return new NextRequest("http://localhost/api/platform/species");
@@ -50,11 +40,21 @@ function makePostRequest(body: Record<string, unknown>) {
   });
 }
 
+function makeGetByIdRequest(id: string) {
+  return new NextRequest(`http://localhost/api/platform/species/${id}`);
+}
+
 function makePatchRequest(id: string, body: Record<string, unknown>) {
   return new NextRequest(`http://localhost/api/platform/species/${id}`, {
     method: "PATCH",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
+  });
+}
+
+function makeDeleteRequest(id: string) {
+  return new NextRequest(`http://localhost/api/platform/species/${id}`, {
+    method: "DELETE",
   });
 }
 
@@ -79,26 +79,18 @@ function validCreatePayload() {
   };
 }
 
-const sampleSpeciesListItem = {
-  id: 10,
-  scientificName: "Papilio glaucus",
-  commonName: "Eastern Tiger Swallowtail",
-  family: "Papilionidae",
-  subFamily: "Papilioninae",
-  lifespanDays: 14,
-  range: ["North America"],
-  createdAt: "2026-01-01T00:00:00.000Z",
-};
-
 describe("Platform Species API", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    mockAuth.mockResolvedValue(makeSession());
   });
+
+  // ──────────────────────────────────────────────
+  // GET /api/platform/species
+  // ──────────────────────────────────────────────
 
   describe("GET /api/platform/species", () => {
     it("returns 401 for unauthenticated requests", async () => {
-      mockAuth.mockResolvedValueOnce(null);
+      mockGetPlatformSpecies.mockRejectedValueOnce(new Error("UNAUTHORIZED"));
 
       const response = (await getSpecies(makeGetRequest()))!;
       expect(response.status).toBe(401);
@@ -106,7 +98,7 @@ describe("Platform Species API", () => {
     });
 
     it("returns 403 for non-SUPERUSER", async () => {
-      mockAuth.mockResolvedValueOnce(makeSession({ role: "ADMIN" }));
+      mockGetPlatformSpecies.mockRejectedValueOnce(new Error("FORBIDDEN"));
 
       const response = (await getSpecies(makeGetRequest()))!;
       expect(response.status).toBe(403);
@@ -114,33 +106,37 @@ describe("Platform Species API", () => {
     });
 
     it("returns 200 with species list", async () => {
-      mockListSpeciesGlobal.mockResolvedValueOnce([sampleSpeciesListItem]);
+      mockGetPlatformSpecies.mockResolvedValueOnce([
+        { id: 10, scientificName: "Papilio glaucus", commonName: "Eastern Tiger Swallowtail" },
+        { id: 11, scientificName: "Morpho peleides", commonName: "Blue Morpho" },
+      ]);
 
       const response = (await getSpecies(makeGetRequest()))!;
       expect(response.status).toBe(200);
 
       const body = await response.json();
-      expect(body.species).toHaveLength(1);
-      expect(body.species[0].scientificName).toBe("Papilio glaucus");
-      expect(mockListSpeciesGlobal).toHaveBeenCalledTimes(1);
+      expect(body.species).toHaveLength(2);
+      expect(mockGetPlatformSpecies).toHaveBeenCalledTimes(1);
     });
   });
 
+  // ──────────────────────────────────────────────
+  // POST /api/platform/species
+  // ──────────────────────────────────────────────
+
   describe("POST /api/platform/species", () => {
     it("returns 401 for unauthenticated requests", async () => {
-      mockAuth.mockResolvedValueOnce(null);
+      mockCreatePlatformSpecies.mockRejectedValueOnce(new Error("UNAUTHORIZED"));
 
       const response = (await postSpecies(makePostRequest(validCreatePayload())))!;
       expect(response.status).toBe(401);
-      expect((await response.json()).error.code).toBe("UNAUTHORIZED");
     });
 
     it("returns 403 for non-SUPERUSER", async () => {
-      mockAuth.mockResolvedValueOnce(makeSession({ role: "EMPLOYEE" }));
+      mockCreatePlatformSpecies.mockRejectedValueOnce(new Error("FORBIDDEN"));
 
       const response = (await postSpecies(makePostRequest(validCreatePayload())))!;
       expect(response.status).toBe(403);
-      expect((await response.json()).error.code).toBe("FORBIDDEN");
     });
 
     it("returns 400 for invalid request body", async () => {
@@ -150,20 +146,20 @@ describe("Platform Species API", () => {
     });
 
     it("returns 201 on successful creation", async () => {
-      mockCreateSpecies.mockResolvedValueOnce({ id: 10, ...validCreatePayload() });
+      mockCreatePlatformSpecies.mockResolvedValueOnce({ id: 10, ...validCreatePayload() });
 
       const response = (await postSpecies(makePostRequest(validCreatePayload())))!;
       expect(response.status).toBe(201);
 
       const body = await response.json();
       expect(body.species.id).toBe(10);
-      expect(mockCreateSpecies).toHaveBeenCalledWith(
+      expect(mockCreatePlatformSpecies).toHaveBeenCalledWith(
         expect.objectContaining({ scientific_name: "Papilio glaucus" }),
       );
     });
 
     it("returns 409 when scientific_name already exists", async () => {
-      mockCreateSpecies.mockRejectedValueOnce({ code: "23505" });
+      mockCreatePlatformSpecies.mockRejectedValueOnce(new Error("CONFLICT"));
 
       const response = (await postSpecies(makePostRequest(validCreatePayload())))!;
       expect(response.status).toBe(409);
@@ -171,27 +167,78 @@ describe("Platform Species API", () => {
     });
   });
 
+  // ──────────────────────────────────────────────
+  // GET /api/platform/species/[id]
+  // ──────────────────────────────────────────────
+
+  describe("GET /api/platform/species/[id]", () => {
+    it("returns 401 for unauthenticated requests", async () => {
+      mockGetPlatformSpeciesById.mockRejectedValueOnce(new Error("UNAUTHORIZED"));
+
+      const response = (await getSpeciesById(makeGetByIdRequest("10"), routeContext("10")))!;
+      expect(response.status).toBe(401);
+    });
+
+    it("returns 403 for non-SUPERUSER", async () => {
+      mockGetPlatformSpeciesById.mockRejectedValueOnce(new Error("FORBIDDEN"));
+
+      const response = (await getSpeciesById(makeGetByIdRequest("10"), routeContext("10")))!;
+      expect(response.status).toBe(403);
+    });
+
+    it("returns 200 with species", async () => {
+      mockGetPlatformSpeciesById.mockResolvedValueOnce({
+        id: 10,
+        scientificName: "Papilio glaucus",
+        commonName: "Eastern Tiger Swallowtail",
+      });
+
+      const response = (await getSpeciesById(makeGetByIdRequest("10"), routeContext("10")))!;
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(body.species.id).toBe(10);
+      expect(mockGetPlatformSpeciesById).toHaveBeenCalledWith(10);
+    });
+
+    it("returns 404 when species not found", async () => {
+      mockGetPlatformSpeciesById.mockRejectedValueOnce(new Error("NOT_FOUND"));
+
+      const response = (await getSpeciesById(makeGetByIdRequest("999"), routeContext("999")))!;
+      expect(response.status).toBe(404);
+      expect((await response.json()).error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 400 for invalid id parameter", async () => {
+      const response = (await getSpeciesById(makeGetByIdRequest("abc"), routeContext("abc")))!;
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.code).toBe("INVALID_REQUEST");
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // PATCH /api/platform/species/[id]
+  // ──────────────────────────────────────────────
+
   describe("PATCH /api/platform/species/[id]", () => {
     it("returns 401 for unauthenticated requests", async () => {
-      mockAuth.mockResolvedValueOnce(null);
+      mockUpdatePlatformSpecies.mockRejectedValueOnce(new Error("UNAUTHORIZED"));
 
       const response = (await patchSpeciesById(
         makePatchRequest("10", { common_name: "Updated Name" }),
         routeContext("10"),
       ))!;
       expect(response.status).toBe(401);
-      expect((await response.json()).error.code).toBe("UNAUTHORIZED");
     });
 
     it("returns 403 for non-SUPERUSER", async () => {
-      mockAuth.mockResolvedValueOnce(makeSession({ role: "ADMIN" }));
+      mockUpdatePlatformSpecies.mockRejectedValueOnce(new Error("FORBIDDEN"));
 
       const response = (await patchSpeciesById(
         makePatchRequest("10", { common_name: "Updated Name" }),
         routeContext("10"),
       ))!;
       expect(response.status).toBe(403);
-      expect((await response.json()).error.code).toBe("FORBIDDEN");
     });
 
     it("returns 400 for invalid id parameter", async () => {
@@ -203,31 +250,17 @@ describe("Platform Species API", () => {
       expect((await response.json()).error.code).toBe("INVALID_REQUEST");
     });
 
-    it("returns 404 when species is not found", async () => {
-      mockGetSpeciesById.mockResolvedValueOnce(null);
-
-      const response = (await patchSpeciesById(
-        makePatchRequest("999", { common_name: "Updated Name" }),
-        routeContext("999"),
-      ))!;
-      expect(response.status).toBe(404);
-      expect((await response.json()).error.code).toBe("NOT_FOUND");
-    });
-
     it("returns 400 when no update fields are provided", async () => {
-      mockGetSpeciesById.mockResolvedValueOnce({ id: 10, scientific_name: "Papilio glaucus" });
-
       const response = (await patchSpeciesById(makePatchRequest("10", {}), routeContext("10")))!;
       expect(response.status).toBe(400);
       expect((await response.json()).error.code).toBe("INVALID_REQUEST");
     });
 
     it("returns 200 on successful update", async () => {
-      mockGetSpeciesById.mockResolvedValueOnce({ id: 10, scientific_name: "Papilio glaucus" });
-      mockUpdateSpecies.mockResolvedValueOnce({
+      mockUpdatePlatformSpecies.mockResolvedValueOnce({
         id: 10,
-        scientific_name: "Papilio glaucus",
-        common_name: "Updated Name",
+        scientificName: "Papilio glaucus",
+        commonName: "Updated Name",
       });
 
       const response = (await patchSpeciesById(
@@ -238,16 +271,14 @@ describe("Platform Species API", () => {
 
       const body = await response.json();
       expect(body.species.id).toBe(10);
-      expect(body.species.common_name).toBe("Updated Name");
-      expect(mockUpdateSpecies).toHaveBeenCalledWith(
+      expect(mockUpdatePlatformSpecies).toHaveBeenCalledWith(
         10,
         expect.objectContaining({ common_name: "Updated Name" }),
       );
     });
 
     it("returns 409 when scientific_name conflicts", async () => {
-      mockGetSpeciesById.mockResolvedValueOnce({ id: 10, scientific_name: "Papilio glaucus" });
-      mockUpdateSpecies.mockRejectedValueOnce({ code: "23505" });
+      mockUpdatePlatformSpecies.mockRejectedValueOnce(new Error("CONFLICT"));
 
       const response = (await patchSpeciesById(
         makePatchRequest("10", { scientific_name: "Taken Name" }),
@@ -255,6 +286,62 @@ describe("Platform Species API", () => {
       ))!;
       expect(response.status).toBe(409);
       expect((await response.json()).error.code).toBe("CONFLICT");
+    });
+
+    it("returns 404 when species not found", async () => {
+      mockUpdatePlatformSpecies.mockRejectedValueOnce(new Error("NOT_FOUND"));
+
+      const response = (await patchSpeciesById(
+        makePatchRequest("999", { common_name: "Updated" }),
+        routeContext("999"),
+      ))!;
+      expect(response.status).toBe(404);
+      expect((await response.json()).error.code).toBe("NOT_FOUND");
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // DELETE /api/platform/species/[id]
+  // ──────────────────────────────────────────────
+
+  describe("DELETE /api/platform/species/[id]", () => {
+    it("returns 401 for unauthenticated requests", async () => {
+      mockDeletePlatformSpecies.mockRejectedValueOnce(new Error("UNAUTHORIZED"));
+
+      const response = (await deleteSpeciesById(makeDeleteRequest("10"), routeContext("10")))!;
+      expect(response.status).toBe(401);
+    });
+
+    it("returns 403 for non-SUPERUSER", async () => {
+      mockDeletePlatformSpecies.mockRejectedValueOnce(new Error("FORBIDDEN"));
+
+      const response = (await deleteSpeciesById(makeDeleteRequest("10"), routeContext("10")))!;
+      expect(response.status).toBe(403);
+    });
+
+    it("returns 200 for successful delete", async () => {
+      mockDeletePlatformSpecies.mockResolvedValueOnce(undefined);
+
+      const response = (await deleteSpeciesById(makeDeleteRequest("10"), routeContext("10")))!;
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(body.deleted).toBe(true);
+      expect(mockDeletePlatformSpecies).toHaveBeenCalledWith(10);
+    });
+
+    it("returns 404 when species not found", async () => {
+      mockDeletePlatformSpecies.mockRejectedValueOnce(new Error("NOT_FOUND"));
+
+      const response = (await deleteSpeciesById(makeDeleteRequest("999"), routeContext("999")))!;
+      expect(response.status).toBe(404);
+      expect((await response.json()).error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 400 for invalid id parameter", async () => {
+      const response = (await deleteSpeciesById(makeDeleteRequest("abc"), routeContext("abc")))!;
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.code).toBe("INVALID_REQUEST");
     });
   });
 });

--- a/src/__test__/api/platform/suppliers.route.test.ts
+++ b/src/__test__/api/platform/suppliers.route.test.ts
@@ -188,9 +188,7 @@ describe("Platform Suppliers API", () => {
     });
 
     it("returns 403 when SUPERUSER omits institutionId", async () => {
-      mockCreatePlatformSupplier.mockRejectedValueOnce(
-        new Error("Tenant required for write operation"),
-      );
+      mockCreatePlatformSupplier.mockRejectedValueOnce(new Error("FORBIDDEN"));
 
       const payload = { name: "Test", code: "TST", country: "US" };
       const response = (await postSupplier(makePostRequest(payload)))!;

--- a/src/__test__/api/platform/suppliers.route.test.ts
+++ b/src/__test__/api/platform/suppliers.route.test.ts
@@ -181,6 +181,14 @@ describe("Platform Suppliers API", () => {
       expect((await response.json()).error.code).toBe("CONFLICT");
     });
 
+    it("returns 404 when institutionId does not exist", async () => {
+      mockCreatePlatformSupplier.mockRejectedValueOnce(new Error("Institution not found"));
+
+      const response = (await postSupplier(makePostRequest(validCreatePayload())))!;
+      expect(response.status).toBe(404);
+      expect((await response.json()).error.code).toBe("NOT_FOUND");
+    });
+
     it("returns 400 for missing required fields", async () => {
       const response = (await postSupplier(makePostRequest({ name: "Only name" })))!;
       expect(response.status).toBe(400);

--- a/src/app/(admin)/platform/institutions/[id]/page.tsx
+++ b/src/app/(admin)/platform/institutions/[id]/page.tsx
@@ -1,0 +1,64 @@
+import { notFound } from "next/navigation";
+
+import { auth } from "@/auth";
+import { requireUser } from "@/lib/authz";
+import { getInstitutionById } from "@/lib/queries/institution";
+import { listUsersForTenant } from "@/lib/queries/users";
+import InstitutionDetailShell from "@/components/platform/institutions/detail/institution-detail-shell";
+import type {
+  InstitutionDetail,
+  InstitutionUser,
+} from "@/components/platform/institutions/detail/institution-detail-shell";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function PlatformInstitutionPage({ params }: Props) {
+  const { id: rawId } = await params;
+  const id = parseInt(rawId, 10);
+
+  if (isNaN(id) || id <= 0) notFound();
+
+  const session = await auth();
+  const platformUser = requireUser(session);
+
+  const [row, rawUsers] = await Promise.all([
+    getInstitutionById(id),
+    listUsersForTenant(id, platformUser),
+  ]);
+
+  if (!row) notFound();
+
+  const institution: InstitutionDetail = {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description ?? null,
+    street_address: row.street_address,
+    extended_address: row.extended_address ?? null,
+    city: row.city,
+    state_province: row.state_province,
+    postal_code: row.postal_code,
+    country: row.country,
+    time_zone: row.time_zone ?? null,
+    email_address: row.email_address ?? null,
+    phone_number: row.phone_number ?? null,
+    website_url: row.website_url ?? null,
+    logo_url: row.logo_url ?? null,
+    facility_image_url: row.facility_image_url ?? null,
+    social_links: (row.social_links as Record<string, string> | null) ?? null,
+    theme_colors: row.theme_colors ?? null,
+    stats_active: row.stats_active,
+    iabes_member: row.iabes_member,
+  };
+
+  const users: InstitutionUser[] = rawUsers.map((u) => ({
+    id: u.id,
+    name: u.name,
+    email: u.email,
+    role: u.role,
+  }));
+
+  return <InstitutionDetailShell institution={institution} users={users} />;
+}

--- a/src/app/(admin)/platform/institutions/[id]/page.tsx
+++ b/src/app/(admin)/platform/institutions/[id]/page.tsx
@@ -12,10 +12,23 @@ import type {
 
 interface Props {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ tab?: string }>;
 }
 
-export default async function PlatformInstitutionPage({ params }: Props) {
+function resolveInitialTab(tab: string | undefined) {
+  switch (tab) {
+    case "theme":
+    case "users":
+    case "data":
+      return tab;
+    default:
+      return "profile";
+  }
+}
+
+export default async function PlatformInstitutionPage({ params, searchParams }: Props) {
   const { id: rawId } = await params;
+  const { tab } = await searchParams;
   const id = parseInt(rawId, 10);
 
   if (isNaN(id) || id <= 0) notFound();
@@ -60,5 +73,11 @@ export default async function PlatformInstitutionPage({ params }: Props) {
     role: u.role,
   }));
 
-  return <InstitutionDetailShell institution={institution} users={users} />;
+  return (
+    <InstitutionDetailShell
+      institution={institution}
+      users={users}
+      initialTab={resolveInitialTab(tab)}
+    />
+  );
 }

--- a/src/app/(admin)/platform/institutions/add/page.tsx
+++ b/src/app/(admin)/platform/institutions/add/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import InstitutionAddForm from "@/components/platform/institutions/add/institution-add-form";
+
+export default function PlatformAddInstitutionPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 py-10">
+      <div className="flex flex-col gap-1">
+        <Button asChild variant="ghost" size="sm" className="-ml-2 w-fit">
+          <Link href="/platform/institutions">
+            <ArrowLeft className="mr-1 size-4" aria-hidden="true" />
+            Institutions
+          </Link>
+        </Button>
+        <h1 className="text-3xl font-semibold">Add Institution</h1>
+        <p className="text-muted-foreground text-sm">Set up a new institution on the platform.</p>
+      </div>
+
+      <InstitutionAddForm />
+    </div>
+  );
+}

--- a/src/app/(admin)/platform/institutions/page.tsx
+++ b/src/app/(admin)/platform/institutions/page.tsx
@@ -1,0 +1,26 @@
+import InstitutionsClient from "@/components/platform/institutions/institutions-client";
+import { getAllInstitutions } from "@/lib/queries/institution";
+
+export default async function PlatformInstitutionsPage() {
+  const raw = await getAllInstitutions();
+
+  const institutions = raw.map((i) => {
+    // NOTE: This status is derived from stats visibility, not a separate account suspension field.
+    const statsVisibleOnPublicPages = i.stats_active;
+    const status = statsVisibleOnPublicPages ? ("ACTIVE" as const) : ("SUSPENDED" as const);
+
+    return {
+      id: i.id,
+      name: i.name,
+      slug: i.slug,
+      city: i.city,
+      state_province: i.state_province,
+      country: i.country,
+      email_address: i.email_address,
+      logo_url: i.logo_url,
+      created_at: i.created_at.toISOString(),
+      status,
+    };
+  });
+  return <InstitutionsClient institutions={institutions} />;
+}

--- a/src/app/(admin)/platform/layout.tsx
+++ b/src/app/(admin)/platform/layout.tsx
@@ -1,0 +1,37 @@
+import { auth } from "@/auth";
+import PlatformFooter from "@/components/platform/layout/platform-footer";
+import PlatformHeader from "@/components/platform/layout/platform-header";
+import PlatformSidebar from "@/components/platform/layout/platform-sidebar";
+import { canCrossTenant, requireUser } from "@/lib/authz";
+import { redirect } from "next/navigation";
+
+export default async function PlatformLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth();
+
+  const user = (() => {
+    try {
+      return requireUser(session);
+    } catch {
+      redirect("/");
+    }
+  })();
+
+  if (!canCrossTenant(user)) {
+    redirect("/");
+  }
+
+  return (
+    <div className="bg-background fixed inset-0 flex flex-col overflow-hidden">
+      <PlatformHeader user={user} sessionUser={session?.user} />
+
+      <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+        <PlatformSidebar />
+        <main id="main-content" className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+          {children}
+        </main>
+      </div>
+
+      <PlatformFooter />
+    </div>
+  );
+}

--- a/src/app/(admin)/platform/page.tsx
+++ b/src/app/(admin)/platform/page.tsx
@@ -1,0 +1,40 @@
+import { Building2, Leaf, Package } from "lucide-react";
+
+import PlatformNavCard from "@/components/platform/dashboard/platform-nav-card";
+import { PLATFORM_ROUTES } from "@/components/platform/layout/platform-nav-items";
+
+export default function PlatformPage() {
+  return (
+    <div className="mx-auto max-w-6xl px-6 py-10">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold">Platform Control Center</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Manage global platform data including institutions, species, and suppliers.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <PlatformNavCard
+          href={PLATFORM_ROUTES.institutions}
+          title="Institutions"
+          description="Manage butterfly houses and onboarding"
+          icon={Building2}
+        />
+
+        <PlatformNavCard
+          href={PLATFORM_ROUTES.species}
+          title="Butterflies"
+          description="Manage the global butterfly species catalog"
+          icon={Leaf}
+        />
+
+        <PlatformNavCard
+          href={PLATFORM_ROUTES.suppliers}
+          title="Suppliers"
+          description="Manage the global supplier list"
+          icon={Package}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/platform/species/page.tsx
+++ b/src/app/(admin)/platform/species/page.tsx
@@ -1,0 +1,9 @@
+// placeholder for species management page
+export default function PlatformSpeciesPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-10">
+      <h1 className="text-2xl font-bold">Species Management</h1>
+      <p>This is a placeholder for the species management page.</p>
+    </div>
+  );
+}

--- a/src/app/(admin)/platform/suppliers/page.tsx
+++ b/src/app/(admin)/platform/suppliers/page.tsx
@@ -1,0 +1,9 @@
+// placeholder for suppliers management page
+export default function PlatformSuppliersPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-10">
+      <h1 className="text-2xl font-bold">Suppliers Management</h1>
+      <p>This is a placeholder for the suppliers management page.</p>
+    </div>
+  );
+}

--- a/src/app/(platform)/login/page.tsx
+++ b/src/app/(platform)/login/page.tsx
@@ -99,8 +99,12 @@ export default function LoginPage() {
       // Get the session to retrieve institution information
       const sessionResponse = await fetch("/api/auth/session");
       const session = await sessionResponse.json();
+      const role = session?.user?.role;
 
-      if (session?.user?.institutionSlug) {
+      if (role === "SUPERUSER") {
+        // Redirect superusers to the platform dashboard
+        router.push("/platform");
+      } else if (session?.user?.institutionSlug) {
         // Redirect to institution dashboard using slug (public tenant segment)
         router.push(`/${session.user.institutionSlug}/dashboard`);
       } else {

--- a/src/app/api/platform/institutions/[id]/route.ts
+++ b/src/app/api/platform/institutions/[id]/route.ts
@@ -15,7 +15,6 @@ import {
   platformUpdateInstitutionSchema,
 } from "@/lib/validation/institution";
 import { requireValidBody } from "@/lib/validation/request";
-import { handleTenantError } from "@/lib/tenant";
 
 import {
   getPlatformInstitutionById,
@@ -47,9 +46,6 @@ export async function GET(_request: NextRequest, context: RouteContext) {
       if (error.message === "FORBIDDEN") return forbidden();
     }
 
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
-
     logger.error("Unexpected GET /platform/institutions/[id] error:", error);
     return internalError();
   }
@@ -77,9 +73,6 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       if (error.message === "CONFLICT") return conflict("Slug already in use");
     }
 
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
-
     logger.error("Unexpected PATCH /platform/institutions/[id] error:", error);
     return internalError();
   }
@@ -100,10 +93,8 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     if (error instanceof Error) {
       if (error.message === "UNAUTHORIZED") return unauthorized();
       if (error.message === "FORBIDDEN") return forbidden();
+      if (error.message === "NOT_FOUND") return notFound("Institution not found");
     }
-
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
 
     logger.error("Unexpected DELETE /platform/institutions/[id] error:", error);
     return internalError();

--- a/src/app/api/platform/institutions/route.ts
+++ b/src/app/api/platform/institutions/route.ts
@@ -4,7 +4,6 @@ import { logger } from "@/lib/logger";
 import { conflict, forbidden, internalError, ok, unauthorized } from "@/lib/api-response";
 import { requireValidBody } from "@/lib/validation/request";
 import { platformCreateInstitutionSchema } from "@/lib/validation/institution";
-import { handleTenantError } from "@/lib/tenant";
 
 import {
   getPlatformInstitutions,
@@ -21,9 +20,6 @@ export async function GET(_request: NextRequest) {
       if (error.message === "UNAUTHORIZED") return unauthorized();
       if (error.message === "FORBIDDEN") return forbidden();
     }
-
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
 
     logger.error("Unexpected GET /platform/institutions error:", error);
     return internalError();
@@ -44,9 +40,6 @@ export async function POST(request: NextRequest) {
       if (error.message === "FORBIDDEN") return forbidden();
       if (error.message === "CONFLICT") return conflict("Slug already in use");
     }
-
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
 
     logger.error("Unexpected POST /platform/institutions error:", error);
     return internalError();

--- a/src/app/api/platform/species/[id]/route.ts
+++ b/src/app/api/platform/species/[id]/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest } from "next/server";
 
-import { auth } from "@/auth";
 import { logger } from "@/lib/logger";
-import { canManageGlobalButterflies, requireUser } from "@/lib/authz";
 import {
   conflict,
   forbidden,
@@ -14,69 +12,86 @@ import {
 } from "@/lib/api-response";
 import { requireValidBody } from "@/lib/validation/request";
 import { speciesIdParamsSchema, updateSpeciesBodySchema } from "@/lib/validation/species";
-import { getSpeciesById, updateSpecies } from "@/lib/queries/species";
-import { handleTenantError } from "@/lib/tenant";
+
+import {
+  getPlatformSpeciesById,
+  updatePlatformSpecies,
+  deletePlatformSpecies,
+} from "@/lib/services/platform-species";
 
 interface RouteContext {
   params: Promise<{ id: string }>;
 }
 
+export async function GET(_request: NextRequest, context: RouteContext) {
+  try {
+    const routeParams = await context.params;
+    const result = speciesIdParamsSchema.safeParse(routeParams);
+    if (!result.success) {
+      return invalidRequest("Invalid request parameters", result.error.issues);
+    }
+
+    const species = await getPlatformSpeciesById(result.data.id);
+
+    return ok({ species });
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === "UNAUTHORIZED") return unauthorized();
+      if (error.message === "FORBIDDEN") return forbidden();
+      if (error.message === "NOT_FOUND") return notFound("Species not found");
+    }
+
+    logger.error("Unexpected GET /platform/species/[id] error:", error);
+    return internalError();
+  }
+}
+
 export async function PATCH(request: NextRequest, context: RouteContext) {
   try {
-    const session = await auth();
-
-    let user;
-    try {
-      user = requireUser(session);
-    } catch {
-      return unauthorized();
-    }
-
-    if (!canManageGlobalButterflies(user)) {
-      return forbidden();
-    }
-
     const routeParams = await context.params;
-    const paramResult = speciesIdParamsSchema.safeParse(routeParams);
-
-    if (!paramResult.success) {
-      return invalidRequest("Invalid request parameters", paramResult.error.issues);
+    const result = speciesIdParamsSchema.safeParse(routeParams);
+    if (!result.success) {
+      return invalidRequest("Invalid request parameters", result.error.issues);
     }
 
     const bodyResult = await requireValidBody(request, updateSpeciesBodySchema);
     if ("error" in bodyResult) return bodyResult.error;
 
-    const speciesId = paramResult.data.id;
-
-    const existingSpecies = await getSpeciesById(speciesId);
-    if (!existingSpecies) {
-      return notFound("Species not found");
-    }
-
-    const species = await updateSpecies(speciesId, bodyResult.data);
-    if (!species) {
-      return notFound("Species not found");
-    }
+    const species = await updatePlatformSpecies(result.data.id, bodyResult.data);
 
     return ok({ species });
   } catch (error) {
-    if (isUniqueViolation(error)) {
-      return conflict("Species scientific name already exists");
+    if (error instanceof Error) {
+      if (error.message === "UNAUTHORIZED") return unauthorized();
+      if (error.message === "FORBIDDEN") return forbidden();
+      if (error.message === "NOT_FOUND") return notFound("Species not found");
+      if (error.message === "CONFLICT") return conflict("Species scientific name already exists");
     }
-
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
 
     logger.error("Unexpected PATCH /platform/species/[id] error:", error);
     return internalError();
   }
 }
 
-function isUniqueViolation(error: unknown): boolean {
-  return (
-    error !== null &&
-    typeof error === "object" &&
-    "code" in error &&
-    (error as { code: unknown }).code === "23505"
-  );
+export async function DELETE(_request: NextRequest, context: RouteContext) {
+  try {
+    const routeParams = await context.params;
+    const result = speciesIdParamsSchema.safeParse(routeParams);
+    if (!result.success) {
+      return invalidRequest("Invalid request parameters", result.error.issues);
+    }
+
+    await deletePlatformSpecies(result.data.id);
+
+    return ok({ deleted: true });
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === "UNAUTHORIZED") return unauthorized();
+      if (error.message === "FORBIDDEN") return forbidden();
+      if (error.message === "NOT_FOUND") return notFound("Species not found");
+    }
+
+    logger.error("Unexpected DELETE /platform/species/[id] error:", error);
+    return internalError();
+  }
 }

--- a/src/app/api/platform/species/route.ts
+++ b/src/app/api/platform/species/route.ts
@@ -1,37 +1,22 @@
 import { NextRequest } from "next/server";
 
-import { auth } from "@/auth";
 import { logger } from "@/lib/logger";
-import { canManageGlobalButterflies, requireUser } from "@/lib/authz";
 import { conflict, forbidden, internalError, ok, unauthorized } from "@/lib/api-response";
-import { handleTenantError } from "@/lib/tenant";
-import { createSpecies, listSpeciesGlobal } from "@/lib/queries/species";
 import { requireValidBody } from "@/lib/validation/request";
 import { createSpeciesBodySchema } from "@/lib/validation/species";
 
-export async function GET(request: NextRequest) {
+import { getPlatformSpecies, createPlatformSpecies } from "@/lib/services/platform-species";
+
+export async function GET(_request: NextRequest) {
+  void _request;
   try {
-    void request;
-
-    const session = await auth();
-
-    let user;
-    try {
-      user = requireUser(session);
-    } catch {
-      return unauthorized();
-    }
-
-    if (!canManageGlobalButterflies(user)) {
-      return forbidden();
-    }
-
-    const species = await listSpeciesGlobal();
-
+    const species = await getPlatformSpecies();
     return ok({ species });
   } catch (error) {
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
+    if (error instanceof Error) {
+      if (error.message === "UNAUTHORIZED") return unauthorized();
+      if (error.message === "FORBIDDEN") return forbidden();
+    }
 
     logger.error("Unexpected GET /platform/species error:", error);
     return internalError();
@@ -40,43 +25,20 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const session = await auth();
-
-    let user;
-    try {
-      user = requireUser(session);
-    } catch {
-      return unauthorized();
-    }
-
-    if (!canManageGlobalButterflies(user)) {
-      return forbidden();
-    }
-
     const bodyResult = await requireValidBody(request, createSpeciesBodySchema);
     if ("error" in bodyResult) return bodyResult.error;
 
-    const species = await createSpecies(bodyResult.data);
+    const species = await createPlatformSpecies(bodyResult.data);
 
     return ok({ species }, 201);
   } catch (error) {
-    if (isUniqueViolation(error)) {
-      return conflict("Species scientific name already exists");
+    if (error instanceof Error) {
+      if (error.message === "UNAUTHORIZED") return unauthorized();
+      if (error.message === "FORBIDDEN") return forbidden();
+      if (error.message === "CONFLICT") return conflict("Species scientific name already exists");
     }
-
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
 
     logger.error("Unexpected POST /platform/species error:", error);
     return internalError();
   }
-}
-
-function isUniqueViolation(error: unknown): boolean {
-  return (
-    error !== null &&
-    typeof error === "object" &&
-    "code" in error &&
-    (error as { code: unknown }).code === "23505"
-  );
 }

--- a/src/app/api/platform/suppliers/[id]/route.ts
+++ b/src/app/api/platform/suppliers/[id]/route.ts
@@ -12,7 +12,6 @@ import {
 } from "@/lib/api-response";
 import { requireValidBody } from "@/lib/validation/request";
 import { supplierIdParamsSchema, updateSupplierBodySchema } from "@/lib/validation/suppliers";
-import { handleTenantError } from "@/lib/tenant";
 
 import {
   getPlatformSupplierById,
@@ -45,9 +44,6 @@ export async function GET(_request: NextRequest, context: RouteContext) {
       if (error.message === "FORBIDDEN") return forbidden();
     }
 
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
-
     logger.error("Unexpected GET /platform/suppliers/[id] error:", error);
     return internalError();
   }
@@ -77,9 +73,6 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       if (error.message === SUPPLIER_ERRORS.REFERENCED_BY_SHIPMENTS) return conflict(error.message);
     }
 
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
-
     logger.error("Unexpected PATCH /platform/suppliers/[id] error:", error);
     return internalError();
   }
@@ -103,9 +96,6 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
       if (error.message === "NOT_FOUND") return notFound("Supplier not found");
       if (error.message === SUPPLIER_ERRORS.REFERENCED_BY_SHIPMENTS) return conflict(error.message);
     }
-
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
 
     logger.error("Unexpected DELETE /platform/suppliers/[id] error:", error);
     return internalError();

--- a/src/app/api/platform/suppliers/route.ts
+++ b/src/app/api/platform/suppliers/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest } from "next/server";
 
 import { logger } from "@/lib/logger";
-import { conflict, forbidden, internalError, ok, unauthorized } from "@/lib/api-response";
+import { conflict, forbidden, internalError, notFound, ok, unauthorized } from "@/lib/api-response";
+import { TENANT_ERRORS } from "@/lib/tenant";
 import { requireValidBody } from "@/lib/validation/request";
 import { requireValidQuery } from "@/lib/validation/query";
 import { createSupplierBodySchema, listSuppliersQuerySchema } from "@/lib/validation/suppliers";
@@ -42,6 +43,8 @@ export async function POST(request: NextRequest) {
     if (error instanceof Error) {
       if (error.message === "UNAUTHORIZED") return unauthorized();
       if (error.message === "FORBIDDEN") return forbidden();
+      if (error.message === TENANT_ERRORS.INSTITUTION_NOT_FOUND)
+        return notFound("Institution not found");
       if (error.message === "CONFLICT")
         return conflict("Supplier code already exists for this institution");
     }

--- a/src/app/api/platform/suppliers/route.ts
+++ b/src/app/api/platform/suppliers/route.ts
@@ -5,7 +5,6 @@ import { conflict, forbidden, internalError, ok, unauthorized } from "@/lib/api-
 import { requireValidBody } from "@/lib/validation/request";
 import { requireValidQuery } from "@/lib/validation/query";
 import { createSupplierBodySchema, listSuppliersQuerySchema } from "@/lib/validation/suppliers";
-import { handleTenantError } from "@/lib/tenant";
 
 import { getPlatformSuppliers, createPlatformSupplier } from "@/lib/services/platform-suppliers";
 
@@ -25,9 +24,6 @@ export async function GET(request: NextRequest) {
       if (error.message === "UNAUTHORIZED") return unauthorized();
       if (error.message === "FORBIDDEN") return forbidden();
     }
-
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
 
     logger.error("Unexpected GET /platform/suppliers error:", error);
     return internalError();
@@ -49,9 +45,6 @@ export async function POST(request: NextRequest) {
       if (error.message === "CONFLICT")
         return conflict("Supplier code already exists for this institution");
     }
-
-    const tenantError = handleTenantError(error);
-    if (tenantError) return tenantError;
 
     logger.error("Unexpected POST /platform/suppliers error:", error);
     return internalError();

--- a/src/app/api/tenant/users/[id]/route.ts
+++ b/src/app/api/tenant/users/[id]/route.ts
@@ -94,8 +94,8 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
     return ok({ user: updated });
   } catch (error: unknown) {
-    const dbError = error as { code?: string };
-    if (dbError?.code === "23505") {
+    const dbError = error as { code?: string; cause?: { code?: string } };
+    if (dbError?.code === "23505" || dbError?.cause?.code === "23505") {
       return conflict("Email already exists");
     }
 

--- a/src/app/api/tenant/users/route.ts
+++ b/src/app/api/tenant/users/route.ts
@@ -65,8 +65,8 @@ export async function POST(request: NextRequest) {
 
     return ok({ user: created });
   } catch (error: unknown) {
-    const dbError = error as { code?: string };
-    if (dbError?.code === "23505") {
+    const dbError = error as { code?: string; cause?: { code?: string } };
+    if (dbError?.code === "23505" || dbError?.cause?.code === "23505") {
       return conflict("Email already exists");
     }
 

--- a/src/components/platform/dashboard/platform-nav-card.tsx
+++ b/src/components/platform/dashboard/platform-nav-card.tsx
@@ -1,0 +1,35 @@
+import { LucideIcon } from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Link } from "@/components/ui/link";
+
+interface PlatformNavCardProps {
+  href: string;
+  title: string;
+  description: string;
+  icon: LucideIcon;
+}
+
+export default function PlatformNavCard({
+  href,
+  title,
+  description,
+  icon: Icon,
+}: PlatformNavCardProps) {
+  return (
+    <Link
+      href={href}
+      className="group focus-visible:ring-ring block rounded-lg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+    >
+      <Card className="group-hover:bg-muted h-full transition-colors group-hover:shadow-sm">
+        <CardContent className="flex flex-col gap-4 p-6">
+          <Icon className="text-primary size-8" aria-hidden="true" />
+          <div>
+            <h2 className="text-base font-semibold">{title}</h2>
+            <p className="text-muted-foreground mt-1 text-sm">{description}</p>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/platform/institutions/add/institution-add-form.tsx
+++ b/src/components/platform/institutions/add/institution-add-form.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+const TIMEZONE_OPTIONS = [
+  // North America
+  { label: "Eastern (ET) — America/New_York", iana: "America/New_York" },
+  { label: "Central (CT) — America/Chicago", iana: "America/Chicago" },
+  { label: "Mountain (MT) — America/Denver", iana: "America/Denver" },
+  { label: "Pacific (PT) — America/Los_Angeles", iana: "America/Los_Angeles" },
+  { label: "Alaska (AKT) — America/Anchorage", iana: "America/Anchorage" },
+  { label: "Hawaii (HST) — Pacific/Honolulu", iana: "Pacific/Honolulu" },
+  // Europe
+  { label: "GMT — Europe/London", iana: "Europe/London" },
+  { label: "CET — Europe/Paris", iana: "Europe/Paris" },
+  { label: "EET — Europe/Helsinki", iana: "Europe/Helsinki" },
+  // Oceania
+  { label: "AEST — Australia/Sydney", iana: "Australia/Sydney" },
+  { label: "NZST — Pacific/Auckland", iana: "Pacific/Auckland" },
+  // Asia
+  { label: "JST — Asia/Tokyo", iana: "Asia/Tokyo" },
+  { label: "IST — Asia/Kolkata", iana: "Asia/Kolkata" },
+  { label: "SGT — Asia/Singapore", iana: "Asia/Singapore" },
+];
+
+const addFormSchema = z.object({
+  // Identity
+  name: z.string().min(1, "Name is required"),
+  slug: z.string().min(1, "Slug is required"),
+  description: z.string().optional(),
+
+  // Address
+  street_address: z.string().min(1, "Street address is required"),
+  extended_address: z.string().optional(),
+  city: z.string().min(1, "City is required"),
+  state_province: z.string().min(1, "State / Province is required"),
+  postal_code: z.string().min(1, "Postal code is required"),
+  country: z.string().min(1, "Country is required"),
+  time_zone: z.string().optional(),
+
+  // Contact (all optional)
+  email_address: z.string().email("Invalid email address").or(z.literal("")).optional(),
+  phone_number: z.string().optional(),
+  website_url: z.string().url("Invalid URL").or(z.literal("")).optional(),
+
+  // Platform flags
+  iabes_member: z.boolean(),
+});
+
+type AddFormValues = z.infer<typeof addFormSchema>;
+
+export default function InstitutionAddForm() {
+  const router = useRouter();
+
+  const form = useForm<AddFormValues>({
+    resolver: zodResolver(addFormSchema),
+    defaultValues: {
+      name: "",
+      slug: "",
+      description: "",
+      street_address: "",
+      extended_address: "",
+      city: "",
+      state_province: "",
+      postal_code: "",
+      country: "",
+      time_zone: "",
+      email_address: "",
+      phone_number: "",
+      website_url: "",
+      iabes_member: false,
+    },
+  });
+
+  const slugValue = form.watch("slug");
+
+  async function onSubmit(values: AddFormValues) {
+    const body = {
+      name: values.name,
+      slug: values.slug,
+      ...(values.description ? { description: values.description } : {}),
+      street_address: values.street_address,
+      ...(values.extended_address ? { extended_address: values.extended_address } : {}),
+      city: values.city,
+      state_province: values.state_province,
+      postal_code: values.postal_code,
+      country: values.country,
+      ...(values.time_zone ? { time_zone: values.time_zone } : {}),
+      ...(values.email_address ? { email_address: values.email_address } : {}),
+      ...(values.phone_number ? { phone_number: values.phone_number } : {}),
+      ...(values.website_url ? { website_url: values.website_url } : {}),
+      iabes_member: values.iabes_member,
+    };
+
+    const res = await fetch("/api/platform/institutions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      router.push(`/platform/institutions/${data.institution.id}`);
+      return;
+    }
+
+    if (res.status === 409) {
+      form.setError("slug", { message: "Slug is already in use." });
+      return;
+    }
+
+    const data = await res.json().catch(() => ({}));
+    toast.error(data?.error ?? "Unable to create institution.");
+  }
+
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-8">
+            {/* Identity */}
+            <section className="flex flex-col gap-4">
+              <h2 className="text-sm font-semibold">Identity</h2>
+
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Butterfly Haven" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="slug"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Slug</FormLabel>
+                    <FormControl>
+                      <Input placeholder="butterfly-haven" {...field} />
+                    </FormControl>
+                    <FormDescription>flutr.app/{slugValue || "…"}/gallery</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Description{" "}
+                      <span className="text-muted-foreground font-normal">(optional)</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="A brief description of the institution…"
+                        rows={3}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </section>
+
+            <Separator />
+
+            {/* Address */}
+            <section className="flex flex-col gap-4">
+              <h2 className="text-sm font-semibold">Address</h2>
+
+              <FormField
+                control={form.control}
+                name="street_address"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Street address</FormLabel>
+                    <FormControl>
+                      <Input placeholder="123 Meadow Lane" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="extended_address"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Extended address{" "}
+                      <span className="text-muted-foreground font-normal">(optional)</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input placeholder="Suite 200" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="grid grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="city"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>City</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Springfield" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="state_province"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>State / Province</FormLabel>
+                      <FormControl>
+                        <Input placeholder="IL" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="postal_code"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Postal code</FormLabel>
+                      <FormControl>
+                        <Input placeholder="62701" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="country"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Country</FormLabel>
+                      <FormControl>
+                        <Input placeholder="United States" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="time_zone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Time zone{" "}
+                      <span className="text-muted-foreground font-normal">(optional)</span>
+                    </FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger aria-label="Select time zone">
+                          <SelectValue placeholder="Select a time zone" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {TIMEZONE_OPTIONS.map((tz) => (
+                          <SelectItem key={tz.iana} value={tz.iana}>
+                            {tz.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </section>
+
+            <Separator />
+
+            {/* Contact */}
+            <section className="flex flex-col gap-4">
+              <h2 className="text-sm font-semibold">Contact</h2>
+
+              <FormField
+                control={form.control}
+                name="email_address"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Email address{" "}
+                      <span className="text-muted-foreground font-normal">(optional)</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input type="email" placeholder="hello@butterfly-haven.org" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="phone_number"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Phone number{" "}
+                      <span className="text-muted-foreground font-normal">(optional)</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input type="tel" placeholder="+1 (555) 000-0000" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="website_url"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Website URL{" "}
+                      <span className="text-muted-foreground font-normal">(optional)</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input type="url" placeholder="https://butterfly-haven.org" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </section>
+
+            <Separator />
+
+            {/* Platform Flags */}
+            <section className="flex flex-col gap-4">
+              <h2 className="text-sm font-semibold">Platform Flags</h2>
+
+              <FormField
+                control={form.control}
+                name="iabes_member"
+                render={({ field }) => (
+                  <FormItem className="flex items-center gap-3 rounded-lg border p-4">
+                    <FormControl>
+                      <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                    <div className="space-y-0.5">
+                      <FormLabel>IABES member</FormLabel>
+                      <FormDescription>This institution is a member of IABES</FormDescription>
+                    </div>
+                  </FormItem>
+                )}
+              />
+            </section>
+
+            <div className="flex justify-end">
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                {form.formState.isSubmitting ? "Creating…" : "Create Institution"}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/platform/institutions/add/institution-add-form.tsx
+++ b/src/components/platform/institutions/add/institution-add-form.tsx
@@ -28,6 +28,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { institutionSlugSchema } from "@/lib/validation/slug";
 
 const TIMEZONE_OPTIONS = [
   // North America
@@ -53,7 +54,7 @@ const TIMEZONE_OPTIONS = [
 const addFormSchema = z.object({
   // Identity
   name: z.string().min(1, "Name is required"),
-  slug: z.string().min(1, "Slug is required"),
+  slug: institutionSlugSchema,
   description: z.string().optional(),
 
   // Address
@@ -81,6 +82,8 @@ export default function InstitutionAddForm() {
 
   const form = useForm<AddFormValues>({
     resolver: zodResolver(addFormSchema),
+    mode: "onChange",
+    reValidateMode: "onChange",
     defaultValues: {
       name: "",
       slug: "",
@@ -127,7 +130,7 @@ export default function InstitutionAddForm() {
 
     if (res.ok) {
       const data = await res.json();
-      router.push(`/platform/institutions/${data.institution.id}`);
+      router.push(`/platform/institutions/${data.institution.id}?tab=profile`);
       return;
     }
 

--- a/src/components/platform/institutions/detail/institution-data-tab.tsx
+++ b/src/components/platform/institutions/detail/institution-data-tab.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@/components/ui/button";
+
+export default function InstitutionDataTab() {
+  return (
+    <div className="mt-6 flex flex-col gap-4">
+      <h2 className="text-sm font-semibold">Historical Shipment Data</h2>
+
+      <p className="text-muted-foreground text-sm">
+        Superusers can import historical shipment records from Excel files and export current
+        institution data for reporting or migration purposes.
+      </p>
+
+      <div className="flex gap-2">
+        <Button variant="outline" disabled>
+          Import from Excel
+        </Button>
+        <Button variant="outline" disabled>
+          Export Data
+        </Button>
+      </div>
+
+      <p className="text-muted-foreground text-xs">
+        Full data tools will be available in the Shipments Hub.
+      </p>
+    </div>
+  );
+}

--- a/src/components/platform/institutions/detail/institution-detail-shell.tsx
+++ b/src/components/platform/institutions/detail/institution-detail-shell.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
 import {
@@ -54,19 +54,38 @@ export interface InstitutionUser {
   role: string;
 }
 
+type InstitutionDetailTab = "profile" | "theme" | "users" | "data";
+
 interface Props {
   institution: InstitutionDetail;
   users: InstitutionUser[];
+  initialTab: InstitutionDetailTab;
 }
 
-export default function InstitutionDetailShell({ institution, users }: Props) {
+export default function InstitutionDetailShell({ institution, users, initialTab }: Props) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [currentInstitution, setCurrentInstitution] = useState(institution);
   const [isDeletingInstitution, setIsDeletingInstitution] = useState(false);
+  const [activeTab, setActiveTab] = useState<InstitutionDetailTab>(initialTab);
 
   useEffect(() => {
     setCurrentInstitution(institution);
   }, [institution]);
+
+  useEffect(() => {
+    setActiveTab(initialTab);
+  }, [initialTab]);
+
+  function handleTabChange(value: string) {
+    const nextTab = value as InstitutionDetailTab;
+    setActiveTab(nextTab);
+
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", nextTab);
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  }
 
   async function handleDeleteInstitution() {
     setIsDeletingInstitution(true);
@@ -89,24 +108,30 @@ export default function InstitutionDetailShell({ institution, users }: Props) {
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-10">
       {/* Header */}
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex flex-col gap-1">
-          <Button variant="ghost" size="sm" className="-ml-2 w-fit" asChild>
-            <Link href="/platform/institutions">
-              <ArrowLeft className="mr-1 size-4" aria-hidden="true" />
-              Institutions
-            </Link>
-          </Button>
-          <h1 className="text-2xl font-bold">{currentInstitution.name}</h1>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-col gap-1">
+            <Button variant="ghost" size="sm" className="-ml-2 w-fit" asChild>
+              <Link href="/platform/institutions">
+                <ArrowLeft className="mr-1 size-4" aria-hidden="true" />
+                Institutions
+              </Link>
+            </Button>
+            <h1 className="text-2xl font-bold break-words whitespace-normal">
+              {currentInstitution.name}
+            </h1>
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" asChild>
+        <div className="flex w-full flex-col gap-2 sm:flex-row lg:w-auto">
+          <Button variant="outline" asChild className="w-full sm:w-auto">
             <Link href={`/${currentInstitution.slug}/dashboard`}>View as Admin</Link>
           </Button>
 
           <AlertDialog>
             <AlertDialogTrigger asChild>
-              <Button variant="destructive">Delete Institution</Button>
+              <Button variant="destructive" className="w-full sm:w-auto">
+                Delete Institution
+              </Button>
             </AlertDialogTrigger>
             <AlertDialogContent>
               <AlertDialogHeader>
@@ -132,8 +157,11 @@ export default function InstitutionDetailShell({ institution, users }: Props) {
       </div>
 
       {/* Tabs */}
-      <Tabs defaultValue="profile">
-        <TabsList aria-label="Institution settings">
+      <Tabs value={activeTab} onValueChange={handleTabChange}>
+        <TabsList
+          aria-label="Institution settings"
+          className="grid w-full grid-cols-4 sm:inline-flex sm:w-fit"
+        >
           <TabsTrigger value="profile">Profile</TabsTrigger>
           <TabsTrigger value="theme">Theme</TabsTrigger>
           <TabsTrigger value="users">Users</TabsTrigger>

--- a/src/components/platform/institutions/detail/institution-detail-shell.tsx
+++ b/src/components/platform/institutions/detail/institution-detail-shell.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import InstitutionProfileTab from "./institution-profile-tab";
+import InstitutionThemeTab from "./institution-theme-tab";
+import InstitutionUsersTab from "./institution-users-tab";
+import InstitutionDataTab from "./institution-data-tab";
+
+export interface InstitutionDetail {
+  id: number;
+  name: string;
+  slug: string;
+  description: string | null;
+  street_address: string;
+  extended_address: string | null;
+  city: string;
+  state_province: string;
+  postal_code: string;
+  country: string;
+  time_zone: string | null;
+  email_address: string | null;
+  phone_number: string | null;
+  website_url: string | null;
+  logo_url: string | null;
+  facility_image_url: string | null;
+  social_links: Record<string, string> | null;
+  theme_colors: string[] | null;
+  stats_active: boolean;
+  iabes_member: boolean;
+}
+
+export interface InstitutionUser {
+  id: number;
+  name: string;
+  email: string;
+  role: string;
+}
+
+interface Props {
+  institution: InstitutionDetail;
+  users: InstitutionUser[];
+}
+
+export default function InstitutionDetailShell({ institution, users }: Props) {
+  const router = useRouter();
+  const [currentInstitution, setCurrentInstitution] = useState(institution);
+  const [isDeletingInstitution, setIsDeletingInstitution] = useState(false);
+
+  useEffect(() => {
+    setCurrentInstitution(institution);
+  }, [institution]);
+
+  async function handleDeleteInstitution() {
+    setIsDeletingInstitution(true);
+
+    const res = await fetch(`/api/platform/institutions/${currentInstitution.id}`, {
+      method: "DELETE",
+    });
+
+    if (res.ok) {
+      toast.success("Institution deleted.");
+      router.push("/platform/institutions");
+      return;
+    }
+
+    const data = await res.json().catch(() => ({}));
+    toast.error(data?.message ?? "Failed to delete institution.");
+    setIsDeletingInstitution(false);
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-10">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <Button variant="ghost" size="sm" className="-ml-2 w-fit" asChild>
+            <Link href="/platform/institutions">
+              <ArrowLeft className="mr-1 size-4" aria-hidden="true" />
+              Institutions
+            </Link>
+          </Button>
+          <h1 className="text-2xl font-bold">{currentInstitution.name}</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" asChild>
+            <Link href={`/${currentInstitution.slug}/dashboard`}>View as Admin</Link>
+          </Button>
+
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="destructive">Delete Institution</Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete institution?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will permanently remove {currentInstitution.name} and all tenant-scoped data
+                  tied to it. This action cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={isDeletingInstitution}>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  disabled={isDeletingInstitution}
+                  onClick={handleDeleteInstitution}
+                >
+                  {isDeletingInstitution ? "Deleting…" : "Delete institution"}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <Tabs defaultValue="profile">
+        <TabsList aria-label="Institution settings">
+          <TabsTrigger value="profile">Profile</TabsTrigger>
+          <TabsTrigger value="theme">Theme</TabsTrigger>
+          <TabsTrigger value="users">Users</TabsTrigger>
+          <TabsTrigger value="data">Data</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="profile">
+          <InstitutionProfileTab institution={currentInstitution} onSaved={setCurrentInstitution} />
+        </TabsContent>
+
+        <TabsContent value="theme">
+          <InstitutionThemeTab institution={currentInstitution} />
+        </TabsContent>
+
+        <TabsContent value="users">
+          <InstitutionUsersTab institution={currentInstitution} initialUsers={users} />
+        </TabsContent>
+
+        <TabsContent value="data">
+          <InstitutionDataTab />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/components/platform/institutions/detail/institution-profile-tab.tsx
+++ b/src/components/platform/institutions/detail/institution-profile-tab.tsx
@@ -1,0 +1,489 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+
+import type { InstitutionDetail } from "./institution-detail-shell";
+
+const profileFormSchema = z.object({
+  // Identity
+  name: z.string().min(1, "Name is required"),
+  slug: z.string().min(1, "Slug is required"),
+  description: z.string().optional(),
+
+  // Address
+  street_address: z.string().min(1, "Street address is required"),
+  extended_address: z.string().optional(),
+  city: z.string().min(1, "City is required"),
+  state_province: z.string().min(1, "State / Province is required"),
+  postal_code: z.string().min(1, "Postal code is required"),
+  country: z.string().min(1, "Country is required"),
+  time_zone: z.string().optional(),
+
+  // Contact
+  email_address: z.string().email("Invalid email address").or(z.literal("")).optional(),
+  phone_number: z.string().optional(),
+  website_url: z.string().url("Invalid URL").or(z.literal("")).optional(),
+
+  // Social links (stored as individual fields, serialised on submit)
+  social_twitter: z.string().optional(),
+  social_instagram: z.string().optional(),
+  social_facebook: z.string().optional(),
+  social_linkedin: z.string().optional(),
+  social_youtube: z.string().optional(),
+
+  // Platform flags
+  stats_active: z.boolean(),
+  iabes_member: z.boolean(),
+});
+
+type ProfileFormValues = z.infer<typeof profileFormSchema>;
+
+interface Props {
+  institution: InstitutionDetail;
+  onSaved: (institution: InstitutionDetail) => void;
+}
+
+type ProfileUpdateResponse = {
+  institution?: Partial<InstitutionDetail> & {
+    social_links?: Record<string, string> | null;
+    theme_colors?: string[] | null;
+  };
+};
+
+export default function InstitutionProfileTab({ institution, onSaved }: Props) {
+  const form = useForm<ProfileFormValues>({
+    resolver: zodResolver(profileFormSchema),
+    defaultValues: {
+      name: institution.name,
+      slug: institution.slug,
+      description: institution.description ?? "",
+      street_address: institution.street_address,
+      extended_address: institution.extended_address ?? "",
+      city: institution.city,
+      state_province: institution.state_province,
+      postal_code: institution.postal_code,
+      country: institution.country,
+      time_zone: institution.time_zone ?? "",
+      email_address: institution.email_address ?? "",
+      phone_number: institution.phone_number ?? "",
+      website_url: institution.website_url ?? "",
+      social_twitter: institution.social_links?.twitter ?? "",
+      social_instagram: institution.social_links?.instagram ?? "",
+      social_facebook: institution.social_links?.facebook ?? "",
+      social_linkedin: institution.social_links?.linkedin ?? "",
+      social_youtube: institution.social_links?.youtube ?? "",
+      stats_active: institution.stats_active,
+      iabes_member: institution.iabes_member,
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      name: institution.name,
+      slug: institution.slug,
+      description: institution.description ?? "",
+      street_address: institution.street_address,
+      extended_address: institution.extended_address ?? "",
+      city: institution.city,
+      state_province: institution.state_province,
+      postal_code: institution.postal_code,
+      country: institution.country,
+      time_zone: institution.time_zone ?? "",
+      email_address: institution.email_address ?? "",
+      phone_number: institution.phone_number ?? "",
+      website_url: institution.website_url ?? "",
+      social_twitter: institution.social_links?.twitter ?? "",
+      social_instagram: institution.social_links?.instagram ?? "",
+      social_facebook: institution.social_links?.facebook ?? "",
+      social_linkedin: institution.social_links?.linkedin ?? "",
+      social_youtube: institution.social_links?.youtube ?? "",
+      stats_active: institution.stats_active,
+      iabes_member: institution.iabes_member,
+    });
+  }, [institution, form]);
+
+  const slugValue = form.watch("slug");
+
+  async function onSubmit(values: ProfileFormValues) {
+    const socialLinks: Record<string, string> = {};
+    if (values.social_twitter) socialLinks.twitter = values.social_twitter;
+    if (values.social_instagram) socialLinks.instagram = values.social_instagram;
+    if (values.social_facebook) socialLinks.facebook = values.social_facebook;
+    if (values.social_linkedin) socialLinks.linkedin = values.social_linkedin;
+    if (values.social_youtube) socialLinks.youtube = values.social_youtube;
+
+    const body = {
+      name: values.name,
+      slug: values.slug,
+      ...(values.description ? { description: values.description } : {}),
+      street_address: values.street_address,
+      ...(values.extended_address ? { extended_address: values.extended_address } : {}),
+      city: values.city,
+      state_province: values.state_province,
+      postal_code: values.postal_code,
+      country: values.country,
+      ...(values.time_zone ? { time_zone: values.time_zone } : {}),
+      ...(values.email_address ? { email_address: values.email_address } : {}),
+      ...(values.phone_number ? { phone_number: values.phone_number } : {}),
+      ...(values.website_url ? { website_url: values.website_url } : {}),
+      social_links: socialLinks,
+      stats_active: values.stats_active,
+      iabes_member: values.iabes_member,
+    };
+
+    const res = await fetch(`/api/platform/institutions/${institution.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (res.ok) {
+      const data = (await res.json().catch(() => ({}))) as ProfileUpdateResponse;
+      const updatedInstitution = data.institution
+        ? {
+            ...institution,
+            ...data.institution,
+            social_links: data.institution.social_links ?? null,
+            theme_colors: data.institution.theme_colors ?? institution.theme_colors,
+          }
+        : institution;
+
+      onSaved(updatedInstitution);
+      toast.success("Institution updated.");
+    } else {
+      const data = await res.json().catch(() => ({}));
+      if (res.status === 409) {
+        form.setError("slug", { message: "Slug is already in use." });
+      } else {
+        toast.error(data.message ?? "Failed to update institution.");
+      }
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="mt-6 flex flex-col gap-8">
+        {/* Identity */}
+        <section className="flex flex-col gap-4">
+          <h2 className="text-sm font-semibold">Identity</h2>
+
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input placeholder="Butterfly Haven" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="slug"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Slug</FormLabel>
+                <FormControl>
+                  <Input placeholder="butterfly-haven" {...field} />
+                </FormControl>
+                <FormDescription>flutr.app/{slugValue || "…"}/gallery</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="A brief description of the institution…"
+                    rows={3}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </section>
+
+        <Separator />
+
+        {/* Address */}
+        <section className="flex flex-col gap-4">
+          <h2 className="text-sm font-semibold">Address</h2>
+
+          <FormField
+            control={form.control}
+            name="street_address"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Street address</FormLabel>
+                <FormControl>
+                  <Input placeholder="123 Meadow Lane" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="extended_address"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Extended address{" "}
+                  <span className="text-muted-foreground font-normal">(optional)</span>
+                </FormLabel>
+                <FormControl>
+                  <Input placeholder="Suite 200" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="grid grid-cols-2 gap-4">
+            <FormField
+              control={form.control}
+              name="city"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>City</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Springfield" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="state_province"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>State / Province</FormLabel>
+                  <FormControl>
+                    <Input placeholder="IL" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="postal_code"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Postal code</FormLabel>
+                  <FormControl>
+                    <Input placeholder="62701" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="country"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Country</FormLabel>
+                  <FormControl>
+                    <Input placeholder="United States" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <FormField
+            control={form.control}
+            name="time_zone"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Time zone <span className="text-muted-foreground font-normal">(optional)</span>
+                </FormLabel>
+                <FormControl>
+                  <Input placeholder="America/Chicago" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </section>
+
+        <Separator />
+
+        {/* Contact */}
+        <section className="flex flex-col gap-4">
+          <h2 className="text-sm font-semibold">Contact</h2>
+
+          <FormField
+            control={form.control}
+            name="email_address"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Email address{" "}
+                  <span className="text-muted-foreground font-normal">(optional)</span>
+                </FormLabel>
+                <FormControl>
+                  <Input type="email" placeholder="hello@butterfly-haven.org" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="phone_number"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Phone number <span className="text-muted-foreground font-normal">(optional)</span>
+                </FormLabel>
+                <FormControl>
+                  <Input type="tel" placeholder="+1 (555) 000-0000" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="website_url"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Website URL <span className="text-muted-foreground font-normal">(optional)</span>
+                </FormLabel>
+                <FormControl>
+                  <Input type="url" placeholder="https://butterfly-haven.org" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </section>
+
+        <Separator />
+
+        {/* Social Links */}
+        <section className="flex flex-col gap-4">
+          <h2 className="text-sm font-semibold">Social Links</h2>
+
+          {(
+            [
+              { name: "social_twitter", label: "Twitter / X" },
+              { name: "social_instagram", label: "Instagram" },
+              { name: "social_facebook", label: "Facebook" },
+              { name: "social_linkedin", label: "LinkedIn" },
+              { name: "social_youtube", label: "YouTube" },
+            ] as const
+          ).map(({ name, label }) => (
+            <FormField
+              key={name}
+              control={form.control}
+              name={name}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {label} <span className="text-muted-foreground font-normal">(optional)</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input type="url" placeholder="https://" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          ))}
+        </section>
+
+        <Separator />
+
+        {/* Platform Flags */}
+        <section className="flex flex-col gap-4">
+          <h2 className="text-sm font-semibold">Platform Flags</h2>
+
+          <FormField
+            control={form.control}
+            name="stats_active"
+            render={({ field }) => (
+              <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                <div className="space-y-0.5">
+                  <FormLabel>Active on public stats</FormLabel>
+                  <FormDescription>
+                    Show this institution on the public statistics page
+                  </FormDescription>
+                </div>
+                <FormControl>
+                  <Switch checked={field.value} onCheckedChange={field.onChange} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="iabes_member"
+            render={({ field }) => (
+              <FormItem className="flex items-center gap-3 rounded-lg border p-4">
+                <FormControl>
+                  <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                </FormControl>
+                <div className="space-y-0.5">
+                  <FormLabel>IABES member</FormLabel>
+                  <FormDescription>This institution is a member of IABES</FormDescription>
+                </div>
+              </FormItem>
+            )}
+          />
+        </section>
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={form.formState.isSubmitting}>
+            {form.formState.isSubmitting ? "Saving…" : "Save changes"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/platform/institutions/detail/institution-profile-tab.tsx
+++ b/src/components/platform/institutions/detail/institution-profile-tab.tsx
@@ -21,13 +21,14 @@ import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
+import { institutionSlugSchema } from "@/lib/validation/slug";
 
 import type { InstitutionDetail } from "./institution-detail-shell";
 
 const profileFormSchema = z.object({
   // Identity
   name: z.string().min(1, "Name is required"),
-  slug: z.string().min(1, "Slug is required"),
+  slug: institutionSlugSchema,
   description: z.string().optional(),
 
   // Address
@@ -73,6 +74,8 @@ type ProfileUpdateResponse = {
 export default function InstitutionProfileTab({ institution, onSaved }: Props) {
   const form = useForm<ProfileFormValues>({
     resolver: zodResolver(profileFormSchema),
+    mode: "onChange",
+    reValidateMode: "onChange",
     defaultValues: {
       name: institution.name,
       slug: institution.slug,

--- a/src/components/platform/institutions/detail/institution-theme-tab.tsx
+++ b/src/components/platform/institutions/detail/institution-theme-tab.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+
+import type { InstitutionDetail } from "./institution-detail-shell";
+
+const PRESET_COLORS: { hex: string; label: string }[] = [
+  { hex: "#0d9488", label: "Teal" },
+  { hex: "#16a34a", label: "Green" },
+  { hex: "#4f46e5", label: "Indigo" },
+  { hex: "#ea580c", label: "Orange" },
+  { hex: "#e11d48", label: "Rose" },
+  { hex: "#475569", label: "Slate" },
+  { hex: "#d97706", label: "Amber" },
+  { hex: "#7c3aed", label: "Violet" },
+];
+
+const HEX_REGEX = /^#[0-9a-fA-F]{6}$/;
+
+const themeFormSchema = z.object({
+  primary_color: z.string().regex(HEX_REGEX, "Must be a valid hex color (#rrggbb)"),
+  logo_url: z.string().url("Invalid URL").or(z.literal("")).optional(),
+  facility_image_url: z.string().url("Invalid URL").or(z.literal("")).optional(),
+});
+
+type ThemeFormValues = z.infer<typeof themeFormSchema>;
+
+interface Props {
+  institution: InstitutionDetail;
+}
+
+export default function InstitutionThemeTab({ institution }: Props) {
+  const initialColor = institution.theme_colors?.[0] ?? PRESET_COLORS[0].hex;
+
+  const [isCustom, setIsCustom] = useState(!PRESET_COLORS.some((c) => c.hex === initialColor));
+  const [logoPreview, setLogoPreview] = useState(institution.logo_url ?? "");
+  const [facilityPreview, setFacilityPreview] = useState(institution.facility_image_url ?? "");
+
+  const form = useForm<ThemeFormValues>({
+    resolver: zodResolver(themeFormSchema),
+    defaultValues: {
+      primary_color: initialColor,
+      logo_url: institution.logo_url ?? "",
+      facility_image_url: institution.facility_image_url ?? "",
+    },
+  });
+
+  const primaryColor = form.watch("primary_color");
+
+  function selectPreset(color: string) {
+    setIsCustom(false);
+    form.setValue("primary_color", color, { shouldValidate: true });
+  }
+
+  function selectCustom() {
+    setIsCustom(true);
+  }
+
+  async function onSubmit(values: ThemeFormValues) {
+    const body = {
+      theme_colors: [values.primary_color],
+      ...(values.logo_url ? { logo_url: values.logo_url } : {}),
+      ...(values.facility_image_url ? { facility_image_url: values.facility_image_url } : {}),
+    };
+
+    const res = await fetch(`/api/platform/institutions/${institution.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (res.ok) {
+      toast.success("Theme updated.");
+    } else {
+      toast.error("Failed to update theme.");
+    }
+  }
+
+  const isValidHex = HEX_REGEX.test(primaryColor);
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="mt-6 flex flex-col gap-8">
+        {/* Theme Colors */}
+        <section className="flex flex-col gap-4">
+          <div className="flex items-center gap-3">
+            <h2 className="text-sm font-semibold">Primary Color</h2>
+            <div
+              className="size-5 rounded-full border"
+              style={{ backgroundColor: isValidHex ? primaryColor : undefined }}
+            />
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            {PRESET_COLORS.map(({ hex, label }) => (
+              <button
+                key={hex}
+                type="button"
+                aria-label={label}
+                aria-pressed={!isCustom && primaryColor === hex}
+                onClick={() => selectPreset(hex)}
+                className={cn(
+                  "size-8 rounded-full border-2 transition-all",
+                  !isCustom && primaryColor === hex
+                    ? "border-foreground ring-2 ring-offset-2"
+                    : "hover:border-muted-foreground/40 border-transparent",
+                )}
+                style={{ backgroundColor: hex }}
+              />
+            ))}
+
+            {/* Custom */}
+            <button
+              type="button"
+              aria-label="Custom color"
+              aria-pressed={isCustom}
+              onClick={selectCustom}
+              className={cn(
+                "flex size-8 items-center justify-center rounded-full border-2 text-xs font-bold transition-all",
+                isCustom
+                  ? "border-foreground bg-muted ring-2 ring-offset-2"
+                  : "border-muted-foreground/40 hover:border-muted-foreground/60 bg-muted/50 border-dashed",
+              )}
+            >
+              +
+            </button>
+          </div>
+
+          {isCustom && (
+            <FormField
+              control={form.control}
+              name="primary_color"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Custom hex color</FormLabel>
+                  <FormControl>
+                    <Input placeholder="#4f46e5" maxLength={7} {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+        </section>
+
+        <Separator />
+
+        {/* Media */}
+        <section className="flex flex-col gap-6">
+          <h2 className="text-sm font-semibold">Media</h2>
+
+          {/* Logo URL */}
+          <div className="flex flex-col gap-3">
+            <FormField
+              control={form.control}
+              name="logo_url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Logo URL <span className="text-muted-foreground font-normal">(optional)</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="url"
+                      placeholder="https://example.com/logo.png"
+                      {...field}
+                      onBlur={(e) => {
+                        field.onBlur();
+                        setLogoPreview(e.target.value);
+                      }}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {logoPreview && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={logoPreview}
+                alt="Logo preview"
+                className="h-16 w-auto rounded border object-contain"
+                onError={(e) => ((e.target as HTMLImageElement).style.display = "none")}
+                onLoad={(e) => ((e.target as HTMLImageElement).style.display = "")}
+              />
+            )}
+          </div>
+
+          {/* Facility image URL */}
+          <div className="flex flex-col gap-3">
+            <FormField
+              control={form.control}
+              name="facility_image_url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Facility image URL{" "}
+                    <span className="text-muted-foreground font-normal">(optional)</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="url"
+                      placeholder="https://example.com/facility.jpg"
+                      {...field}
+                      onBlur={(e) => {
+                        field.onBlur();
+                        setFacilityPreview(e.target.value);
+                      }}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {facilityPreview && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={facilityPreview}
+                alt="Facility image preview"
+                className="h-32 w-full rounded border object-cover"
+                onError={(e) => ((e.target as HTMLImageElement).style.display = "none")}
+                onLoad={(e) => ((e.target as HTMLImageElement).style.display = "")}
+              />
+            )}
+          </div>
+        </section>
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={form.formState.isSubmitting}>
+            {form.formState.isSubmitting ? "Saving…" : "Save changes"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/platform/institutions/detail/institution-user-form.tsx
+++ b/src/components/platform/institutions/detail/institution-user-form.tsx
@@ -47,6 +47,17 @@ const userFormSchema = z.object({
 
 type UserFormValues = z.infer<typeof userFormSchema>;
 
+type UserErrorResponse = {
+  error?:
+    | {
+        code?: string;
+        message?: string;
+      }
+    | string
+    | unknown;
+  message?: unknown;
+};
+
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -73,6 +84,31 @@ export default function InstitutionUserForm({
       password: "",
     },
   });
+
+  function getErrorMessage(data: UserErrorResponse) {
+    if (typeof data.message === "string") return data.message;
+    if (
+      typeof data.error === "object" &&
+      data.error !== null &&
+      "message" in data.error &&
+      typeof data.error.message === "string"
+    ) {
+      return data.error.message;
+    }
+    if (typeof data.error === "string") return data.error;
+    return "";
+  }
+
+  function isDuplicateEmailError(status: number, data: UserErrorResponse) {
+    if (status === 409) return true;
+
+    const message = getErrorMessage(data);
+    return message.toLowerCase().includes("email already exists");
+  }
+
+  async function readErrorResponse(res: Response): Promise<UserErrorResponse> {
+    return (await res.json().catch(() => ({}))) as UserErrorResponse;
+  }
 
   // Reset form whenever the dialog opens or the target user changes
   useEffect(() => {
@@ -123,10 +159,14 @@ export default function InstitutionUserForm({
           role: data.user.role,
         });
         onOpenChange(false);
-      } else if (res.status === 409) {
-        form.setError("email", { message: "Email already in use." });
       } else {
-        toast.error("Failed to update user.");
+        const data = await readErrorResponse(res);
+        if (isDuplicateEmailError(res.status, data)) {
+          form.setError("email", { message: "Email already in use." });
+          return;
+        }
+
+        toast.error(getErrorMessage(data) || "Failed to update user.");
       }
     } else {
       const res = await fetch("/api/tenant/users", {
@@ -150,10 +190,14 @@ export default function InstitutionUserForm({
           role: data.user.role,
         });
         onOpenChange(false);
-      } else if (res.status === 409) {
-        form.setError("email", { message: "Email already in use." });
       } else {
-        toast.error("Failed to add user.");
+        const data = await readErrorResponse(res);
+        if (isDuplicateEmailError(res.status, data)) {
+          form.setError("email", { message: "Email already in use." });
+          return;
+        }
+
+        toast.error(getErrorMessage(data) || "Failed to add user.");
       }
     }
   }
@@ -193,7 +237,17 @@ export default function InstitutionUserForm({
                 <FormItem>
                   <FormLabel>Email</FormLabel>
                   <FormControl>
-                    <Input type="email" placeholder="jane@example.com" {...field} />
+                    <Input
+                      type="email"
+                      placeholder="jane@example.com"
+                      {...field}
+                      onChange={(event) => {
+                        field.onChange(event);
+                        if (form.formState.errors.email) {
+                          form.clearErrors("email");
+                        }
+                      }}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/components/platform/institutions/detail/institution-user-form.tsx
+++ b/src/components/platform/institutions/detail/institution-user-form.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import type { InstitutionUser } from "./institution-detail-shell";
+
+const userFormSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  email: z.string().email("Invalid email address"),
+  role: z.enum(["EMPLOYEE", "ADMIN"]),
+  // Empty string = no change (edit only). Min 8 enforced when non-empty.
+  password: z
+    .string()
+    .max(200)
+    .refine((v) => !v || v.length >= 8, "Password must be at least 8 characters"),
+});
+
+type UserFormValues = z.infer<typeof userFormSchema>;
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  institutionSlug: string;
+  editUser?: InstitutionUser;
+  onSuccess: (user: InstitutionUser) => void;
+}
+
+export default function InstitutionUserForm({
+  open,
+  onOpenChange,
+  institutionSlug,
+  editUser,
+  onSuccess,
+}: Props) {
+  const isEdit = !!editUser;
+
+  const form = useForm<UserFormValues>({
+    resolver: zodResolver(userFormSchema),
+    defaultValues: {
+      name: "",
+      email: "",
+      role: "EMPLOYEE",
+      password: "",
+    },
+  });
+
+  // Reset form whenever the dialog opens or the target user changes
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        name: editUser?.name ?? "",
+        email: editUser?.email ?? "",
+        role:
+          editUser?.role === "ADMIN" || editUser?.role === "EMPLOYEE" ? editUser.role : "EMPLOYEE",
+        password: "",
+      });
+    }
+  }, [open, editUser, form]);
+
+  async function onSubmit(values: UserFormValues) {
+    // Password required for add
+    if (!isEdit && !values.password) {
+      form.setError("password", { message: "Password is required" });
+      return;
+    }
+
+    const tenantHeaders = {
+      "Content-Type": "application/json",
+      "x-tenant-slug": institutionSlug,
+    };
+
+    if (isEdit) {
+      const body: Record<string, unknown> = {
+        name: values.name,
+        email: values.email,
+        role: values.role,
+      };
+      if (values.password) body.password = values.password;
+
+      const res = await fetch(`/api/tenant/users/${editUser!.id}`, {
+        method: "PATCH",
+        headers: tenantHeaders,
+        body: JSON.stringify(body),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        toast.success("User updated.");
+        onSuccess({
+          id: data.user.id,
+          name: data.user.name,
+          email: data.user.email,
+          role: data.user.role,
+        });
+        onOpenChange(false);
+      } else if (res.status === 409) {
+        form.setError("email", { message: "Email already in use." });
+      } else {
+        toast.error("Failed to update user.");
+      }
+    } else {
+      const res = await fetch("/api/tenant/users", {
+        method: "POST",
+        headers: tenantHeaders,
+        body: JSON.stringify({
+          name: values.name,
+          email: values.email,
+          role: values.role,
+          password: values.password,
+        }),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        toast.success("User added.");
+        onSuccess({
+          id: data.user.id,
+          name: data.user.name,
+          email: data.user.email,
+          role: data.user.role,
+        });
+        onOpenChange(false);
+      } else if (res.status === 409) {
+        form.setError("email", { message: "Email already in use." });
+      } else {
+        toast.error("Failed to add user.");
+      }
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Edit User" : "Add User"}</DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Update this institution user’s details and access level."
+              : "Create a new institution user and choose their role."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="mt-2 flex flex-col gap-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Jane Smith" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input type="email" placeholder="jane@example.com" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger aria-label="Select role">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="EMPLOYEE">Employee</SelectItem>
+                      <SelectItem value="ADMIN">Admin</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      placeholder={isEdit ? "Leave blank to keep current" : "Min. 8 characters"}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter className="mt-2">
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                {form.formState.isSubmitting
+                  ? isEdit
+                    ? "Saving…"
+                    : "Adding…"
+                  : isEdit
+                    ? "Save changes"
+                    : "Add user"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/platform/institutions/detail/institution-users-cards.tsx
+++ b/src/components/platform/institutions/detail/institution-users-cards.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+import type { InstitutionUser } from "./institution-detail-shell";
+
+const ROLE_LABELS: Record<string, string> = {
+  EMPLOYEE: "Employee",
+  ADMIN: "Admin",
+  SUPERUSER: "Superuser",
+};
+
+interface Props {
+  users: InstitutionUser[];
+  onEdit: (user: InstitutionUser) => void;
+  renderDeleteAction: (user: InstitutionUser) => React.ReactNode;
+}
+
+export default function InstitutionUsersCards({ users, onEdit, renderDeleteAction }: Props) {
+  if (users.length === 0) {
+    return (
+      <Card className="md:hidden">
+        <CardContent className="py-8 text-center">
+          <p className="text-muted-foreground text-sm">No users found.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 md:hidden">
+      {users.map((user) => (
+        <Card key={user.id}>
+          <CardContent className="flex flex-col gap-4 pt-6">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-base font-medium break-words">{user.name}</p>
+                <p className="text-muted-foreground text-sm break-all">{user.email}</p>
+              </div>
+
+              <Badge variant="outline">{ROLE_LABELS[user.role] ?? user.role}</Badge>
+            </div>
+
+            <div className="xs:flex-row flex flex-col gap-2">
+              <Button variant="outline" onClick={() => onEdit(user)} className="xs:flex-1">
+                Edit
+              </Button>
+              <div className="xs:flex-1">{renderDeleteAction(user)}</div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/platform/institutions/detail/institution-users-tab.tsx
+++ b/src/components/platform/institutions/detail/institution-users-tab.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+import type { InstitutionDetail, InstitutionUser } from "./institution-detail-shell";
+import InstitutionUserForm from "./institution-user-form";
+
+const ROLE_LABELS: Record<string, string> = {
+  EMPLOYEE: "Employee",
+  ADMIN: "Admin",
+  SUPERUSER: "Superuser",
+};
+
+interface Props {
+  institution: InstitutionDetail;
+  initialUsers: InstitutionUser[];
+}
+
+export default function InstitutionUsersTab({ institution, initialUsers }: Props) {
+  const [users, setUsers] = useState<InstitutionUser[]>(initialUsers);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingUser, setEditingUser] = useState<InstitutionUser | undefined>(undefined);
+  const [isDeletingUser, setIsDeletingUser] = useState(false);
+
+  function openAdd() {
+    setEditingUser(undefined);
+    setDialogOpen(true);
+  }
+
+  function openEdit(user: InstitutionUser) {
+    setEditingUser(user);
+    setDialogOpen(true);
+  }
+
+  function handleSuccess(user: InstitutionUser) {
+    if (editingUser) {
+      setUsers((prev) => prev.map((u) => (u.id === user.id ? user : u)));
+    } else {
+      setUsers((prev) => [...prev, user]);
+    }
+  }
+
+  async function handleDelete(user: InstitutionUser) {
+    setIsDeletingUser(true);
+
+    const res = await fetch(`/api/tenant/users/${user.id}`, {
+      method: "DELETE",
+      headers: { "x-tenant-slug": institution.slug },
+    });
+
+    if (res.ok) {
+      setUsers((prev) => prev.filter((u) => u.id !== user.id));
+      toast.success("User removed.");
+    } else {
+      toast.error("Failed to remove user.");
+    }
+
+    setIsDeletingUser(false);
+  }
+
+  const onlyOneUser = users.length === 1;
+
+  return (
+    <TooltipProvider>
+      <div className="mt-6 flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <p className="text-muted-foreground text-sm">
+            {users.length} {users.length === 1 ? "user" : "users"}
+          </p>
+          <Button size="sm" onClick={openAdd}>
+            Add User
+          </Button>
+        </div>
+
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead className="w-[120px]">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {users.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-muted-foreground py-8 text-center text-sm">
+                    No users found.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                users.map((user) => (
+                  <TableRow key={user.id}>
+                    <TableCell className="font-medium">{user.name}</TableCell>
+                    <TableCell>{user.email}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline">{ROLE_LABELS[user.role] ?? user.role}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-2">
+                        <Button size="sm" variant="outline" onClick={() => openEdit(user)}>
+                          Edit
+                        </Button>
+
+                        {onlyOneUser ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span>
+                                <Button size="sm" variant="destructive" disabled>
+                                  Delete
+                                </Button>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>At least one user is required</TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button size="sm" variant="destructive">
+                                Delete
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent size="sm">
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>Delete user?</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  Remove {user.name} from {institution.name}.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel disabled={isDeletingUser}>
+                                  Cancel
+                                </AlertDialogCancel>
+                                <AlertDialogAction
+                                  variant="destructive"
+                                  disabled={isDeletingUser}
+                                  onClick={() => handleDelete(user)}
+                                >
+                                  {isDeletingUser ? "Deleting…" : "Delete user"}
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        <InstitutionUserForm
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          institutionSlug={institution.slug}
+          editUser={editingUser}
+          onSuccess={handleSuccess}
+        />
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/components/platform/institutions/detail/institution-users-tab.tsx
+++ b/src/components/platform/institutions/detail/institution-users-tab.tsx
@@ -27,6 +27,7 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 import type { InstitutionDetail, InstitutionUser } from "./institution-detail-shell";
+import InstitutionUsersCards from "./institution-users-cards";
 import InstitutionUserForm from "./institution-user-form";
 
 const ROLE_LABELS: Record<string, string> = {
@@ -84,19 +85,75 @@ export default function InstitutionUsersTab({ institution, initialUsers }: Props
 
   const onlyOneUser = users.length === 1;
 
+  function renderDeleteAction(user: InstitutionUser, fullWidth = false) {
+    if (onlyOneUser) {
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className={fullWidth ? "block w-full" : undefined}>
+              <Button
+                size="sm"
+                variant="destructive"
+                disabled
+                className={fullWidth ? "w-full" : undefined}
+              >
+                Delete
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>At least one user is required</TooltipContent>
+        </Tooltip>
+      );
+    }
+
+    return (
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button size="sm" variant="destructive" className={fullWidth ? "w-full" : undefined}>
+            Delete
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete user?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Remove {user.name} from {institution.name}.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeletingUser}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={isDeletingUser}
+              onClick={() => handleDelete(user)}
+            >
+              {isDeletingUser ? "Deleting…" : "Delete user"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
+
   return (
     <TooltipProvider>
       <div className="mt-6 flex flex-col gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-muted-foreground text-sm">
             {users.length} {users.length === 1 ? "user" : "users"}
           </p>
-          <Button size="sm" onClick={openAdd}>
+          <Button size="sm" onClick={openAdd} className="w-full sm:w-auto">
             Add User
           </Button>
         </div>
 
-        <div className="rounded-md border">
+        <InstitutionUsersCards
+          users={users}
+          onEdit={openEdit}
+          renderDeleteAction={(user) => renderDeleteAction(user, true)}
+        />
+
+        <div className="hidden rounded-md border md:block">
           <Table>
             <TableHeader>
               <TableRow>
@@ -117,7 +174,9 @@ export default function InstitutionUsersTab({ institution, initialUsers }: Props
                 users.map((user) => (
                   <TableRow key={user.id}>
                     <TableCell className="font-medium">{user.name}</TableCell>
-                    <TableCell>{user.email}</TableCell>
+                    <TableCell className="max-w-[18rem]">
+                      <span className="break-all whitespace-normal">{user.email}</span>
+                    </TableCell>
                     <TableCell>
                       <Badge variant="outline">{ROLE_LABELS[user.role] ?? user.role}</Badge>
                     </TableCell>
@@ -127,46 +186,7 @@ export default function InstitutionUsersTab({ institution, initialUsers }: Props
                           Edit
                         </Button>
 
-                        {onlyOneUser ? (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span>
-                                <Button size="sm" variant="destructive" disabled>
-                                  Delete
-                                </Button>
-                              </span>
-                            </TooltipTrigger>
-                            <TooltipContent>At least one user is required</TooltipContent>
-                          </Tooltip>
-                        ) : (
-                          <AlertDialog>
-                            <AlertDialogTrigger asChild>
-                              <Button size="sm" variant="destructive">
-                                Delete
-                              </Button>
-                            </AlertDialogTrigger>
-                            <AlertDialogContent size="sm">
-                              <AlertDialogHeader>
-                                <AlertDialogTitle>Delete user?</AlertDialogTitle>
-                                <AlertDialogDescription>
-                                  Remove {user.name} from {institution.name}.
-                                </AlertDialogDescription>
-                              </AlertDialogHeader>
-                              <AlertDialogFooter>
-                                <AlertDialogCancel disabled={isDeletingUser}>
-                                  Cancel
-                                </AlertDialogCancel>
-                                <AlertDialogAction
-                                  variant="destructive"
-                                  disabled={isDeletingUser}
-                                  onClick={() => handleDelete(user)}
-                                >
-                                  {isDeletingUser ? "Deleting…" : "Delete user"}
-                                </AlertDialogAction>
-                              </AlertDialogFooter>
-                            </AlertDialogContent>
-                          </AlertDialog>
-                        )}
+                        {renderDeleteAction(user)}
                       </div>
                     </TableCell>
                   </TableRow>

--- a/src/components/platform/institutions/institutions-cards.tsx
+++ b/src/components/platform/institutions/institutions-cards.tsx
@@ -1,0 +1,83 @@
+import { Link } from "@/components/ui/link";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+import { Institution } from "./institutions.utils";
+
+function getStatusVariant(status: string) {
+  switch (status) {
+    case "ACTIVE":
+      return "default";
+    case "SUSPENDED":
+      return "destructive";
+    default:
+      return "outline";
+  }
+}
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .map((w) => w[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
+
+export default function InstitutionsCards({ institutions }: { institutions: Institution[] }) {
+  if (institutions.length === 0) {
+    return (
+      <Card className="md:hidden">
+        <CardContent className="py-8 text-center">
+          <p className="text-muted-foreground text-sm">No institutions found.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 md:hidden">
+      {institutions.map((institution) => {
+        const platformHref = `/platform/institutions/${institution.id}?tab=profile`;
+        const location = [institution.city, institution.state_province, institution.country]
+          .filter(Boolean)
+          .join(", ");
+
+        return (
+          <Card key={institution.id}>
+            <CardContent className="flex flex-col gap-4 pt-6">
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-start gap-3">
+                  <Avatar className="size-10">
+                    <AvatarImage src={institution.logo_url ?? ""} alt="" />
+                    <AvatarFallback>{getInitials(institution.name)}</AvatarFallback>
+                  </Avatar>
+
+                  <div className="min-w-0">
+                    <p className="text-base font-medium break-words">{institution.name}</p>
+                    <p className="text-muted-foreground text-sm break-words">{location || "—"}</p>
+                  </div>
+                </div>
+
+                <Badge variant={getStatusVariant(institution.status)}>{institution.status}</Badge>
+              </div>
+
+              <div className="space-y-1">
+                <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                  Primary contact
+                </p>
+                <p className="text-sm break-all">{institution.email_address ?? "—"}</p>
+              </div>
+
+              <Button className="w-full" variant="outline" asChild>
+                <Link href={platformHref}>Manage Institution</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/platform/institutions/institutions-client.tsx
+++ b/src/components/platform/institutions/institutions-client.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 
+import InstitutionsCards from "./institutions-cards";
 import InstitutionsHeader from "./institutions-header";
 import InstitutionsToolbar from "./institutions-toolbar";
 import InstitutionsTable from "./institutions-table";
@@ -48,10 +49,11 @@ export default function InstitutionsClient({ institutions }: { institutions: Ins
         onStatusChange={handleStatusChange}
       />
 
+      <InstitutionsCards institutions={paginated} />
       <InstitutionsTable institutions={paginated} />
 
       {filtered.length > 0 && (
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-muted-foreground text-sm">
             Showing {start + 1}–{showingEnd} of {filtered.length}{" "}
             {filtered.length === 1 ? "institution" : "institutions"}

--- a/src/components/platform/institutions/institutions-client.tsx
+++ b/src/components/platform/institutions/institutions-client.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+import InstitutionsHeader from "./institutions-header";
+import InstitutionsToolbar from "./institutions-toolbar";
+import InstitutionsTable from "./institutions-table";
+import { filterInstitutions, Institution } from "./institutions.utils";
+
+const PAGE_SIZE = 15;
+
+export default function InstitutionsClient({ institutions }: { institutions: Institution[] }) {
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const filtered = useMemo(
+    () => filterInstitutions(institutions, search, statusFilter),
+    [institutions, search, statusFilter],
+  );
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const safePage = Math.min(currentPage, totalPages);
+  const start = (safePage - 1) * PAGE_SIZE;
+  const paginated = filtered.slice(start, start + PAGE_SIZE);
+
+  function handleSearchChange(value: string) {
+    setSearch(value);
+    setCurrentPage(1);
+  }
+
+  function handleStatusChange(value: string) {
+    setStatusFilter(value);
+    setCurrentPage(1);
+  }
+
+  const showingEnd = Math.min(start + PAGE_SIZE, filtered.length);
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-10">
+      <InstitutionsHeader />
+
+      <InstitutionsToolbar
+        search={search}
+        onSearchChange={handleSearchChange}
+        statusFilter={statusFilter}
+        onStatusChange={handleStatusChange}
+      />
+
+      <InstitutionsTable institutions={paginated} />
+
+      {filtered.length > 0 && (
+        <div className="flex items-center justify-between">
+          <p className="text-muted-foreground text-sm">
+            Showing {start + 1}–{showingEnd} of {filtered.length}{" "}
+            {filtered.length === 1 ? "institution" : "institutions"}
+          </p>
+
+          {filtered.length > PAGE_SIZE && (
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                disabled={safePage === 1}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                disabled={safePage === totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/platform/institutions/institutions-header.tsx
+++ b/src/components/platform/institutions/institutions-header.tsx
@@ -12,9 +12,6 @@ export default function InstitutionsHeader() {
       </div>
 
       <div className="flex items-center gap-2">
-        <Button variant="outline" disabled>
-          Export
-        </Button>
         <Button asChild>
           <Link href="/platform/institutions/add">Add Institution</Link>
         </Button>

--- a/src/components/platform/institutions/institutions-header.tsx
+++ b/src/components/platform/institutions/institutions-header.tsx
@@ -1,0 +1,24 @@
+import { Button } from "@/components/ui/button";
+import { Link } from "@/components/ui/link";
+
+export default function InstitutionsHeader() {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <h1 className="text-2xl font-bold">Institutions</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Manage tenant institutions across the platform.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button variant="outline" disabled>
+          Export
+        </Button>
+        <Button asChild>
+          <Link href="/platform/institutions/add">Add Institution</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/platform/institutions/institutions-table-row.tsx
+++ b/src/components/platform/institutions/institutions-table-row.tsx
@@ -1,0 +1,77 @@
+import { Link } from "@/components/ui/link";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+import { Institution } from "./institutions.utils";
+
+function getStatusVariant(status: string) {
+  switch (status) {
+    case "ACTIVE":
+      return "default";
+    case "SUSPENDED":
+      return "destructive";
+    default:
+      return "outline";
+  }
+}
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .map((w) => w[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
+
+export default function InstitutionsTableRow({ institution }: { institution: Institution }) {
+  const platformHref = `/platform/institutions/${institution.id}`;
+
+  const location = [institution.city, institution.state_province, institution.country]
+    .filter(Boolean)
+    .join(", ");
+
+  return (
+    <TableRow>
+      {/* Institution */}
+      <TableCell>
+        <div className="flex items-center gap-3">
+          <Avatar className="size-8">
+            <AvatarImage src={institution.logo_url ?? ""} alt="" />
+            <AvatarFallback>{getInitials(institution.name)}</AvatarFallback>
+          </Avatar>
+
+          <div className="flex flex-col">
+            <span className="font-medium">{institution.name}</span>
+            <span className="text-muted-foreground text-xs">{location || "—"}</span>
+          </div>
+        </div>
+      </TableCell>
+
+      {/* Contact */}
+      <TableCell>{institution.email_address ?? "—"}</TableCell>
+
+      {/* Theme */}
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <div className="bg-muted-foreground/40 h-3 w-3 rounded-full" />
+          <span className="text-muted-foreground text-xs">Default</span>
+        </div>
+      </TableCell>
+
+      {/* Status */}
+      <TableCell>
+        <Badge variant={getStatusVariant(institution.status)}>{institution.status}</Badge>
+      </TableCell>
+
+      {/* Actions */}
+      <TableCell>
+        <Button size="sm" variant="outline" asChild>
+          <Link href={platformHref}>Manage</Link>
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/components/platform/institutions/institutions-table-row.tsx
+++ b/src/components/platform/institutions/institutions-table-row.tsx
@@ -27,7 +27,7 @@ function getInitials(name: string) {
 }
 
 export default function InstitutionsTableRow({ institution }: { institution: Institution }) {
-  const platformHref = `/platform/institutions/${institution.id}`;
+  const platformHref = `/platform/institutions/${institution.id}?tab=profile`;
 
   const location = [institution.city, institution.state_province, institution.country]
     .filter(Boolean)
@@ -43,18 +43,22 @@ export default function InstitutionsTableRow({ institution }: { institution: Ins
             <AvatarFallback>{getInitials(institution.name)}</AvatarFallback>
           </Avatar>
 
-          <div className="flex flex-col">
-            <span className="font-medium">{institution.name}</span>
-            <span className="text-muted-foreground text-xs">{location || "—"}</span>
+          <div className="flex min-w-0 flex-col">
+            <span className="font-medium break-words whitespace-normal">{institution.name}</span>
+            <span className="text-muted-foreground text-xs break-words whitespace-normal">
+              {location || "—"}
+            </span>
           </div>
         </div>
       </TableCell>
 
       {/* Contact */}
-      <TableCell>{institution.email_address ?? "—"}</TableCell>
+      <TableCell className="max-w-[16rem]">
+        <span className="break-all whitespace-normal">{institution.email_address ?? "—"}</span>
+      </TableCell>
 
       {/* Theme */}
-      <TableCell>
+      <TableCell className="hidden xl:table-cell">
         <div className="flex items-center gap-2">
           <div className="bg-muted-foreground/40 h-3 w-3 rounded-full" />
           <span className="text-muted-foreground text-xs">Default</span>
@@ -67,7 +71,7 @@ export default function InstitutionsTableRow({ institution }: { institution: Ins
       </TableCell>
 
       {/* Actions */}
-      <TableCell>
+      <TableCell className="w-[1%] whitespace-nowrap">
         <Button size="sm" variant="outline" asChild>
           <Link href={platformHref}>Manage</Link>
         </Button>

--- a/src/components/platform/institutions/institutions-table.tsx
+++ b/src/components/platform/institutions/institutions-table.tsx
@@ -14,14 +14,14 @@ import { Institution } from "./institutions.utils";
 
 export default function InstitutionsTable({ institutions }: { institutions: Institution[] }) {
   return (
-    <Card>
+    <Card className="hidden md:block">
       <CardContent className="space-y-4">
         <Table>
           <TableHeader>
             <TableRow>
               <TableHead>Institution</TableHead>
               <TableHead>Primary Contact</TableHead>
-              <TableHead>Theme</TableHead>
+              <TableHead className="hidden xl:table-cell">Theme</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Actions</TableHead>
             </TableRow>

--- a/src/components/platform/institutions/institutions-table.tsx
+++ b/src/components/platform/institutions/institutions-table.tsx
@@ -1,0 +1,45 @@
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table";
+
+import { Card, CardContent } from "@/components/ui/card";
+
+import InstitutionsTableRow from "./institutions-table-row";
+import { Institution } from "./institutions.utils";
+
+export default function InstitutionsTable({ institutions }: { institutions: Institution[] }) {
+  return (
+    <Card>
+      <CardContent className="space-y-4">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Institution</TableHead>
+              <TableHead>Primary Contact</TableHead>
+              <TableHead>Theme</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+
+          <TableBody>
+            {institutions.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-muted-foreground py-8 text-center text-sm">
+                  No institutions found.
+                </TableCell>
+              </TableRow>
+            ) : (
+              institutions.map((inst) => <InstitutionsTableRow key={inst.id} institution={inst} />)
+            )}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/platform/institutions/institutions-toolbar.tsx
+++ b/src/components/platform/institutions/institutions-toolbar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+interface Props {
+  search: string;
+  onSearchChange: (value: string) => void;
+  statusFilter: string;
+  onStatusChange: (value: string) => void;
+}
+
+export default function InstitutionsToolbar({
+  search,
+  onSearchChange,
+  statusFilter,
+  onStatusChange,
+}: Props) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      {/* Search */}
+      <div className="relative flex-1">
+        <Search
+          aria-hidden="true"
+          className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2"
+        />
+        <Input
+          aria-label="Search institutions"
+          placeholder="Search by name, email, or location..."
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      {/* Status filter tabs */}
+      <ToggleGroup
+        type="single"
+        value={statusFilter}
+        onValueChange={(val) => {
+          if (val) onStatusChange(val);
+        }}
+        aria-label="Filter by status"
+        variant="outline"
+      >
+        <ToggleGroupItem value="all">All</ToggleGroupItem>
+        <ToggleGroupItem value="ACTIVE">Active</ToggleGroupItem>
+        <ToggleGroupItem value="SUSPENDED">Suspended</ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  );
+}

--- a/src/components/platform/institutions/institutions.utils.ts
+++ b/src/components/platform/institutions/institutions.utils.ts
@@ -1,0 +1,41 @@
+export type Institution = {
+  id: number;
+  name: string;
+  slug: string;
+
+  city: string;
+  state_province: string;
+  country: string;
+
+  email_address: string | null;
+  logo_url: string | null;
+
+  created_at: string;
+
+  status: "ACTIVE" | "SUSPENDED";
+};
+
+export function filterInstitutions(
+  institutions: Institution[],
+  search: string,
+  statusFilter: string,
+): Institution[] {
+  const normalizedSearch = search.toLowerCase();
+
+  return institutions
+    .filter((inst) => {
+      const matchesSearch =
+        normalizedSearch === "" ||
+        inst.name.toLowerCase().includes(normalizedSearch) ||
+        inst.slug.toLowerCase().includes(normalizedSearch) ||
+        inst.email_address?.toLowerCase().includes(normalizedSearch) ||
+        inst.city.toLowerCase().includes(normalizedSearch) ||
+        inst.state_province.toLowerCase().includes(normalizedSearch) ||
+        inst.country.toLowerCase().includes(normalizedSearch);
+
+      const matchesStatus = statusFilter === "all" || inst.status === statusFilter;
+
+      return matchesSearch && matchesStatus;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/components/platform/layout/platform-footer.tsx
+++ b/src/components/platform/layout/platform-footer.tsx
@@ -1,0 +1,13 @@
+export default function PlatformFooter() {
+  const year = new Date().getUTCFullYear();
+
+  return (
+    <footer
+      aria-label="Platform footer"
+      className="bg-background flex shrink-0 items-center justify-between border-t px-6 py-3"
+    >
+      <p className="text-muted-foreground text-xs">&copy; {year} Flutr Platform</p>
+      <p className="text-muted-foreground text-xs">All Systems Operational</p>
+    </footer>
+  );
+}

--- a/src/components/platform/layout/platform-footer.tsx
+++ b/src/components/platform/layout/platform-footer.tsx
@@ -4,10 +4,9 @@ export default function PlatformFooter() {
   return (
     <footer
       aria-label="Platform footer"
-      className="bg-background flex shrink-0 items-center justify-between border-t px-6 py-3"
+      className="bg-background flex shrink-0 items-center border-t px-6 py-3"
     >
       <p className="text-muted-foreground text-xs">&copy; {year} Flutr Platform</p>
-      <p className="text-muted-foreground text-xs">All Systems Operational</p>
     </footer>
   );
 }

--- a/src/components/platform/layout/platform-header.tsx
+++ b/src/components/platform/layout/platform-header.tsx
@@ -1,8 +1,21 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
+import { Menu } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+
+import PlatformNavList from "./platform-nav-list";
 
 type AuthUser = {
   id: string;
@@ -37,15 +50,36 @@ export default function PlatformHeader({
   user: AuthUser;
   sessionUser?: SessionUser;
 }) {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
   return (
     <header role="banner" className="bg-background flex h-14 shrink-0 items-center border-b px-6">
       <div className="flex min-w-0 flex-1 items-center justify-between gap-6">
-        <Link
-          href="/platform"
-          className="text-foreground focus-visible:ring-ring rounded-sm text-lg font-bold tracking-tight focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-        >
-          Flutr
-        </Link>
+        <div className="flex items-center gap-3">
+          <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+            <SheetTrigger asChild>
+              <Button variant="ghost" size="icon" className="md:hidden" aria-label="Open menu">
+                <Menu className="size-5" aria-hidden="true" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="w-72 p-0" showCloseButton>
+              <SheetHeader className="border-b px-4 py-3">
+                <SheetTitle>Platform navigation</SheetTitle>
+                <SheetDescription>
+                  Navigate between platform admin sections and account actions.
+                </SheetDescription>
+              </SheetHeader>
+              <PlatformNavList onNavigate={() => setMobileNavOpen(false)} />
+            </SheetContent>
+          </Sheet>
+
+          <Link
+            href="/platform"
+            className="text-foreground focus-visible:ring-ring rounded-sm text-lg font-bold tracking-tight focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          >
+            Flutr
+          </Link>
+        </div>
 
         <div className="text-right">
           <div className="flex items-center gap-3">

--- a/src/components/platform/layout/platform-header.tsx
+++ b/src/components/platform/layout/platform-header.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Link from "next/link";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+type AuthUser = {
+  id: string;
+  role: string;
+  institutionId: number | null;
+};
+
+type SessionUser = {
+  name?: string | null;
+  image?: string | null;
+};
+
+function getInitials(name: string | null | undefined): string {
+  if (!name) return "?";
+  return name
+    .split(" ")
+    .map((part) => part[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
+
+function getRoleLabel(role: string | undefined): string {
+  if (role === "SUPERUSER") return "Global Admin";
+  return role ?? "";
+}
+
+export default function PlatformHeader({
+  user,
+  sessionUser,
+}: {
+  user: AuthUser;
+  sessionUser?: SessionUser;
+}) {
+  return (
+    <header role="banner" className="bg-background flex h-14 shrink-0 items-center border-b px-6">
+      <div className="flex min-w-0 flex-1 items-center justify-between gap-6">
+        <Link
+          href="/platform"
+          className="text-foreground focus-visible:ring-ring rounded-sm text-lg font-bold tracking-tight focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        >
+          Flutr
+        </Link>
+
+        <div className="text-right">
+          <div className="flex items-center gap-3">
+            <div className="min-w-0 text-right">
+              <p className="truncate text-sm leading-none font-medium">
+                {sessionUser?.name ?? `User #${user.id}`}
+              </p>
+              <p className="text-muted-foreground mt-0.5 text-xs">{getRoleLabel(user.role)}</p>
+            </div>
+
+            <Avatar className="size-8">
+              <AvatarImage src={sessionUser?.image ?? ""} alt="" />
+              <AvatarFallback className="text-xs">{getInitials(sessionUser?.name)}</AvatarFallback>
+            </Avatar>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/platform/layout/platform-nav-items.ts
+++ b/src/components/platform/layout/platform-nav-items.ts
@@ -1,0 +1,69 @@
+import {
+  Building2,
+  LayoutDashboard,
+  Leaf,
+  LogOut,
+  LucideIcon,
+  Package,
+  Settings,
+} from "lucide-react";
+
+export interface NavItem {
+  id: string;
+  label: string;
+  href: string;
+  icon: LucideIcon;
+}
+
+export const PLATFORM_ROUTES = {
+  dashboard: "/platform",
+  institutions: "/platform/institutions",
+  species: "/platform/species",
+  suppliers: "/platform/suppliers",
+  settings: "/platform/settings",
+} as const;
+
+/** Primary navigation items rendered in the sidebar. */
+export const PLATFORM_NAV_ITEMS: readonly NavItem[] = [
+  {
+    id: "dashboard",
+    label: "Dashboard",
+    href: PLATFORM_ROUTES.dashboard,
+    icon: LayoutDashboard,
+  },
+  {
+    id: "institutions",
+    label: "Institutions",
+    href: PLATFORM_ROUTES.institutions,
+    icon: Building2,
+  },
+  {
+    id: "species",
+    label: "Butterflies",
+    href: PLATFORM_ROUTES.species,
+    icon: Leaf,
+  },
+  {
+    id: "suppliers",
+    label: "Suppliers",
+    href: PLATFORM_ROUTES.suppliers,
+    icon: Package,
+  },
+];
+
+/** Bottom utility items rendered below the spacer. */
+export const PLATFORM_BOTTOM_ITEMS: readonly NavItem[] = [
+  {
+    id: "settings",
+    label: "Settings",
+    href: PLATFORM_ROUTES.settings,
+    icon: Settings,
+  },
+];
+
+/** Logout action — rendered as a button, not a link. */
+export const LOGOUT_ITEM = {
+  id: "logout",
+  label: "Log out",
+  icon: LogOut,
+} as const;

--- a/src/components/platform/layout/platform-nav-list.tsx
+++ b/src/components/platform/layout/platform-nav-list.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Link from "next/link";
+import { signOut } from "next-auth/react";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+
+import {
+  LOGOUT_ITEM,
+  PLATFORM_BOTTOM_ITEMS,
+  PLATFORM_NAV_ITEMS,
+  NavItem,
+} from "./platform-nav-items";
+
+function isActive(href: string, pathname: string): boolean {
+  if (href === "/platform") {
+    return pathname === "/platform";
+  }
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+function NavListItem({
+  item,
+  pathname,
+  onNavigate,
+}: {
+  item: NavItem;
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  const active = isActive(item.href, pathname);
+  const Icon = item.icon;
+
+  return (
+    <li>
+      <Link
+        href={item.href}
+        aria-current={active ? "page" : undefined}
+        onClick={onNavigate}
+        className={cn(
+          "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
+          active
+            ? "bg-primary text-primary-foreground"
+            : "text-muted-foreground hover:bg-muted hover:text-foreground",
+        )}
+      >
+        <Icon className="size-4 shrink-0" aria-hidden="true" />
+        {item.label}
+      </Link>
+    </li>
+  );
+}
+
+export default function PlatformNavList({ onNavigate }: { onNavigate?: () => void }) {
+  const pathname = usePathname();
+  const LogoutIcon = LOGOUT_ITEM.icon;
+
+  async function handleLogout() {
+    onNavigate?.();
+    await signOut({ redirectTo: "/login" });
+  }
+
+  return (
+    <nav aria-label="Platform navigation" className="flex flex-1 flex-col overflow-y-auto p-3">
+      <ul className="flex-1 space-y-1">
+        {PLATFORM_NAV_ITEMS.map((item) => (
+          <NavListItem key={item.href} item={item} pathname={pathname} onNavigate={onNavigate} />
+        ))}
+      </ul>
+
+      <ul className="space-y-1 pt-3">
+        {PLATFORM_BOTTOM_ITEMS.map((item) => (
+          <NavListItem key={item.href} item={item} pathname={pathname} onNavigate={onNavigate} />
+        ))}
+        <li>
+          <button
+            onClick={handleLogout}
+            aria-label="Log out"
+            className="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          >
+            <LogoutIcon className="size-4 shrink-0" aria-hidden="true" />
+            {LOGOUT_ITEM.label}
+          </button>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/platform/layout/platform-sidebar.tsx
+++ b/src/components/platform/layout/platform-sidebar.tsx
@@ -1,86 +1,11 @@
 "use client";
 
-import { signOut } from "next-auth/react";
-import { usePathname } from "next/navigation";
-
-import { cn } from "@/lib/utils";
-import Link from "next/link";
-
-import {
-  LOGOUT_ITEM,
-  PLATFORM_BOTTOM_ITEMS,
-  PLATFORM_NAV_ITEMS,
-  NavItem,
-} from "./platform-nav-items";
-
-function isActive(href: string, pathname: string): boolean {
-  if (href === "/platform") {
-    return pathname === "/platform";
-  }
-  return pathname === href || pathname.startsWith(`${href}/`);
-}
-
-function SidebarNavItem({ item, pathname }: { item: NavItem; pathname: string }) {
-  const active = isActive(item.href, pathname);
-  const Icon = item.icon;
-
-  return (
-    <li>
-      <Link
-        href={item.href}
-        aria-current={active ? "page" : undefined}
-        className={cn(
-          "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
-          active
-            ? "bg-primary text-primary-foreground"
-            : "text-muted-foreground hover:bg-muted hover:text-foreground",
-        )}
-      >
-        <Icon className="size-4 shrink-0" aria-hidden="true" />
-        {item.label}
-      </Link>
-    </li>
-  );
-}
+import PlatformNavList from "./platform-nav-list";
 
 export default function PlatformSidebar() {
-  const pathname = usePathname();
-
-  async function handleLogout() {
-    await signOut({ redirectTo: "/login" });
-  }
-
-  const LogoutIcon = LOGOUT_ITEM.icon;
-
   return (
-    <aside className="bg-background flex min-h-0 w-56 shrink-0 flex-col border-r">
-      {/* Navigation */}
-      <nav aria-label="Platform navigation" className="flex flex-1 flex-col overflow-y-auto p-3">
-        {/* Primary items */}
-        <ul className="flex-1 space-y-1">
-          {PLATFORM_NAV_ITEMS.map((item) => (
-            <SidebarNavItem key={item.href} item={item} pathname={pathname} />
-          ))}
-        </ul>
-
-        {/* Bottom utility items */}
-        <ul className="space-y-1 pt-3">
-          {PLATFORM_BOTTOM_ITEMS.map((item) => (
-            <SidebarNavItem key={item.href} item={item} pathname={pathname} />
-          ))}
-          <li>
-            <button
-              onClick={handleLogout}
-              aria-label="Log out"
-              className="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-            >
-              <LogoutIcon className="size-4 shrink-0" aria-hidden="true" />
-              {LOGOUT_ITEM.label}
-            </button>
-          </li>
-        </ul>
-      </nav>
+    <aside className="bg-background hidden min-h-0 w-56 shrink-0 border-r md:flex md:flex-col">
+      <PlatformNavList />
     </aside>
   );
 }

--- a/src/components/platform/layout/platform-sidebar.tsx
+++ b/src/components/platform/layout/platform-sidebar.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+
+import {
+  LOGOUT_ITEM,
+  PLATFORM_BOTTOM_ITEMS,
+  PLATFORM_NAV_ITEMS,
+  NavItem,
+} from "./platform-nav-items";
+
+function isActive(href: string, pathname: string): boolean {
+  if (href === "/platform") {
+    return pathname === "/platform";
+  }
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+function SidebarNavItem({ item, pathname }: { item: NavItem; pathname: string }) {
+  const active = isActive(item.href, pathname);
+  const Icon = item.icon;
+
+  return (
+    <li>
+      <Link
+        href={item.href}
+        aria-current={active ? "page" : undefined}
+        className={cn(
+          "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
+          active
+            ? "bg-primary text-primary-foreground"
+            : "text-muted-foreground hover:bg-muted hover:text-foreground",
+        )}
+      >
+        <Icon className="size-4 shrink-0" aria-hidden="true" />
+        {item.label}
+      </Link>
+    </li>
+  );
+}
+
+export default function PlatformSidebar() {
+  const pathname = usePathname();
+
+  async function handleLogout() {
+    await signOut({ redirectTo: "/login" });
+  }
+
+  const LogoutIcon = LOGOUT_ITEM.icon;
+
+  return (
+    <aside className="bg-background flex min-h-0 w-56 shrink-0 flex-col border-r">
+      {/* Navigation */}
+      <nav aria-label="Platform navigation" className="flex flex-1 flex-col overflow-y-auto p-3">
+        {/* Primary items */}
+        <ul className="flex-1 space-y-1">
+          {PLATFORM_NAV_ITEMS.map((item) => (
+            <SidebarNavItem key={item.href} item={item} pathname={pathname} />
+          ))}
+        </ul>
+
+        {/* Bottom utility items */}
+        <ul className="space-y-1 pt-3">
+          {PLATFORM_BOTTOM_ITEMS.map((item) => (
+            <SidebarNavItem key={item.href} item={item} pathname={pathname} />
+          ))}
+          <li>
+            <button
+              onClick={handleLogout}
+              aria-label="Log out"
+              className="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+              <LogoutIcon className="size-4 shrink-0" aria-hidden="true" />
+              {LOGOUT_ITEM.label}
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/src/lib/queries/institution.ts
+++ b/src/lib/queries/institution.ts
@@ -72,10 +72,12 @@ export async function updateTenantInstitution(
  * PLATFORM QUERY
  *
  * Create a new institution (platform-level access).
- *
+ * Accepts an optional transaction for use within onboard operations.
  */
-export async function createInstitution(data: PlatformCreateInstitutionInput) {
-  const [row] = await db
+export async function createInstitution(data: PlatformCreateInstitutionInput, tx?: typeof db) {
+  const database = tx ?? db;
+
+  const [row] = await database
     .insert(institutions)
     .values({
       ...data,

--- a/src/lib/queries/species.ts
+++ b/src/lib/queries/species.ts
@@ -167,3 +167,17 @@ export async function updateSpecies(speciesId: number, input: UpdateSpeciesBody)
 
   return row ?? null;
 }
+
+/**
+ * PLATFORM QUERY
+ *
+ * Delete species by ID. Returns the deleted row, or undefined if not found.
+ */
+export async function deleteSpecies(speciesId: number) {
+  const [row] = await db
+    .delete(butterfly_species)
+    .where(eq(butterfly_species.id, speciesId))
+    .returning();
+
+  return row ?? undefined;
+}

--- a/src/lib/queries/users.ts
+++ b/src/lib/queries/users.ts
@@ -1,5 +1,5 @@
 import bcrypt from "bcrypt";
-import { and, asc, eq, ne } from "drizzle-orm";
+import { and, asc, count, eq, ne } from "drizzle-orm";
 
 import { db } from "@/lib/db";
 import { users } from "@/lib/schema";
@@ -29,6 +29,21 @@ export async function listUsersForTenant(institutionId: number, user: Authentica
     .from(users)
     .where(condition)
     .orderBy(asc(users.name));
+}
+
+/**
+ *
+ * TENANT QUERY
+ *
+ * Count users for Institution.
+ */
+export async function countUsersForTenant(institutionId: number) {
+  const [row] = await db
+    .select({ count: count() })
+    .from(users)
+    .where(eq(users.institution_id, institutionId));
+
+  return row?.count ?? 0;
 }
 
 /**
@@ -104,11 +119,14 @@ export async function emailExistsForTenant(
  * TENANT QUERY
  *
  * Create a user for the given tenant.
+ * Accepts an optional transaction for use within onboard operations.
  */
-export async function createUser(institutionId: number, input: CreateUserBody) {
+export async function createUser(institutionId: number, input: CreateUserBody, tx?: typeof db) {
+  const database = tx ?? db;
+
   const passwordHash = await bcrypt.hash(input.password, 10);
 
-  const [row] = await db
+  const [row] = await database
     .insert(users)
     .values({
       institution_id: institutionId,

--- a/src/lib/queries/users.ts
+++ b/src/lib/queries/users.ts
@@ -43,7 +43,8 @@ export async function countUsersForTenant(institutionId: number) {
     .from(users)
     .where(eq(users.institution_id, institutionId));
 
-  return row?.count ?? 0;
+  const normalizedCount = Number(row?.count ?? 0);
+  return Number.isNaN(normalizedCount) ? 0 : normalizedCount;
 }
 
 /**

--- a/src/lib/services/platform-institutions.ts
+++ b/src/lib/services/platform-institutions.ts
@@ -37,7 +37,11 @@ export async function getPlatformInstitutionById(id: number) {
 export async function updatePlatformInstitution(id: number, data: PlatformUpdateInstitutionInput) {
   const user = requireUser(await auth());
   if (!canCrossTenant(user)) throw new Error("FORBIDDEN");
-  await ensureTenantExists(id);
+  try {
+    await ensureTenantExists(id);
+  } catch {
+    throw new Error("NOT_FOUND");
+  }
   if (typeof data.slug === "string") {
     const slugExists = await institutionSlugExists(data.slug, id);
     if (slugExists) throw new Error("CONFLICT");
@@ -50,6 +54,10 @@ export async function updatePlatformInstitution(id: number, data: PlatformUpdate
 export async function deletePlatformInstitution(id: number) {
   const user = requireUser(await auth());
   if (!canCrossTenant(user)) throw new Error("FORBIDDEN");
-  await ensureTenantExists(id);
+  try {
+    await ensureTenantExists(id);
+  } catch {
+    throw new Error("NOT_FOUND");
+  }
   await deleteInstitution(id);
 }

--- a/src/lib/services/platform-institutions.ts
+++ b/src/lib/services/platform-institutions.ts
@@ -1,6 +1,6 @@
 import { auth } from "@/auth";
 import { requireUser, canCrossTenant } from "@/lib/authz";
-import { ensureTenantExists } from "@/lib/tenant";
+import { ensureTenantExists, TENANT_ERRORS } from "@/lib/tenant";
 import {
   getAllInstitutions,
   institutionSlugExists,
@@ -42,8 +42,12 @@ export async function updatePlatformInstitution(id: number, data: PlatformUpdate
   if (!canCrossTenant(user)) throw new Error("FORBIDDEN");
   try {
     await ensureTenantExists(id);
-  } catch {
-    throw new Error("NOT_FOUND");
+  } catch (error) {
+    if (error instanceof Error && error.message === TENANT_ERRORS.INSTITUTION_NOT_FOUND) {
+      throw new Error("NOT_FOUND");
+    }
+
+    throw error;
   }
   if (typeof data.slug === "string") {
     const slugExists = await institutionSlugExists(data.slug, id);
@@ -59,8 +63,12 @@ export async function deletePlatformInstitution(id: number) {
   if (!canCrossTenant(user)) throw new Error("FORBIDDEN");
   try {
     await ensureTenantExists(id);
-  } catch {
-    throw new Error("NOT_FOUND");
+  } catch (error) {
+    if (error instanceof Error && error.message === TENANT_ERRORS.INSTITUTION_NOT_FOUND) {
+      throw new Error("NOT_FOUND");
+    }
+
+    throw error;
   }
   await deleteInstitution(id);
 }

--- a/src/lib/services/platform-institutions.ts
+++ b/src/lib/services/platform-institutions.ts
@@ -25,7 +25,10 @@ export async function createPlatformInstitution(data: PlatformCreateInstitutionI
   if (!canCrossTenant(user)) throw new Error("FORBIDDEN");
   const exists = await institutionSlugExists(data.slug);
   if (exists) throw new Error("CONFLICT");
-  return createInstitution(data);
+  return createInstitution({
+    ...data,
+    stats_active: false,
+  });
 }
 
 export async function getPlatformInstitutionById(id: number) {

--- a/src/lib/services/platform-species.ts
+++ b/src/lib/services/platform-species.ts
@@ -1,0 +1,67 @@
+import { auth } from "@/auth";
+import { requireUser, canManageGlobalButterflies } from "@/lib/authz";
+import {
+  listSpeciesGlobal,
+  getSpeciesById,
+  createSpecies,
+  updateSpecies,
+  deleteSpecies,
+} from "@/lib/queries/species";
+import type { CreateSpeciesBody, UpdateSpeciesBody } from "@/lib/validation/species";
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code: unknown }).code === "23505"
+  );
+}
+
+export async function getPlatformSpecies() {
+  const user = requireUser(await auth());
+  if (!canManageGlobalButterflies(user)) throw new Error("FORBIDDEN");
+  return listSpeciesGlobal();
+}
+
+export async function getPlatformSpeciesById(id: number) {
+  const user = requireUser(await auth());
+  if (!canManageGlobalButterflies(user)) throw new Error("FORBIDDEN");
+  const species = await getSpeciesById(id);
+  if (!species) throw new Error("NOT_FOUND");
+  return species;
+}
+
+export async function createPlatformSpecies(data: CreateSpeciesBody) {
+  const user = requireUser(await auth());
+  if (!canManageGlobalButterflies(user)) throw new Error("FORBIDDEN");
+  try {
+    return await createSpecies(data);
+  } catch (error) {
+    if (isUniqueViolation(error)) throw new Error("CONFLICT");
+    throw error;
+  }
+}
+
+export async function updatePlatformSpecies(id: number, data: UpdateSpeciesBody) {
+  const user = requireUser(await auth());
+  if (!canManageGlobalButterflies(user)) throw new Error("FORBIDDEN");
+  const existing = await getSpeciesById(id);
+  if (!existing) throw new Error("NOT_FOUND");
+  try {
+    const updated = await updateSpecies(id, data);
+    if (!updated) throw new Error("NOT_FOUND");
+    return updated;
+  } catch (error) {
+    if (isUniqueViolation(error)) throw new Error("CONFLICT");
+    throw error;
+  }
+}
+
+export async function deletePlatformSpecies(id: number) {
+  const user = requireUser(await auth());
+  if (!canManageGlobalButterflies(user)) throw new Error("FORBIDDEN");
+  const existing = await getSpeciesById(id);
+  if (!existing) throw new Error("NOT_FOUND");
+  await deleteSpecies(id);
+}

--- a/src/lib/services/platform-species.ts
+++ b/src/lib/services/platform-species.ts
@@ -10,12 +10,20 @@ import {
 import type { CreateSpeciesBody, UpdateSpeciesBody } from "@/lib/validation/species";
 
 function isUniqueViolation(error: unknown): boolean {
-  return (
-    error !== null &&
-    typeof error === "object" &&
-    "code" in error &&
-    (error as { code: unknown }).code === "23505"
-  );
+  if (error === null || typeof error !== "object") {
+    return false;
+  }
+
+  const code = "code" in error ? (error as { code?: unknown }).code : undefined;
+  const causeCode =
+    "cause" in error &&
+    error.cause !== null &&
+    typeof error.cause === "object" &&
+    "code" in error.cause
+      ? (error.cause as { code?: unknown }).code
+      : undefined;
+
+  return code === "23505" || causeCode === "23505";
 }
 
 export async function getPlatformSpecies() {

--- a/src/lib/services/platform-suppliers.ts
+++ b/src/lib/services/platform-suppliers.ts
@@ -23,7 +23,12 @@ export async function getPlatformSuppliers(institutionId?: number) {
 export async function createPlatformSupplier(data: CreateSupplierBody) {
   const user = requireUser(await auth());
   if (!canCrossTenant(user)) throw new Error("FORBIDDEN");
-  const tenantId = resolveTenantId(user, data.institutionId);
+  let tenantId: number;
+  try {
+    tenantId = resolveTenantId(user, data.institutionId);
+  } catch {
+    throw new Error("FORBIDDEN");
+  }
   await ensureTenantExists(tenantId);
   const codeExists = await supplierCodeExistsForTenant(tenantId, data.code);
   if (codeExists) throw new Error("CONFLICT");

--- a/src/lib/services/tenant-institution.ts
+++ b/src/lib/services/tenant-institution.ts
@@ -1,6 +1,6 @@
 import { auth } from "@/auth";
 import { requireUser, canManageInstitutionProfile } from "@/lib/authz";
-import { ensureTenantExists, resolveTenantBySlug } from "@/lib/tenant";
+import { resolveTenantBySlug, TENANT_ERRORS } from "@/lib/tenant";
 import { getTenantInstitution, updateTenantInstitution } from "@/lib/queries/institution";
 
 export async function getTenantInstitutionService(slug: string) {
@@ -8,17 +8,15 @@ export async function getTenantInstitutionService(slug: string) {
   const user = requireUser(session);
 
   if (!canManageInstitutionProfile(user)) {
-    throw new Error("FORBIDDEN");
+    throw new Error(TENANT_ERRORS.FORBIDDEN_CROSS_TENANT_ACCESS);
   }
 
   const tenantId = await resolveTenantBySlug(user, slug);
 
-  await ensureTenantExists(tenantId);
-
   const institution = await getTenantInstitution(tenantId);
 
   if (!institution) {
-    throw new Error("NOT_FOUND");
+    throw new Error(TENANT_ERRORS.INSTITUTION_NOT_FOUND);
   }
 
   return institution;
@@ -29,17 +27,15 @@ export async function updateTenantInstitutionService(slug: string, data: Record<
   const user = requireUser(session);
 
   if (!canManageInstitutionProfile(user)) {
-    throw new Error("FORBIDDEN");
+    throw new Error(TENANT_ERRORS.FORBIDDEN_CROSS_TENANT_ACCESS);
   }
 
   const tenantId = await resolveTenantBySlug(user, slug);
 
-  await ensureTenantExists(tenantId);
-
   const updated = await updateTenantInstitution(tenantId, data);
 
   if (!updated) {
-    throw new Error("NOT_FOUND");
+    throw new Error(TENANT_ERRORS.INSTITUTION_NOT_FOUND);
   }
 
   return updated;

--- a/src/lib/services/tenant-users.ts
+++ b/src/lib/services/tenant-users.ts
@@ -15,7 +15,9 @@ import {
   updateUserForTenant,
   deleteUserForTenant,
   getUserByIdForTenant,
+  countUsersForTenant,
 } from "@/lib/queries/users";
+import { updateInstitutionById } from "../queries/institution";
 
 // ---------- TYPES ----------
 type TenantContext = {
@@ -90,7 +92,19 @@ export async function createTenantUser(data: CreateUserInput) {
   }
 
   const { slug, ...userData } = data;
-  return createUser(tenantId, userData);
+  // return createUser(tenantId, userData);
+  const newUser = await createUser(tenantId, userData);
+
+  // activate institution if this is the first user
+  const userCount = await countUsersForTenant(tenantId);
+
+  if (userCount === 1) {
+    await updateInstitutionById(tenantId, {
+      stats_active: true,
+    });
+  }
+
+  return newUser;
 }
 
 // ---------- UPDATE ----------

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -115,11 +115,11 @@ export async function resolveTenantBySlug(user: AuthenticatedUser, slug: string)
     .limit(1);
 
   if (!institution) {
-    throw new Error("NOT_FOUND");
+    throw new Error(TENANT_ERRORS.INSTITUTION_NOT_FOUND);
   }
 
   if (user.role !== "SUPERUSER" && user.institutionId !== institution.id) {
-    throw new Error("FORBIDDEN");
+    throw new Error(TENANT_ERRORS.FORBIDDEN_CROSS_TENANT_ACCESS);
   }
 
   return institution.id;

--- a/src/lib/validation/institution.ts
+++ b/src/lib/validation/institution.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { sanitizeText, sanitizedNonEmpty } from "@/lib/validation/sanitize";
+import { institutionSlugSchema } from "@/lib/validation/slug";
 
 /**
  * This file defines Zod schemas for validating institution-related data across the platform.
@@ -58,7 +59,7 @@ export const platformCreateInstitutionSchema = z
     ...baseInstitutionFields,
 
     // SUPERUSER defines slug on creation
-    slug: sanitizedNonEmpty(100),
+    slug: institutionSlugSchema,
 
     // Optional fields not in baseInstitutionFields
     time_zone: z.string().max(100).optional(),

--- a/src/lib/validation/institution.ts
+++ b/src/lib/validation/institution.ts
@@ -60,6 +60,11 @@ export const platformCreateInstitutionSchema = z
     // SUPERUSER defines slug on creation
     slug: sanitizedNonEmpty(100),
 
+    // Optional fields not in baseInstitutionFields
+    time_zone: z.string().max(100).optional(),
+    theme_colors: z.array(z.string()).optional(),
+    social_links: z.record(z.string(), z.string()).optional(),
+
     // Platform flags
     iabes_member: z.boolean().optional(),
     stats_active: z.boolean().optional(),

--- a/src/lib/validation/public.ts
+++ b/src/lib/validation/public.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 
 import { sanitizedNonEmpty } from "@/lib/validation/sanitize";
+import { institutionSlugSchema } from "@/lib/validation/slug";
 
-const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const scientificNameRegex = /^[A-Za-z0-9_.-]+$/;
 
 export const institutionSlugParamsSchema = z
   .object({
-    slug: z.string().min(1).regex(slugRegex),
+    slug: institutionSlugSchema,
   })
   .strict();
 

--- a/src/lib/validation/shipments.ts
+++ b/src/lib/validation/shipments.ts
@@ -127,9 +127,9 @@ export const updateShipmentBodySchema = z
     supplier_code: z.string().min(1).max(30).optional(),
     shipment_date: z.coerce.date().optional(),
     arrival_date: z.coerce.date().optional(),
-    update_items: z.array(shipmentItemUpdateSchema).optional(),
-    add_items: z.array(shipmentItemAddSchema).optional(),
-    delete_items: z.array(z.number().int().positive()).optional(),
+    update_items: z.array(shipmentItemUpdateSchema).min(1).optional(),
+    add_items: z.array(shipmentItemAddSchema).min(1).optional(),
+    delete_items: z.array(z.number().int().positive()).min(1).optional(),
   })
   .strict()
   .superRefine((data, ctx) => {
@@ -169,8 +169,10 @@ export type UpdateShipmentBody = z.infer<typeof updateShipmentBodySchema>;
  * Used primarily for historical import testing.
  */
 
-export const deleteShipmentTenantSchema = z.object({
-  // Tenant context is supplied via x-tenant-slug header.
-});
+export const deleteShipmentTenantSchema = z
+  .object({
+    // Tenant context is supplied via x-tenant-slug header.
+  })
+  .strict();
 
 export type DeleteShipmentTenantBody = z.infer<typeof deleteShipmentTenantSchema>;

--- a/src/lib/validation/slug.ts
+++ b/src/lib/validation/slug.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+import { sanitizeText } from "@/lib/validation/sanitize";
+
+export const institutionSlugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const institutionSlugSchema = z
+  .string()
+  .max(100)
+  .transform(sanitizeText)
+  .pipe(
+    z
+      .string()
+      .min(1, "Slug is required")
+      .regex(
+        institutionSlugRegex,
+        "Slug may contain lowercase letters (a-z), numbers (0-9), separated by single hyphens (-).",
+      ),
+  );


### PR DESCRIPTION
## Summary

Adds the first pass of the platform SUPERUSER experience for institution onboarding and management. This introduces the platform admin shell, dashboard navigation, institution list/add/detail flows, and the core institution user management experience.

This PR remains a draft because the historical shipment data import/export work is still pending.

## Changes

- add the platform admin dashboard shell with full-width header/footer and sidebar navigation
- add the platform dashboard landing page and institutions list page
- add the institution onboarding page and institution detail experience
- add profile, theme, users, and data tabs for institution management
- add dialog-based user add/edit flows and confirmation-based delete flows
- add institution deletion from the detail view
- fix stale institution detail state after profile updates so slug-dependent UI updates immediately
- stabilize the platform layout so the main content area scrolls while the surrounding shell stays pinned

## Review Fixes

- remove the dead-end export action from the institutions index
- improve duplicate-email handling so institution user email conflicts surface as inline field errors
- add shared slug validation across the platform forms and validation layer
- keep institution detail tabs in the URL and normalize entry links to the profile tab
- add responsive platform navigation via a mobile sheet and simplify the footer copy
- improve responsive behavior for the institutions index with mobile cards and a trimmed mid-width table
- improve institution detail responsiveness with stacked header actions, mobile user cards, and cleaner small-screen tabs

## Test Plan

- [x] `pnpm lint`
- [x] `pnpm test -- --runInBand src/__test__/api/platform/institutions.route.test.ts src/__test__/api/tenant/users.route.test.ts src/__test__/middleware.test.ts`
- [x] Manual browser QA for the platform onboarding flow and responsive states

