### PR TITLE
feat: tenant dashboard and organization management page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,14 +50,13 @@ src/
 │   ├── platform/           # Superuser platform admin components
 │   │   ├── layout/         # PlatformSidebar, PlatformHeader, PlatformFooter, nav items
 │   │   │   └── tenant/     # TenantHeader, TenantSidebar, TenantFooter, TenantNavList, nav items
-│   │   ├── dashboard/      # PlatformNavCard
 │   │   ├── institutions/   # InstitutionsTable and related
 │   │   ├── species/        # SpeciesTable, SpeciesGalleryCard, toolbar, row, utils
 │   │   └── suppliers/      # SuppliersTable, toolbar, row, utils
 │   ├── nav/                # Public navigation components (top-nav, mobile-nav, footer)
 │   ├── providers/          # Context providers (session, institution data, theme)
 │   ├── public/             # Public-facing components (gallery, home, species detail)
-│   ├── shared/             # Shared components used across public/admin (theme toggle, back button)
+│   ├── shared/             # Shared components used across public/admin (theme toggle, back button, nav card)
 │   └── ui/                 # 55 Shadcn/UI primitives
 ├── hooks/                  # Custom React hooks
 │   ├── use-institution.ts  # Institution slug/basePath from URL params

--- a/src/__test__/api/tenant/institution.route.test.ts
+++ b/src/__test__/api/tenant/institution.route.test.ts
@@ -1,17 +1,17 @@
 import { NextRequest } from "next/server";
 
 jest.mock("@/lib/services/tenant-institution", () => ({
-  getTenantInstitutionService: jest.fn(),
+  viewTenantInstitutionService: jest.fn(),
   updateTenantInstitutionService: jest.fn(),
 }));
 
 import {
-  getTenantInstitutionService,
+  viewTenantInstitutionService,
   updateTenantInstitutionService,
 } from "@/lib/services/tenant-institution";
 import { GET, PATCH } from "@/app/api/tenant/institution/route";
 
-const mockGetTenantInstitutionService = getTenantInstitutionService as jest.Mock;
+const mockViewTenantInstitutionService = viewTenantInstitutionService as jest.Mock;
 const mockUpdateTenantInstitutionService = updateTenantInstitutionService as jest.Mock;
 
 const SLUG = "butterfly-house";
@@ -60,7 +60,7 @@ describe("Tenant Institution API", () => {
     });
 
     it("returns 401 for unauthenticated requests", async () => {
-      mockGetTenantInstitutionService.mockRejectedValueOnce(new Error("UNAUTHORIZED"));
+      mockViewTenantInstitutionService.mockRejectedValueOnce(new Error("UNAUTHORIZED"));
 
       const response = (await GET(makeGetRequest(SLUG)))!;
       expect(response.status).toBe(401);
@@ -68,7 +68,7 @@ describe("Tenant Institution API", () => {
     });
 
     it("returns 403 for insufficient permission", async () => {
-      mockGetTenantInstitutionService.mockRejectedValueOnce(new Error("FORBIDDEN"));
+      mockViewTenantInstitutionService.mockRejectedValueOnce(new Error("FORBIDDEN"));
 
       const response = (await GET(makeGetRequest(SLUG)))!;
       expect(response.status).toBe(403);
@@ -76,7 +76,7 @@ describe("Tenant Institution API", () => {
     });
 
     it("returns 404 when institution not found", async () => {
-      mockGetTenantInstitutionService.mockRejectedValueOnce(new Error("NOT_FOUND"));
+      mockViewTenantInstitutionService.mockRejectedValueOnce(new Error("NOT_FOUND"));
 
       const response = (await GET(makeGetRequest(SLUG)))!;
       expect(response.status).toBe(404);
@@ -84,7 +84,7 @@ describe("Tenant Institution API", () => {
     });
 
     it("returns 200 with institution and calls service with slug", async () => {
-      mockGetTenantInstitutionService.mockResolvedValueOnce(sampleInstitution);
+      mockViewTenantInstitutionService.mockResolvedValueOnce(sampleInstitution);
 
       const response = (await GET(makeGetRequest(SLUG)))!;
       expect(response.status).toBe(200);
@@ -92,7 +92,7 @@ describe("Tenant Institution API", () => {
       const body = await response.json();
       expect(body.institution.id).toBe(1);
       expect(body.institution.name).toBe("Butterfly House");
-      expect(mockGetTenantInstitutionService).toHaveBeenCalledWith(SLUG);
+      expect(mockViewTenantInstitutionService).toHaveBeenCalledWith(SLUG);
     });
   });
 

--- a/src/app/(platform)/admin/dashboard/page.tsx
+++ b/src/app/(platform)/admin/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { Building2, Leaf, Package } from "lucide-react";
 
-import PlatformNavCard from "@/components/platform/dashboard/platform-nav-card";
+import NavCard from "@/components/shared/nav-card";
 import { PLATFORM_ROUTES } from "@/components/platform/layout/platform-nav-items";
 
 export default function PlatformPage() {
@@ -14,21 +14,21 @@ export default function PlatformPage() {
       </div>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <PlatformNavCard
+        <NavCard
           href={PLATFORM_ROUTES.institutions}
           title="Institutions"
           description="Manage butterfly houses and onboarding"
           icon={Building2}
         />
 
-        <PlatformNavCard
+        <NavCard
           href={PLATFORM_ROUTES.species}
           title="Butterflies"
           description="Manage the global butterfly species catalog"
           icon={Leaf}
         />
 
-        <PlatformNavCard
+        <NavCard
           href={PLATFORM_ROUTES.suppliers}
           title="Suppliers"
           description="Manage the global supplier list"

--- a/src/app/[institution]/(tenant)/dashboard/page.tsx
+++ b/src/app/[institution]/(tenant)/dashboard/page.tsx
@@ -1,3 +1,46 @@
-export default function DashboardPage() {
-  return <h1>Dashboard</h1>;
+import { Building2, Package, Rocket } from "lucide-react";
+
+import NavCard from "@/components/shared/nav-card";
+import { ROUTES } from "@/lib/routes";
+
+export default async function DashboardPage({
+  params,
+}: {
+  params: Promise<{ institution: string }>;
+}) {
+  const { institution } = await params;
+
+  return (
+    <div className="mx-auto max-w-6xl px-6 py-10">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold">Dashboard</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Manage your institution&apos;s shipments, releases, and organization settings.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <NavCard
+          href={ROUTES.tenant.organization(institution)}
+          title="Organization"
+          description="Manage institution details and settings"
+          icon={Building2}
+        />
+
+        <NavCard
+          href={ROUTES.tenant.shipments(institution)}
+          title="Shipments"
+          description="Track and manage butterfly shipments"
+          icon={Package}
+        />
+
+        <NavCard
+          href={ROUTES.tenant.releases(institution)}
+          title="Releases"
+          description="Record and view butterfly release events"
+          icon={Rocket}
+        />
+      </div>
+    </div>
+  );
 }

--- a/src/app/[institution]/(tenant)/organization/page.tsx
+++ b/src/app/[institution]/(tenant)/organization/page.tsx
@@ -1,3 +1,93 @@
-export default function OrganizationPage() {
-  return <h1>Organization</h1>;
+import { redirect } from "next/navigation";
+
+import { auth } from "@/auth";
+import { AUTH_ERRORS, canManageInstitutionProfile, requireUser } from "@/lib/authz";
+import { listUsersForTenant } from "@/lib/queries/users";
+import { viewTenantInstitutionService } from "@/lib/services/tenant-institution";
+import InstitutionDetailShell from "@/components/platform/institutions/detail/institution-detail-shell";
+import type {
+  InstitutionDetail,
+  InstitutionUser,
+} from "@/components/platform/institutions/detail/institution-detail-shell";
+
+interface Props {
+  params: Promise<{ institution: string }>;
+  searchParams: Promise<{ tab?: string }>;
+}
+
+function resolveInitialTab(tab: string | undefined, readOnly: boolean) {
+  switch (tab) {
+    case "theme":
+      return tab;
+    case "users":
+    case "data":
+      return readOnly ? "profile" : tab;
+    default:
+      return "profile";
+  }
+}
+
+export default async function OrganizationPage({ params, searchParams }: Props) {
+  const { institution: slug } = await params;
+  const { tab } = await searchParams;
+
+  const session = await auth();
+  const user = (() => {
+    try {
+      return requireUser(session);
+    } catch (e) {
+      if (e instanceof Error && e.message === AUTH_ERRORS.UNAUTHORIZED) {
+        redirect("/login");
+      }
+      throw e;
+    }
+  })();
+
+  const row = await viewTenantInstitutionService(slug, user);
+
+  const isAdmin = canManageInstitutionProfile(user);
+
+  const rawUsers = isAdmin
+    ? await listUsersForTenant(row.id, user, { excludeSuperusers: true })
+    : [];
+
+  const institution: InstitutionDetail = {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description ?? null,
+    street_address: row.street_address,
+    extended_address: row.extended_address ?? null,
+    city: row.city,
+    state_province: row.state_province,
+    postal_code: row.postal_code,
+    country: row.country,
+    time_zone: row.time_zone ?? null,
+    email_address: row.email_address ?? null,
+    phone_number: row.phone_number ?? null,
+    website_url: row.website_url ?? null,
+    logo_url: row.logo_url ?? null,
+    facility_image_url: row.facility_image_url ?? null,
+    social_links: (row.social_links as Record<string, string> | null) ?? null,
+    theme_colors: row.theme_colors ?? null,
+    stats_active: row.stats_active,
+    iabes_member: row.iabes_member,
+  };
+
+  const users: InstitutionUser[] = rawUsers.map((u) => ({
+    id: u.id,
+    name: u.name,
+    email: u.email,
+    role: u.role,
+  }));
+
+  return (
+    <InstitutionDetailShell
+      institution={institution}
+      users={users}
+      initialTab={resolveInitialTab(tab, !isAdmin)}
+      mode="tenant"
+      readOnly={!isAdmin}
+    />
+  );
 }

--- a/src/app/api/tenant/institution/route.ts
+++ b/src/app/api/tenant/institution/route.ts
@@ -14,7 +14,7 @@ import { tenantUpdateInstitutionSchema } from "@/lib/validation/institution";
 import { handleTenantError } from "@/lib/tenant";
 
 import {
-  getTenantInstitutionService,
+  viewTenantInstitutionService,
   updateTenantInstitutionService,
 } from "@/lib/services/tenant-institution";
 
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
       return invalidRequest("Missing tenant slug");
     }
 
-    const institution = await getTenantInstitutionService(slug);
+    const institution = await viewTenantInstitutionService(slug);
 
     return ok({ institution });
   } catch (error) {

--- a/src/components/platform/institutions/detail/institution-detail-shell.tsx
+++ b/src/components/platform/institutions/detail/institution-detail-shell.tsx
@@ -134,7 +134,7 @@ export default function InstitutionDetailShell({
                 </Link>
               </Button>
             )}
-            <h1 className="text-2xl font-bold break-words whitespace-normal">
+            <h1 className="text-2xl font-bold wrap-break-word whitespace-normal">
               {currentInstitution.name}
             </h1>
           </div>

--- a/src/components/platform/institutions/detail/institution-detail-shell.tsx
+++ b/src/components/platform/institutions/detail/institution-detail-shell.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import { ROUTES } from "@/lib/routes";
 
 import {
@@ -55,15 +56,28 @@ export interface InstitutionUser {
   role: string;
 }
 
+export type InstitutionDetailMode = "platform" | "tenant";
+
 type InstitutionDetailTab = "profile" | "theme" | "users" | "data";
 
 interface Props {
   institution: InstitutionDetail;
   users: InstitutionUser[];
   initialTab: InstitutionDetailTab;
+  /** @default "platform" */
+  mode?: InstitutionDetailMode;
+  /** When true, all editing controls are hidden (read-only view for EMPLOYEE). */
+  readOnly?: boolean;
 }
 
-export default function InstitutionDetailShell({ institution, users, initialTab }: Props) {
+export default function InstitutionDetailShell({
+  institution,
+  users,
+  initialTab,
+  mode = "platform",
+  readOnly = false,
+}: Props) {
+  const isTenant = mode === "tenant";
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -112,78 +126,98 @@ export default function InstitutionDetailShell({ institution, users, initialTab 
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0 flex-1">
           <div className="flex flex-col gap-1">
-            <Button variant="ghost" size="sm" className="-ml-2 w-fit" asChild>
-              <Link href={ROUTES.admin.institutions}>
-                <ArrowLeft className="mr-1 size-4" aria-hidden="true" />
-                Institutions
-              </Link>
-            </Button>
+            {!isTenant && (
+              <Button variant="ghost" size="sm" className="-ml-2 w-fit" asChild>
+                <Link href={ROUTES.admin.institutions}>
+                  <ArrowLeft className="mr-1 size-4" aria-hidden="true" />
+                  Institutions
+                </Link>
+              </Button>
+            )}
             <h1 className="text-2xl font-bold break-words whitespace-normal">
               {currentInstitution.name}
             </h1>
           </div>
         </div>
-        <div className="flex w-full flex-col gap-2 sm:flex-row lg:w-auto">
-          <Button variant="outline" asChild className="w-full sm:w-auto">
-            <Link href={ROUTES.tenant.dashboard(currentInstitution.slug)}>View as Admin</Link>
-          </Button>
+        {!isTenant && (
+          <div className="flex w-full flex-col gap-2 sm:flex-row lg:w-auto">
+            <Button variant="outline" asChild className="w-full sm:w-auto">
+              <Link href={ROUTES.tenant.dashboard(currentInstitution.slug)}>View as Admin</Link>
+            </Button>
 
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button variant="destructive" className="w-full sm:w-auto">
-                Delete Institution
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Delete institution?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will permanently remove {currentInstitution.name} and all tenant-scoped data
-                  tied to it. This action cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel disabled={isDeletingInstitution}>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  variant="destructive"
-                  disabled={isDeletingInstitution}
-                  onClick={handleDeleteInstitution}
-                >
-                  {isDeletingInstitution ? "Deleting…" : "Delete institution"}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        </div>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive" className="w-full sm:w-auto">
+                  Delete Institution
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete institution?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will permanently remove {currentInstitution.name} and all tenant-scoped
+                    data tied to it. This action cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={isDeletingInstitution}>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    variant="destructive"
+                    disabled={isDeletingInstitution}
+                    onClick={handleDeleteInstitution}
+                  >
+                    {isDeletingInstitution ? "Deleting…" : "Delete institution"}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        )}
       </div>
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={handleTabChange}>
         <TabsList
           aria-label="Institution settings"
-          className="grid w-full grid-cols-4 sm:inline-flex sm:w-fit"
+          className={cn(
+            "grid w-full sm:inline-flex sm:w-fit",
+            isTenant && readOnly ? "grid-cols-2" : "grid-cols-4",
+          )}
         >
           <TabsTrigger value="profile">Profile</TabsTrigger>
           <TabsTrigger value="theme">Theme</TabsTrigger>
-          <TabsTrigger value="users">Users</TabsTrigger>
-          <TabsTrigger value="data">Data</TabsTrigger>
+          {!(isTenant && readOnly) && <TabsTrigger value="users">Users</TabsTrigger>}
+          {!(isTenant && readOnly) && <TabsTrigger value="data">Data</TabsTrigger>}
         </TabsList>
 
         <TabsContent value="profile">
-          <InstitutionProfileTab institution={currentInstitution} onSaved={setCurrentInstitution} />
+          <InstitutionProfileTab
+            institution={currentInstitution}
+            onSaved={setCurrentInstitution}
+            mode={mode}
+            readOnly={readOnly}
+          />
         </TabsContent>
 
         <TabsContent value="theme">
-          <InstitutionThemeTab institution={currentInstitution} />
+          <InstitutionThemeTab institution={currentInstitution} mode={mode} readOnly={readOnly} />
         </TabsContent>
 
-        <TabsContent value="users">
-          <InstitutionUsersTab institution={currentInstitution} initialUsers={users} />
-        </TabsContent>
+        {!(isTenant && readOnly) && (
+          <TabsContent value="users">
+            <InstitutionUsersTab
+              institution={currentInstitution}
+              initialUsers={users}
+              readOnly={readOnly}
+            />
+          </TabsContent>
+        )}
 
-        <TabsContent value="data">
-          <InstitutionDataTab />
-        </TabsContent>
+        {!(isTenant && readOnly) && (
+          <TabsContent value="data">
+            <InstitutionDataTab />
+          </TabsContent>
+        )}
       </Tabs>
     </div>
   );

--- a/src/components/platform/institutions/detail/institution-profile-tab.tsx
+++ b/src/components/platform/institutions/detail/institution-profile-tab.tsx
@@ -23,7 +23,7 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { institutionSlugSchema } from "@/lib/validation/slug";
 
-import type { InstitutionDetail } from "./institution-detail-shell";
+import type { InstitutionDetail, InstitutionDetailMode } from "./institution-detail-shell";
 
 const profileFormSchema = z.object({
   // Identity
@@ -62,6 +62,9 @@ type ProfileFormValues = z.infer<typeof profileFormSchema>;
 interface Props {
   institution: InstitutionDetail;
   onSaved: (institution: InstitutionDetail) => void;
+  /** @default "platform" */
+  mode?: InstitutionDetailMode;
+  readOnly?: boolean;
 }
 
 type ProfileUpdateResponse = {
@@ -71,7 +74,13 @@ type ProfileUpdateResponse = {
   };
 };
 
-export default function InstitutionProfileTab({ institution, onSaved }: Props) {
+export default function InstitutionProfileTab({
+  institution,
+  onSaved,
+  mode = "platform",
+  readOnly = false,
+}: Props) {
+  const isTenant = mode === "tenant";
   const form = useForm<ProfileFormValues>({
     resolver: zodResolver(profileFormSchema),
     mode: "onChange",
@@ -137,7 +146,7 @@ export default function InstitutionProfileTab({ institution, onSaved }: Props) {
 
     const body = {
       name: values.name,
-      slug: values.slug,
+      ...(!isTenant ? { slug: values.slug } : {}),
       ...(values.description ? { description: values.description } : {}),
       street_address: values.street_address,
       ...(values.extended_address ? { extended_address: values.extended_address } : {}),
@@ -150,13 +159,21 @@ export default function InstitutionProfileTab({ institution, onSaved }: Props) {
       ...(values.phone_number ? { phone_number: values.phone_number } : {}),
       ...(values.website_url ? { website_url: values.website_url } : {}),
       social_links: socialLinks,
-      stats_active: values.stats_active,
-      iabes_member: values.iabes_member,
+      ...(!isTenant
+        ? { stats_active: values.stats_active, iabes_member: values.iabes_member }
+        : {}),
     };
 
-    const res = await fetch(`/api/platform/institutions/${institution.id}`, {
+    const [url, headers]: [string, Record<string, string>] = isTenant
+      ? [
+          "/api/tenant/institution",
+          { "Content-Type": "application/json", "x-tenant-slug": institution.slug },
+        ]
+      : [`/api/platform/institutions/${institution.id}`, { "Content-Type": "application/json" }];
+
+    const res = await fetch(url, {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify(body),
     });
 
@@ -186,104 +203,80 @@ export default function InstitutionProfileTab({ institution, onSaved }: Props) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="mt-6 flex flex-col gap-8">
-        {/* Identity */}
-        <section className="flex flex-col gap-4">
-          <h2 className="text-sm font-semibold">Identity</h2>
+        <fieldset disabled={readOnly} className="flex flex-col gap-8">
+          {readOnly && (
+            <p className="text-muted-foreground text-sm">
+              Only administrators can edit institution profile settings.
+            </p>
+          )}
+          {/* Identity */}
+          <section className="flex flex-col gap-4">
+            <h2 className="text-sm font-semibold">Identity</h2>
 
-          <FormField
-            control={form.control}
-            name="name"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Name</FormLabel>
-                <FormControl>
-                  <Input placeholder="Butterfly Haven" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="slug"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Slug</FormLabel>
-                <FormControl>
-                  <Input placeholder="butterfly-haven" {...field} />
-                </FormControl>
-                <FormDescription>flutr.app/{slugValue || "…"}/gallery</FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="description"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Description</FormLabel>
-                <FormControl>
-                  <Textarea
-                    placeholder="A brief description of the institution…"
-                    rows={3}
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </section>
-
-        <Separator />
-
-        {/* Address */}
-        <section className="flex flex-col gap-4">
-          <h2 className="text-sm font-semibold">Address</h2>
-
-          <FormField
-            control={form.control}
-            name="street_address"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Street address</FormLabel>
-                <FormControl>
-                  <Input placeholder="123 Meadow Lane" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="extended_address"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Extended address{" "}
-                  <span className="text-muted-foreground font-normal">(optional)</span>
-                </FormLabel>
-                <FormControl>
-                  <Input placeholder="Suite 200" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <div className="grid grid-cols-2 gap-4">
             <FormField
               control={form.control}
-              name="city"
+              name="name"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>City</FormLabel>
+                  <FormLabel>Name</FormLabel>
                   <FormControl>
-                    <Input placeholder="Springfield" {...field} />
+                    <Input placeholder="Butterfly Haven" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {!isTenant && (
+              <FormField
+                control={form.control}
+                name="slug"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Slug</FormLabel>
+                    <FormControl>
+                      <Input placeholder="butterfly-haven" {...field} />
+                    </FormControl>
+                    <FormDescription>flutr.app/{slugValue || "…"}/gallery</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="A brief description of the institution…"
+                      rows={3}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </section>
+
+          <Separator />
+
+          {/* Address */}
+          <section className="flex flex-col gap-4">
+            <h2 className="text-sm font-semibold">Address</h2>
+
+            <FormField
+              control={form.control}
+              name="street_address"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Street address</FormLabel>
+                  <FormControl>
+                    <Input placeholder="123 Meadow Lane" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -292,200 +285,241 @@ export default function InstitutionProfileTab({ institution, onSaved }: Props) {
 
             <FormField
               control={form.control}
-              name="state_province"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>State / Province</FormLabel>
-                  <FormControl>
-                    <Input placeholder="IL" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="postal_code"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Postal code</FormLabel>
-                  <FormControl>
-                    <Input placeholder="62701" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="country"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Country</FormLabel>
-                  <FormControl>
-                    <Input placeholder="United States" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-
-          <FormField
-            control={form.control}
-            name="time_zone"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Time zone <span className="text-muted-foreground font-normal">(optional)</span>
-                </FormLabel>
-                <FormControl>
-                  <Input placeholder="America/Chicago" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </section>
-
-        <Separator />
-
-        {/* Contact */}
-        <section className="flex flex-col gap-4">
-          <h2 className="text-sm font-semibold">Contact</h2>
-
-          <FormField
-            control={form.control}
-            name="email_address"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Email address{" "}
-                  <span className="text-muted-foreground font-normal">(optional)</span>
-                </FormLabel>
-                <FormControl>
-                  <Input type="email" placeholder="hello@butterfly-haven.org" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="phone_number"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Phone number <span className="text-muted-foreground font-normal">(optional)</span>
-                </FormLabel>
-                <FormControl>
-                  <Input type="tel" placeholder="+1 (555) 000-0000" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="website_url"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Website URL <span className="text-muted-foreground font-normal">(optional)</span>
-                </FormLabel>
-                <FormControl>
-                  <Input type="url" placeholder="https://butterfly-haven.org" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </section>
-
-        <Separator />
-
-        {/* Social Links */}
-        <section className="flex flex-col gap-4">
-          <h2 className="text-sm font-semibold">Social Links</h2>
-
-          {(
-            [
-              { name: "social_twitter", label: "Twitter / X" },
-              { name: "social_instagram", label: "Instagram" },
-              { name: "social_facebook", label: "Facebook" },
-              { name: "social_linkedin", label: "LinkedIn" },
-              { name: "social_youtube", label: "YouTube" },
-            ] as const
-          ).map(({ name, label }) => (
-            <FormField
-              key={name}
-              control={form.control}
-              name={name}
+              name="extended_address"
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>
-                    {label} <span className="text-muted-foreground font-normal">(optional)</span>
+                    Extended address{" "}
+                    <span className="text-muted-foreground font-normal">(optional)</span>
                   </FormLabel>
                   <FormControl>
-                    <Input type="url" placeholder="https://" {...field} />
+                    <Input placeholder="Suite 200" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
             />
-          ))}
-        </section>
 
-        <Separator />
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="city"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>City</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Springfield" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-        {/* Platform Flags */}
-        <section className="flex flex-col gap-4">
-          <h2 className="text-sm font-semibold">Platform Flags</h2>
+              <FormField
+                control={form.control}
+                name="state_province"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>State / Province</FormLabel>
+                    <FormControl>
+                      <Input placeholder="IL" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-          <FormField
-            control={form.control}
-            name="stats_active"
-            render={({ field }) => (
-              <FormItem className="flex items-center justify-between rounded-lg border p-4">
-                <div className="space-y-0.5">
-                  <FormLabel>Active on public stats</FormLabel>
-                  <FormDescription>
-                    Show this institution on the public statistics page
-                  </FormDescription>
-                </div>
-                <FormControl>
-                  <Switch checked={field.value} onCheckedChange={field.onChange} />
-                </FormControl>
-              </FormItem>
-            )}
-          />
+              <FormField
+                control={form.control}
+                name="postal_code"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Postal code</FormLabel>
+                    <FormControl>
+                      <Input placeholder="62701" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-          <FormField
-            control={form.control}
-            name="iabes_member"
-            render={({ field }) => (
-              <FormItem className="flex items-center gap-3 rounded-lg border p-4">
-                <FormControl>
-                  <Checkbox checked={field.value} onCheckedChange={field.onChange} />
-                </FormControl>
-                <div className="space-y-0.5">
-                  <FormLabel>IABES member</FormLabel>
-                  <FormDescription>This institution is a member of IABES</FormDescription>
-                </div>
-              </FormItem>
-            )}
-          />
-        </section>
+              <FormField
+                control={form.control}
+                name="country"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Country</FormLabel>
+                    <FormControl>
+                      <Input placeholder="United States" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
 
-        <div className="flex justify-end">
-          <Button type="submit" disabled={form.formState.isSubmitting}>
-            {form.formState.isSubmitting ? "Saving…" : "Save changes"}
-          </Button>
-        </div>
+            <FormField
+              control={form.control}
+              name="time_zone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Time zone <span className="text-muted-foreground font-normal">(optional)</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input placeholder="America/Chicago" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </section>
+
+          <Separator />
+
+          {/* Contact */}
+          <section className="flex flex-col gap-4">
+            <h2 className="text-sm font-semibold">Contact</h2>
+
+            <FormField
+              control={form.control}
+              name="email_address"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Email address{" "}
+                    <span className="text-muted-foreground font-normal">(optional)</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input type="email" placeholder="hello@butterfly-haven.org" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="phone_number"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Phone number{" "}
+                    <span className="text-muted-foreground font-normal">(optional)</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input type="tel" placeholder="+1 (555) 000-0000" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="website_url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Website URL{" "}
+                    <span className="text-muted-foreground font-normal">(optional)</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input type="url" placeholder="https://butterfly-haven.org" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </section>
+
+          <Separator />
+
+          {/* Social Links */}
+          <section className="flex flex-col gap-4">
+            <h2 className="text-sm font-semibold">Social Links</h2>
+
+            {(
+              [
+                { name: "social_twitter", label: "Twitter / X" },
+                { name: "social_instagram", label: "Instagram" },
+                { name: "social_facebook", label: "Facebook" },
+                { name: "social_linkedin", label: "LinkedIn" },
+                { name: "social_youtube", label: "YouTube" },
+              ] as const
+            ).map(({ name, label }) => (
+              <FormField
+                key={name}
+                control={form.control}
+                name={name}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {label} <span className="text-muted-foreground font-normal">(optional)</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input type="url" placeholder="https://" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            ))}
+          </section>
+
+          {!isTenant && (
+            <>
+              <Separator />
+
+              {/* Platform Flags */}
+              <section className="flex flex-col gap-4">
+                <h2 className="text-sm font-semibold">Platform Flags</h2>
+
+                <FormField
+                  control={form.control}
+                  name="stats_active"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                      <div className="space-y-0.5">
+                        <FormLabel>Active on public stats</FormLabel>
+                        <FormDescription>
+                          Show this institution on the public statistics page
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch checked={field.value} onCheckedChange={field.onChange} />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="iabes_member"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center gap-3 rounded-lg border p-4">
+                      <FormControl>
+                        <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                      </FormControl>
+                      <div className="space-y-0.5">
+                        <FormLabel>IABES member</FormLabel>
+                        <FormDescription>This institution is a member of IABES</FormDescription>
+                      </div>
+                    </FormItem>
+                  )}
+                />
+              </section>
+            </>
+          )}
+        </fieldset>
+
+        {!readOnly && (
+          <div className="flex justify-end">
+            <Button type="submit" disabled={form.formState.isSubmitting}>
+              {form.formState.isSubmitting ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        )}
       </form>
     </Form>
   );

--- a/src/components/platform/institutions/detail/institution-theme-tab.tsx
+++ b/src/components/platform/institutions/detail/institution-theme-tab.tsx
@@ -19,7 +19,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 
-import type { InstitutionDetail } from "./institution-detail-shell";
+import type { InstitutionDetail, InstitutionDetailMode } from "./institution-detail-shell";
 
 const PRESET_COLORS: { hex: string; label: string }[] = [
   { hex: "#0d9488", label: "Teal" },
@@ -44,9 +44,17 @@ type ThemeFormValues = z.infer<typeof themeFormSchema>;
 
 interface Props {
   institution: InstitutionDetail;
+  /** @default "platform" */
+  mode?: InstitutionDetailMode;
+  readOnly?: boolean;
 }
 
-export default function InstitutionThemeTab({ institution }: Props) {
+export default function InstitutionThemeTab({
+  institution,
+  mode = "platform",
+  readOnly = false,
+}: Props) {
+  const isTenant = mode === "tenant";
   const initialColor = institution.theme_colors?.[0] ?? PRESET_COLORS[0].hex;
 
   const [isCustom, setIsCustom] = useState(!PRESET_COLORS.some((c) => c.hex === initialColor));
@@ -80,9 +88,16 @@ export default function InstitutionThemeTab({ institution }: Props) {
       ...(values.facility_image_url ? { facility_image_url: values.facility_image_url } : {}),
     };
 
-    const res = await fetch(`/api/platform/institutions/${institution.id}`, {
+    const [url, headers]: [string, Record<string, string>] = isTenant
+      ? [
+          "/api/tenant/institution",
+          { "Content-Type": "application/json", "x-tenant-slug": institution.slug },
+        ]
+      : [`/api/platform/institutions/${institution.id}`, { "Content-Type": "application/json" }];
+
+    const res = await fetch(url, {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify(body),
     });
 
@@ -98,155 +113,179 @@ export default function InstitutionThemeTab({ institution }: Props) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="mt-6 flex flex-col gap-8">
-        {/* Theme Colors */}
-        <section className="flex flex-col gap-4">
-          <div className="flex items-center gap-3">
-            <h2 className="text-sm font-semibold">Primary Color</h2>
-            <div
-              className="size-5 rounded-full border"
-              style={{ backgroundColor: isValidHex ? primaryColor : undefined }}
-            />
-          </div>
-
-          <div className="flex flex-wrap gap-3">
-            {PRESET_COLORS.map(({ hex, label }) => (
-              <button
-                key={hex}
-                type="button"
-                aria-label={label}
-                aria-pressed={!isCustom && primaryColor === hex}
-                onClick={() => selectPreset(hex)}
-                className={cn(
-                  "size-8 rounded-full border-2 transition-all",
-                  !isCustom && primaryColor === hex
-                    ? "border-foreground ring-2 ring-offset-2"
-                    : "hover:border-muted-foreground/40 border-transparent",
-                )}
-                style={{ backgroundColor: hex }}
-              />
-            ))}
-
-            {/* Custom */}
-            <button
-              type="button"
-              aria-label="Custom color"
-              aria-pressed={isCustom}
-              onClick={selectCustom}
-              className={cn(
-                "flex size-8 items-center justify-center rounded-full border-2 text-xs font-bold transition-all",
-                isCustom
-                  ? "border-foreground bg-muted ring-2 ring-offset-2"
-                  : "border-muted-foreground/40 hover:border-muted-foreground/60 bg-muted/50 border-dashed",
-              )}
-            >
-              +
-            </button>
-          </div>
-
-          {isCustom && (
-            <FormField
-              control={form.control}
-              name="primary_color"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Custom hex color</FormLabel>
-                  <FormControl>
-                    <Input placeholder="#4f46e5" maxLength={7} {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+        <fieldset disabled={readOnly} className="flex flex-col gap-8">
+          {readOnly && (
+            <p className="text-muted-foreground text-sm">
+              Only administrators can edit theme settings.
+            </p>
           )}
-        </section>
+          {/* Theme Colors */}
+          <section className="flex flex-col gap-4">
+            <h2 className="text-sm font-semibold">Primary Color</h2>
 
-        <Separator />
+            {readOnly ? (
+              <div className="flex items-center gap-3">
+                <div
+                  role="img"
+                  aria-label={`Primary color: ${primaryColor}`}
+                  className="size-8 rounded-full border"
+                  style={{ backgroundColor: isValidHex ? primaryColor : undefined }}
+                />
+                <span className="text-muted-foreground font-mono text-sm">{primaryColor}</span>
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center gap-3">
+                  <div
+                    className="size-5 rounded-full border"
+                    style={{ backgroundColor: isValidHex ? primaryColor : undefined }}
+                  />
+                </div>
 
-        {/* Media */}
-        <section className="flex flex-col gap-6">
-          <h2 className="text-sm font-semibold">Media</h2>
-
-          {/* Logo URL */}
-          <div className="flex flex-col gap-3">
-            <FormField
-              control={form.control}
-              name="logo_url"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>
-                    Logo URL <span className="text-muted-foreground font-normal">(optional)</span>
-                  </FormLabel>
-                  <FormControl>
-                    <Input
-                      type="url"
-                      placeholder="https://example.com/logo.png"
-                      {...field}
-                      onBlur={(e) => {
-                        field.onBlur();
-                        setLogoPreview(e.target.value);
-                      }}
+                <div className="flex flex-wrap gap-3">
+                  {PRESET_COLORS.map(({ hex, label }) => (
+                    <button
+                      key={hex}
+                      type="button"
+                      aria-label={label}
+                      aria-pressed={!isCustom && primaryColor === hex}
+                      onClick={() => selectPreset(hex)}
+                      className={cn(
+                        "size-8 rounded-full border-2 transition-all",
+                        !isCustom && primaryColor === hex
+                          ? "border-foreground ring-2 ring-offset-2"
+                          : "hover:border-muted-foreground/40 border-transparent",
+                      )}
+                      style={{ backgroundColor: hex }}
                     />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            {logoPreview && (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={logoPreview}
-                alt="Logo preview"
-                className="h-16 w-auto rounded border object-contain"
-                onError={(e) => ((e.target as HTMLImageElement).style.display = "none")}
-                onLoad={(e) => ((e.target as HTMLImageElement).style.display = "")}
-              />
-            )}
-          </div>
+                  ))}
 
-          {/* Facility image URL */}
-          <div className="flex flex-col gap-3">
-            <FormField
-              control={form.control}
-              name="facility_image_url"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>
-                    Facility image URL{" "}
-                    <span className="text-muted-foreground font-normal">(optional)</span>
-                  </FormLabel>
-                  <FormControl>
-                    <Input
-                      type="url"
-                      placeholder="https://example.com/facility.jpg"
-                      {...field}
-                      onBlur={(e) => {
-                        field.onBlur();
-                        setFacilityPreview(e.target.value);
-                      }}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            {facilityPreview && (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={facilityPreview}
-                alt="Facility image preview"
-                className="h-32 w-full rounded border object-cover"
-                onError={(e) => ((e.target as HTMLImageElement).style.display = "none")}
-                onLoad={(e) => ((e.target as HTMLImageElement).style.display = "")}
-              />
-            )}
-          </div>
-        </section>
+                  {/* Custom */}
+                  <button
+                    type="button"
+                    aria-label="Custom color"
+                    aria-pressed={isCustom}
+                    onClick={selectCustom}
+                    className={cn(
+                      "flex size-8 items-center justify-center rounded-full border-2 text-xs font-bold transition-all",
+                      isCustom
+                        ? "border-foreground bg-muted ring-2 ring-offset-2"
+                        : "border-muted-foreground/40 hover:border-muted-foreground/60 bg-muted/50 border-dashed",
+                    )}
+                  >
+                    +
+                  </button>
+                </div>
 
-        <div className="flex justify-end">
-          <Button type="submit" disabled={form.formState.isSubmitting}>
-            {form.formState.isSubmitting ? "Saving…" : "Save changes"}
-          </Button>
-        </div>
+                {isCustom && (
+                  <FormField
+                    control={form.control}
+                    name="primary_color"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Custom hex color</FormLabel>
+                        <FormControl>
+                          <Input placeholder="#4f46e5" maxLength={7} {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
+              </>
+            )}
+          </section>
+
+          <Separator />
+
+          {/* Media */}
+          <section className="flex flex-col gap-6">
+            <h2 className="text-sm font-semibold">Media</h2>
+
+            {/* Logo URL */}
+            <div className="flex flex-col gap-3">
+              <FormField
+                control={form.control}
+                name="logo_url"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Logo URL <span className="text-muted-foreground font-normal">(optional)</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="url"
+                        placeholder="https://example.com/logo.png"
+                        {...field}
+                        onBlur={(e) => {
+                          field.onBlur();
+                          setLogoPreview(e.target.value);
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              {logoPreview && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={logoPreview}
+                  alt="Logo preview"
+                  className="h-16 w-auto rounded border object-contain"
+                  onError={(e) => ((e.target as HTMLImageElement).style.display = "none")}
+                  onLoad={(e) => ((e.target as HTMLImageElement).style.display = "")}
+                />
+              )}
+            </div>
+
+            {/* Facility image URL */}
+            <div className="flex flex-col gap-3">
+              <FormField
+                control={form.control}
+                name="facility_image_url"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Facility image URL{" "}
+                      <span className="text-muted-foreground font-normal">(optional)</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="url"
+                        placeholder="https://example.com/facility.jpg"
+                        {...field}
+                        onBlur={(e) => {
+                          field.onBlur();
+                          setFacilityPreview(e.target.value);
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              {facilityPreview && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={facilityPreview}
+                  alt="Facility image preview"
+                  className="h-32 w-full rounded border object-cover"
+                  onError={(e) => ((e.target as HTMLImageElement).style.display = "none")}
+                  onLoad={(e) => ((e.target as HTMLImageElement).style.display = "")}
+                />
+              )}
+            </div>
+          </section>
+        </fieldset>
+
+        {!readOnly && (
+          <div className="flex justify-end">
+            <Button type="submit" disabled={form.formState.isSubmitting}>
+              {form.formState.isSubmitting ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        )}
       </form>
     </Form>
   );

--- a/src/components/platform/institutions/detail/institution-users-cards.tsx
+++ b/src/components/platform/institutions/detail/institution-users-cards.tsx
@@ -16,9 +16,15 @@ interface Props {
   users: InstitutionUser[];
   onEdit: (user: InstitutionUser) => void;
   renderDeleteAction: (user: InstitutionUser) => React.ReactNode;
+  readOnly?: boolean;
 }
 
-export default function InstitutionUsersCards({ users, onEdit, renderDeleteAction }: Props) {
+export default function InstitutionUsersCards({
+  users,
+  onEdit,
+  renderDeleteAction,
+  readOnly = false,
+}: Props) {
   if (users.length === 0) {
     return (
       <Card className="md:hidden">
@@ -43,12 +49,14 @@ export default function InstitutionUsersCards({ users, onEdit, renderDeleteActio
               <Badge variant="outline">{ROLE_LABELS[user.role] ?? user.role}</Badge>
             </div>
 
-            <div className="xs:flex-row flex flex-col gap-2">
-              <Button variant="outline" onClick={() => onEdit(user)} className="xs:flex-1">
-                Edit
-              </Button>
-              <div className="xs:flex-1">{renderDeleteAction(user)}</div>
-            </div>
+            {!readOnly && (
+              <div className="xs:flex-row flex flex-col gap-2">
+                <Button variant="outline" onClick={() => onEdit(user)} className="xs:flex-1">
+                  Edit
+                </Button>
+                <div className="xs:flex-1">{renderDeleteAction(user)}</div>
+              </div>
+            )}
           </CardContent>
         </Card>
       ))}

--- a/src/components/platform/institutions/detail/institution-users-cards.tsx
+++ b/src/components/platform/institutions/detail/institution-users-cards.tsx
@@ -42,7 +42,7 @@ export default function InstitutionUsersCards({
           <CardContent className="flex flex-col gap-4 pt-6">
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0">
-                <p className="text-base font-medium break-words">{user.name}</p>
+                <p className="text-base font-medium wrap-break-word">{user.name}</p>
                 <p className="text-muted-foreground text-sm break-all">{user.email}</p>
               </div>
 

--- a/src/components/platform/institutions/detail/institution-users-tab.tsx
+++ b/src/components/platform/institutions/detail/institution-users-tab.tsx
@@ -39,9 +39,14 @@ const ROLE_LABELS: Record<string, string> = {
 interface Props {
   institution: InstitutionDetail;
   initialUsers: InstitutionUser[];
+  readOnly?: boolean;
 }
 
-export default function InstitutionUsersTab({ institution, initialUsers }: Props) {
+export default function InstitutionUsersTab({
+  institution,
+  initialUsers,
+  readOnly = false,
+}: Props) {
   const [users, setUsers] = useState<InstitutionUser[]>(initialUsers);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingUser, setEditingUser] = useState<InstitutionUser | undefined>(undefined);
@@ -142,15 +147,18 @@ export default function InstitutionUsersTab({ institution, initialUsers }: Props
           <p className="text-muted-foreground text-sm">
             {users.length} {users.length === 1 ? "user" : "users"}
           </p>
-          <Button size="sm" onClick={openAdd} className="w-full sm:w-auto">
-            Add User
-          </Button>
+          {!readOnly && (
+            <Button size="sm" onClick={openAdd} className="w-full sm:w-auto">
+              Add User
+            </Button>
+          )}
         </div>
 
         <InstitutionUsersCards
           users={users}
           onEdit={openEdit}
           renderDeleteAction={(user) => renderDeleteAction(user, true)}
+          readOnly={readOnly}
         />
 
         <div className="hidden rounded-md border md:block">
@@ -160,13 +168,16 @@ export default function InstitutionUsersTab({ institution, initialUsers }: Props
                 <TableHead>Name</TableHead>
                 <TableHead>Email</TableHead>
                 <TableHead>Role</TableHead>
-                <TableHead className="w-[120px]">Actions</TableHead>
+                {!readOnly && <TableHead className="w-[120px]">Actions</TableHead>}
               </TableRow>
             </TableHeader>
             <TableBody>
               {users.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={4} className="text-muted-foreground py-8 text-center text-sm">
+                  <TableCell
+                    colSpan={readOnly ? 3 : 4}
+                    className="text-muted-foreground py-8 text-center text-sm"
+                  >
                     No users found.
                   </TableCell>
                 </TableRow>
@@ -180,15 +191,17 @@ export default function InstitutionUsersTab({ institution, initialUsers }: Props
                     <TableCell>
                       <Badge variant="outline">{ROLE_LABELS[user.role] ?? user.role}</Badge>
                     </TableCell>
-                    <TableCell>
-                      <div className="flex gap-2">
-                        <Button size="sm" variant="outline" onClick={() => openEdit(user)}>
-                          Edit
-                        </Button>
+                    {!readOnly && (
+                      <TableCell>
+                        <div className="flex gap-2">
+                          <Button size="sm" variant="outline" onClick={() => openEdit(user)}>
+                            Edit
+                          </Button>
 
-                        {renderDeleteAction(user)}
-                      </div>
-                    </TableCell>
+                          {renderDeleteAction(user)}
+                        </div>
+                      </TableCell>
+                    )}
                   </TableRow>
                 ))
               )}

--- a/src/components/shared/nav-card.tsx
+++ b/src/components/shared/nav-card.tsx
@@ -3,19 +3,14 @@ import { LucideIcon } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Link } from "@/components/ui/link";
 
-interface PlatformNavCardProps {
+interface NavCardProps {
   href: string;
   title: string;
   description: string;
   icon: LucideIcon;
 }
 
-export default function PlatformNavCard({
-  href,
-  title,
-  description,
-  icon: Icon,
-}: PlatformNavCardProps) {
+export default function NavCard({ href, title, description, icon: Icon }: NavCardProps) {
   return (
     <Link
       href={href}

--- a/src/lib/queries/users.ts
+++ b/src/lib/queries/users.ts
@@ -12,9 +12,16 @@ import type { CreateUserBody, UpdateUserBody } from "@/lib/validation/users";
  * TENANT QUERY
  *
  * List users for the current tenant scope.
+ * When excludeSuperusers is true, SUPERUSER accounts are filtered out
+ * (used by tenant org page so admins only see tenant-level users).
  */
-export async function listUsersForTenant(institutionId: number, user: AuthenticatedUser) {
-  const condition = tenantCondition(user, users.institution_id, institutionId);
+export async function listUsersForTenant(
+  institutionId: number,
+  user: AuthenticatedUser,
+  { excludeSuperusers = false }: { excludeSuperusers?: boolean } = {},
+) {
+  const tenantCond = tenantCondition(user, users.institution_id, institutionId);
+  const conditions = excludeSuperusers ? and(tenantCond, ne(users.role, "SUPERUSER")) : tenantCond;
 
   return db
     .select({
@@ -27,7 +34,7 @@ export async function listUsersForTenant(institutionId: number, user: Authentica
       updatedAt: users.updated_at,
     })
     .from(users)
-    .where(condition)
+    .where(conditions)
     .orderBy(asc(users.name));
 }
 

--- a/src/lib/services/tenant-institution.ts
+++ b/src/lib/services/tenant-institution.ts
@@ -1,15 +1,18 @@
 import { auth } from "@/auth";
+import type { AuthenticatedUser } from "@/lib/authz";
 import { requireUser, canManageInstitutionProfile } from "@/lib/authz";
 import { resolveTenantBySlug, TENANT_ERRORS } from "@/lib/tenant";
 import { getTenantInstitution, updateTenantInstitution } from "@/lib/queries/institution";
 
-export async function getTenantInstitutionService(slug: string) {
-  const session = await auth();
-  const user = requireUser(session);
-
-  if (!canManageInstitutionProfile(user)) {
-    throw new Error(TENANT_ERRORS.FORBIDDEN_CROSS_TENANT_ACCESS);
-  }
+/**
+ * Read-only access to the institution for any authenticated tenant member.
+ * Used by the tenant organization page to display settings to all roles.
+ *
+ * Accepts an optional pre-resolved user to avoid redundant auth() calls
+ * when the caller has already authenticated.
+ */
+export async function viewTenantInstitutionService(slug: string, caller?: AuthenticatedUser) {
+  const user = caller ?? requireUser(await auth());
 
   const tenantId = await resolveTenantBySlug(user, slug);
 


### PR DESCRIPTION
## Summary
- Add tenant dashboard page with nav cards for Organization, Shipments, and Releases
- Reuse `InstitutionDetailShell` for the tenant organization page with `mode` and `readOnly` props, allowing EMPLOYEEs to view (but not edit) institution settings
- Add `viewTenantInstitutionService` for read-only institution access (any authenticated tenant member)
- Rename `PlatformNavCard` → `NavCard` and move to `components/shared/` for reuse across platform and tenant dashboards
- Add `excludeSuperusers` option to `listUsersForTenant` so tenant admins only see tenant-level users

## Test plan
- [ ] Verify tenant dashboard renders nav cards with correct links
- [ ] Verify EMPLOYEE sees profile + theme tabs (read-only, no submit button)
- [ ] Verify ADMIN sees all 4 tabs and can edit profile/theme
- [ ] Verify SUPERUSER accounts are hidden from tenant users tab
- [ ] Verify platform admin dashboard still works after NavCard rename
- [ ] Run `pnpm test` — tenant institution route tests updated
