### PR TITLE
feat: add drizzle baseline and species fun facts json migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,32 @@ Then run:
 ```bash
 docker compose down -v     # Reset Docker volumes if data exists (caution: deletes all data)
 docker compose up -d
-pnpm db:push               # Or: docker compose exec app pnpm db:push
+pnpm db:migrate            # Apply Drizzle migration history from scratch
 pnpm seed                  # Run seed script to populate initial data (Ensure .json files in scripts/data/ are present)
 ```
 
 Open [http://localhost:3000](http://localhost:3000) to view the app.
+
+## Fresh Migration Reset
+
+When a migration changes the local schema in a way that is easier to rebuild than backfill, the team should start from a clean local database instead of trying to preserve old dev data.
+
+Current recommended reset flow:
+
+```bash
+git pull
+docker compose down -v
+docker compose up -d
+pnpm db:migrate
+pnpm seed
+```
+
+Notes:
+
+- `docker compose down -v` removes the local Postgres volume and deletes all local DB data.
+- Use `pnpm db:migrate`, not `pnpm db:push`, so everyone applies the committed Drizzle migration history in order.
+- `pnpm seed` expects a fresh database and will stop if data already exists.
+- This is the preferred workflow for the new baseline `0000` migration and follow-up schema migration.
 
 ## Environment Variables
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -127,6 +127,84 @@ All tenant routes use `x-tenant-slug` for tenant context:
 - `GET/POST /api/platform/suppliers` — list & create suppliers (cross-tenant)
 - `GET/PATCH/DELETE /api/platform/suppliers/[id]` — supplier detail, update, delete
 
+### Platform species create/update contract
+
+`POST /api/platform/species` accepts a full species payload.
+
+`PATCH /api/platform/species/[id]` accepts any subset of the same fields, but at least one field is required.
+
+`fun_facts` shape:
+
+```json
+[
+  {
+    "title": "Fun Fact",
+    "fact": "Adults can glide for long distances."
+  },
+  {
+    "title": "Fun Fact",
+    "fact": "Larvae prefer citrus host plants."
+  }
+]
+```
+
+Example request body:
+
+```json
+{
+  "scientific_name": "Papilio glaucus",
+  "common_name": "Eastern Tiger Swallowtail",
+  "family": "Papilionidae",
+  "sub_family": "Papilioninae",
+  "lifespan_days": 14,
+  "range": ["North America"],
+  "description": "A striking yellow butterfly species",
+  "host_plant": "Willow",
+  "habitat": "Woodlands",
+  "fun_facts": [
+    { "title": "Fun Fact", "fact": "Adults can glide for long distances." },
+    { "title": "Fun Fact", "fact": "Larvae prefer citrus host plants." }
+  ],
+  "img_wings_open": "https://example.com/open.jpg",
+  "img_wings_closed": "https://example.com/closed.jpg"
+}
+```
+
+Notes:
+
+- `fun_facts` is optional.
+- When provided, `fun_facts` must be a non-empty array of `{ title, fact }` objects.
+- `PATCH` replaces the full `fun_facts` array; it does not append a single fact item.
+- The legacy string format for `fun_facts` is no longer accepted.
+
+### Public species detail contract
+
+`GET /api/public/institutions/[slug]/species/[scientific_name]` response shape:
+
+```json
+{
+  "species": {
+    "speciesId": 10,
+    "scientific_name": "Papilio glaucus",
+    "common_name": "Eastern Tiger Swallowtail",
+    "common_name_override": null,
+    "lifespan_days": 14,
+    "lifespan_override": null,
+    "description": "A striking yellow butterfly species",
+    "host_plant": "Willow",
+    "habitat": "Woodlands",
+    "fun_facts": [
+      { "title": "Fun Fact", "fact": "Adults can glide for long distances." },
+      { "title": "Fun Fact", "fact": "Larvae prefer citrus host plants." }
+    ],
+    "img_wings_open": "https://example.com/open.jpg",
+    "img_wings_closed": "https://example.com/closed.jpg",
+    "extra_img_1": null,
+    "extra_img_2": null
+  }
+}
+```
+
 ### Tenant shipments list contract
 
 `GET /api/tenant/shipments` supports pagination with query params:

--- a/drizzle/0000_next_darwin.sql
+++ b/drizzle/0000_next_darwin.sql
@@ -1,0 +1,167 @@
+CREATE TABLE "butterfly_species" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"scientific_name" text NOT NULL,
+	"common_name" text NOT NULL,
+	"family" text NOT NULL,
+	"sub_family" text NOT NULL,
+	"lifespan_days" integer NOT NULL,
+	"range" text[] NOT NULL,
+	"description" text,
+	"host_plant" text,
+	"habitat" text,
+	"fun_facts" text,
+	"img_wings_open" text,
+	"img_wings_closed" text,
+	"extra_img_1" text,
+	"extra_img_2" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "butterfly_species_scientific_name_unique" UNIQUE("scientific_name")
+);
+--> statement-breakpoint
+CREATE TABLE "butterfly_species_institution" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"butterfly_species_id" integer NOT NULL,
+	"institution_id" integer NOT NULL,
+	"common_name_override" text,
+	"lifespan_override" integer,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "in_flight" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"institution_id" integer NOT NULL,
+	"release_event_id" integer NOT NULL,
+	"shipment_item_id" integer NOT NULL,
+	"quantity" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "institution_news" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"institution_id" integer NOT NULL,
+	"title" text NOT NULL,
+	"content" text NOT NULL,
+	"image_url" text,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "institutions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"slug" text NOT NULL,
+	"name" text NOT NULL,
+	"street_address" text NOT NULL,
+	"extended_address" text,
+	"city" text NOT NULL,
+	"state_province" text NOT NULL,
+	"postal_code" text NOT NULL,
+	"time_zone" text,
+	"country" text NOT NULL,
+	"phone_number" text,
+	"email_address" text,
+	"iabes_member" boolean DEFAULT false NOT NULL,
+	"theme_colors" text[],
+	"website_url" text,
+	"facility_image_url" text,
+	"logo_url" text,
+	"description" text,
+	"social_links" jsonb,
+	"stats_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "institutions_slug_unique" UNIQUE("slug"),
+	CONSTRAINT "institutions_email_address_unique" UNIQUE("email_address")
+);
+--> statement-breakpoint
+CREATE TABLE "release_events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"institution_id" integer NOT NULL,
+	"shipment_id" integer NOT NULL,
+	"release_date" timestamp NOT NULL,
+	"released_by" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "unique_release_event_id_per_institution" UNIQUE("institution_id","id")
+);
+--> statement-breakpoint
+CREATE TABLE "shipment_items" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"institution_id" integer NOT NULL,
+	"shipment_id" integer NOT NULL,
+	"butterfly_species_id" integer NOT NULL,
+	"number_received" integer NOT NULL,
+	"emerged_in_transit" integer DEFAULT 0 NOT NULL,
+	"damaged_in_transit" integer DEFAULT 0 NOT NULL,
+	"diseased_in_transit" integer DEFAULT 0 NOT NULL,
+	"parasite" integer DEFAULT 0 NOT NULL,
+	"non_emergence" integer DEFAULT 0 NOT NULL,
+	"poor_emergence" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "unique_shipment_item_id_per_institution" UNIQUE("institution_id","id")
+);
+--> statement-breakpoint
+CREATE TABLE "shipments" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"institution_id" integer NOT NULL,
+	"supplier_code" text NOT NULL,
+	"shipment_date" timestamp NOT NULL,
+	"arrival_date" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "unique_shipment_id_per_institution" UNIQUE("institution_id","id")
+);
+--> statement-breakpoint
+CREATE TABLE "suppliers" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"institution_id" integer NOT NULL,
+	"name" text NOT NULL,
+	"code" text NOT NULL,
+	"country" text NOT NULL,
+	"website_url" text,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "unique_supplier_per_institution" UNIQUE("institution_id","code"),
+	CONSTRAINT "unique_supplier_id_per_institution" UNIQUE("institution_id","id")
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"password_hash" text NOT NULL,
+	"institution_id" integer NOT NULL,
+	"role" text DEFAULT 'user' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+ALTER TABLE "butterfly_species_institution" ADD CONSTRAINT "butterfly_species_institution_butterfly_species_id_butterfly_species_id_fk" FOREIGN KEY ("butterfly_species_id") REFERENCES "public"."butterfly_species"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "butterfly_species_institution" ADD CONSTRAINT "butterfly_species_institution_institution_id_institutions_id_fk" FOREIGN KEY ("institution_id") REFERENCES "public"."institutions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "in_flight" ADD CONSTRAINT "in_flight_institution_id_institutions_id_fk" FOREIGN KEY ("institution_id") REFERENCES "public"."institutions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "in_flight" ADD CONSTRAINT "fk_in_flight_event_institution" FOREIGN KEY ("institution_id","release_event_id") REFERENCES "public"."release_events"("institution_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "in_flight" ADD CONSTRAINT "fk_in_flight_shipment_item_institution" FOREIGN KEY ("institution_id","shipment_item_id") REFERENCES "public"."shipment_items"("institution_id","id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "institution_news" ADD CONSTRAINT "institution_news_institution_id_institutions_id_fk" FOREIGN KEY ("institution_id") REFERENCES "public"."institutions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "release_events" ADD CONSTRAINT "release_events_institution_id_institutions_id_fk" FOREIGN KEY ("institution_id") REFERENCES "public"."institutions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "release_events" ADD CONSTRAINT "fk_release_events_shipment_institution" FOREIGN KEY ("institution_id","shipment_id") REFERENCES "public"."shipments"("institution_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "shipment_items" ADD CONSTRAINT "shipment_items_institution_id_institutions_id_fk" FOREIGN KEY ("institution_id") REFERENCES "public"."institutions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "shipment_items" ADD CONSTRAINT "shipment_items_butterfly_species_id_butterfly_species_id_fk" FOREIGN KEY ("butterfly_species_id") REFERENCES "public"."butterfly_species"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "shipment_items" ADD CONSTRAINT "fk_shipment_items_shipment_institution" FOREIGN KEY ("institution_id","shipment_id") REFERENCES "public"."shipments"("institution_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "shipments" ADD CONSTRAINT "shipments_institution_id_institutions_id_fk" FOREIGN KEY ("institution_id") REFERENCES "public"."institutions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "shipments" ADD CONSTRAINT "fk_shipments_supplier_code" FOREIGN KEY ("institution_id","supplier_code") REFERENCES "public"."suppliers"("institution_id","code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "suppliers" ADD CONSTRAINT "suppliers_institution_id_institutions_id_fk" FOREIGN KEY ("institution_id") REFERENCES "public"."institutions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_institution_id_institutions_id_fk" FOREIGN KEY ("institution_id") REFERENCES "public"."institutions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_institution_species" ON "butterfly_species_institution" USING btree ("butterfly_species_id","institution_id");--> statement-breakpoint
+CREATE INDEX "idx_bsi_institution_id" ON "butterfly_species_institution" USING btree ("institution_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_in_flight_shipment_item" ON "in_flight" USING btree ("release_event_id","shipment_item_id");--> statement-breakpoint
+CREATE INDEX "idx_in_flight_institution_shipment_item" ON "in_flight" USING btree ("institution_id","shipment_item_id");--> statement-breakpoint
+CREATE INDEX "idx_institution_news_institution_id" ON "institution_news" USING btree ("institution_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_shipment_species" ON "shipment_items" USING btree ("shipment_id","butterfly_species_id");--> statement-breakpoint
+CREATE INDEX "idx_shipment_items_institution_species" ON "shipment_items" USING btree ("institution_id","butterfly_species_id");--> statement-breakpoint
+CREATE INDEX "idx_users_institution_id" ON "users" USING btree ("institution_id");

--- a/drizzle/0001_icy_hedge_knight.sql
+++ b/drizzle/0001_icy_hedge_knight.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "butterfly_species"
+ALTER COLUMN "fun_facts" TYPE jsonb
+USING CASE
+  WHEN "fun_facts" IS NULL THEN NULL
+  WHEN btrim("fun_facts") = '' THEN NULL
+  ELSE jsonb_build_array(
+    jsonb_build_object(
+      'title',
+      'Fun Fact',
+      'fact',
+      "fun_facts"
+    )
+  )
+END;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,1253 @@
+{
+  "id": "20af176a-a235-42de-8331-fa25c95ee8fe",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.butterfly_species": {
+      "name": "butterfly_species",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scientific_name": {
+          "name": "scientific_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name": {
+          "name": "common_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_family": {
+          "name": "sub_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifespan_days": {
+          "name": "lifespan_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range": {
+          "name": "range",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_plant": {
+          "name": "host_plant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "habitat": {
+          "name": "habitat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fun_facts": {
+          "name": "fun_facts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "img_wings_open": {
+          "name": "img_wings_open",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "img_wings_closed": {
+          "name": "img_wings_closed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_img_1": {
+          "name": "extra_img_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_img_2": {
+          "name": "extra_img_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "butterfly_species_scientific_name_unique": {
+          "name": "butterfly_species_scientific_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scientific_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.butterfly_species_institution": {
+      "name": "butterfly_species_institution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "butterfly_species_id": {
+          "name": "butterfly_species_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name_override": {
+          "name": "common_name_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifespan_override": {
+          "name": "lifespan_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_institution_species": {
+          "name": "unique_institution_species",
+          "columns": [
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bsi_institution_id": {
+          "name": "idx_bsi_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "butterfly_species_institution_butterfly_species_id_butterfly_species_id_fk": {
+          "name": "butterfly_species_institution_butterfly_species_id_butterfly_species_id_fk",
+          "tableFrom": "butterfly_species_institution",
+          "tableTo": "butterfly_species",
+          "columnsFrom": [
+            "butterfly_species_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "butterfly_species_institution_institution_id_institutions_id_fk": {
+          "name": "butterfly_species_institution_institution_id_institutions_id_fk",
+          "tableFrom": "butterfly_species_institution",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_flight": {
+      "name": "in_flight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_event_id": {
+          "name": "release_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_item_id": {
+          "name": "shipment_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_in_flight_shipment_item": {
+          "name": "unique_in_flight_shipment_item",
+          "columns": [
+            {
+              "expression": "release_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_flight_institution_shipment_item": {
+          "name": "idx_in_flight_institution_shipment_item",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_flight_institution_id_institutions_id_fk": {
+          "name": "in_flight_institution_id_institutions_id_fk",
+          "tableFrom": "in_flight",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_in_flight_event_institution": {
+          "name": "fk_in_flight_event_institution",
+          "tableFrom": "in_flight",
+          "tableTo": "release_events",
+          "columnsFrom": [
+            "institution_id",
+            "release_event_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_in_flight_shipment_item_institution": {
+          "name": "fk_in_flight_shipment_item_institution",
+          "tableFrom": "in_flight",
+          "tableTo": "shipment_items",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_item_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institution_news": {
+      "name": "institution_news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_institution_news_institution_id": {
+          "name": "idx_institution_news_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "institution_news_institution_id_institutions_id_fk": {
+          "name": "institution_news_institution_id_institutions_id_fk",
+          "tableFrom": "institution_news",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street_address": {
+          "name": "street_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extended_address": {
+          "name": "extended_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_province": {
+          "name": "state_province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iabes_member": {
+          "name": "iabes_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_colors": {
+          "name": "theme_colors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_image_url": {
+          "name": "facility_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_active": {
+          "name": "stats_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_slug_unique": {
+          "name": "institutions_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "institutions_email_address_unique": {
+          "name": "institutions_email_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.release_events": {
+      "name": "release_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_by": {
+          "name": "released_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "release_events_institution_id_institutions_id_fk": {
+          "name": "release_events_institution_id_institutions_id_fk",
+          "tableFrom": "release_events",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_release_events_shipment_institution": {
+          "name": "fk_release_events_shipment_institution",
+          "tableFrom": "release_events",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_release_event_id_per_institution": {
+          "name": "unique_release_event_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipment_items": {
+      "name": "shipment_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "butterfly_species_id": {
+          "name": "butterfly_species_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_received": {
+          "name": "number_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emerged_in_transit": {
+          "name": "emerged_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "damaged_in_transit": {
+          "name": "damaged_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "diseased_in_transit": {
+          "name": "diseased_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parasite": {
+          "name": "parasite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "non_emergence": {
+          "name": "non_emergence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "poor_emergence": {
+          "name": "poor_emergence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_shipment_species": {
+          "name": "unique_shipment_species",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipment_items_institution_species": {
+          "name": "idx_shipment_items_institution_species",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_items_institution_id_institutions_id_fk": {
+          "name": "shipment_items_institution_id_institutions_id_fk",
+          "tableFrom": "shipment_items",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shipment_items_butterfly_species_id_butterfly_species_id_fk": {
+          "name": "shipment_items_butterfly_species_id_butterfly_species_id_fk",
+          "tableFrom": "shipment_items",
+          "tableTo": "butterfly_species",
+          "columnsFrom": [
+            "butterfly_species_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fk_shipment_items_shipment_institution": {
+          "name": "fk_shipment_items_shipment_institution",
+          "tableFrom": "shipment_items",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_shipment_item_id_per_institution": {
+          "name": "unique_shipment_item_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipments": {
+      "name": "shipments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_date": {
+          "name": "shipment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrival_date": {
+          "name": "arrival_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shipments_institution_id_institutions_id_fk": {
+          "name": "shipments_institution_id_institutions_id_fk",
+          "tableFrom": "shipments",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_shipments_supplier_code": {
+          "name": "fk_shipments_supplier_code",
+          "tableFrom": "shipments",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "institution_id",
+            "supplier_code"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "code"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_shipment_id_per_institution": {
+          "name": "unique_shipment_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "suppliers_institution_id_institutions_id_fk": {
+          "name": "suppliers_institution_id_institutions_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_supplier_per_institution": {
+          "name": "unique_supplier_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "code"
+          ]
+        },
+        "unique_supplier_id_per_institution": {
+          "name": "unique_supplier_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_institution_id": {
+          "name": "idx_users_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_institution_id_institutions_id_fk": {
+          "name": "users_institution_id_institutions_id_fk",
+          "tableFrom": "users",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1253 @@
+{
+  "id": "fa73bbc4-9aa1-45c3-bc11-40af855cbceb",
+  "prevId": "20af176a-a235-42de-8331-fa25c95ee8fe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.butterfly_species": {
+      "name": "butterfly_species",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scientific_name": {
+          "name": "scientific_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name": {
+          "name": "common_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_family": {
+          "name": "sub_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifespan_days": {
+          "name": "lifespan_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range": {
+          "name": "range",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_plant": {
+          "name": "host_plant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "habitat": {
+          "name": "habitat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fun_facts": {
+          "name": "fun_facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "img_wings_open": {
+          "name": "img_wings_open",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "img_wings_closed": {
+          "name": "img_wings_closed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_img_1": {
+          "name": "extra_img_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_img_2": {
+          "name": "extra_img_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "butterfly_species_scientific_name_unique": {
+          "name": "butterfly_species_scientific_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scientific_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.butterfly_species_institution": {
+      "name": "butterfly_species_institution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "butterfly_species_id": {
+          "name": "butterfly_species_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name_override": {
+          "name": "common_name_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifespan_override": {
+          "name": "lifespan_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_institution_species": {
+          "name": "unique_institution_species",
+          "columns": [
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bsi_institution_id": {
+          "name": "idx_bsi_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "butterfly_species_institution_butterfly_species_id_butterfly_species_id_fk": {
+          "name": "butterfly_species_institution_butterfly_species_id_butterfly_species_id_fk",
+          "tableFrom": "butterfly_species_institution",
+          "tableTo": "butterfly_species",
+          "columnsFrom": [
+            "butterfly_species_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "butterfly_species_institution_institution_id_institutions_id_fk": {
+          "name": "butterfly_species_institution_institution_id_institutions_id_fk",
+          "tableFrom": "butterfly_species_institution",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_flight": {
+      "name": "in_flight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_event_id": {
+          "name": "release_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_item_id": {
+          "name": "shipment_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_in_flight_shipment_item": {
+          "name": "unique_in_flight_shipment_item",
+          "columns": [
+            {
+              "expression": "release_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_flight_institution_shipment_item": {
+          "name": "idx_in_flight_institution_shipment_item",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_flight_institution_id_institutions_id_fk": {
+          "name": "in_flight_institution_id_institutions_id_fk",
+          "tableFrom": "in_flight",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_in_flight_event_institution": {
+          "name": "fk_in_flight_event_institution",
+          "tableFrom": "in_flight",
+          "tableTo": "release_events",
+          "columnsFrom": [
+            "institution_id",
+            "release_event_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_in_flight_shipment_item_institution": {
+          "name": "fk_in_flight_shipment_item_institution",
+          "tableFrom": "in_flight",
+          "tableTo": "shipment_items",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_item_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institution_news": {
+      "name": "institution_news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_institution_news_institution_id": {
+          "name": "idx_institution_news_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "institution_news_institution_id_institutions_id_fk": {
+          "name": "institution_news_institution_id_institutions_id_fk",
+          "tableFrom": "institution_news",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street_address": {
+          "name": "street_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extended_address": {
+          "name": "extended_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_province": {
+          "name": "state_province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iabes_member": {
+          "name": "iabes_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_colors": {
+          "name": "theme_colors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_image_url": {
+          "name": "facility_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_active": {
+          "name": "stats_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_slug_unique": {
+          "name": "institutions_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "institutions_email_address_unique": {
+          "name": "institutions_email_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.release_events": {
+      "name": "release_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_by": {
+          "name": "released_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "release_events_institution_id_institutions_id_fk": {
+          "name": "release_events_institution_id_institutions_id_fk",
+          "tableFrom": "release_events",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_release_events_shipment_institution": {
+          "name": "fk_release_events_shipment_institution",
+          "tableFrom": "release_events",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_release_event_id_per_institution": {
+          "name": "unique_release_event_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipment_items": {
+      "name": "shipment_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "butterfly_species_id": {
+          "name": "butterfly_species_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_received": {
+          "name": "number_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emerged_in_transit": {
+          "name": "emerged_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "damaged_in_transit": {
+          "name": "damaged_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "diseased_in_transit": {
+          "name": "diseased_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parasite": {
+          "name": "parasite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "non_emergence": {
+          "name": "non_emergence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "poor_emergence": {
+          "name": "poor_emergence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_shipment_species": {
+          "name": "unique_shipment_species",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipment_items_institution_species": {
+          "name": "idx_shipment_items_institution_species",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_items_institution_id_institutions_id_fk": {
+          "name": "shipment_items_institution_id_institutions_id_fk",
+          "tableFrom": "shipment_items",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shipment_items_butterfly_species_id_butterfly_species_id_fk": {
+          "name": "shipment_items_butterfly_species_id_butterfly_species_id_fk",
+          "tableFrom": "shipment_items",
+          "tableTo": "butterfly_species",
+          "columnsFrom": [
+            "butterfly_species_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fk_shipment_items_shipment_institution": {
+          "name": "fk_shipment_items_shipment_institution",
+          "tableFrom": "shipment_items",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_shipment_item_id_per_institution": {
+          "name": "unique_shipment_item_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipments": {
+      "name": "shipments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_date": {
+          "name": "shipment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrival_date": {
+          "name": "arrival_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shipments_institution_id_institutions_id_fk": {
+          "name": "shipments_institution_id_institutions_id_fk",
+          "tableFrom": "shipments",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_shipments_supplier_code": {
+          "name": "fk_shipments_supplier_code",
+          "tableFrom": "shipments",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "institution_id",
+            "supplier_code"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "code"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_shipment_id_per_institution": {
+          "name": "unique_shipment_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "suppliers_institution_id_institutions_id_fk": {
+          "name": "suppliers_institution_id_institutions_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_supplier_per_institution": {
+          "name": "unique_supplier_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "code"
+          ]
+        },
+        "unique_supplier_id_per_institution": {
+          "name": "unique_supplier_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_institution_id": {
+          "name": "idx_users_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_institution_id_institutions_id_fk": {
+          "name": "users_institution_id_institutions_id_fk",
+          "tableFrom": "users",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1775749109390,
+      "tag": "0000_next_darwin",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1775749264952,
+      "tag": "0001_icy_hedge_knight",
+      "breakpoints": true
+    }
+  ]
+}

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -21,18 +21,20 @@ import masterSpeciesData from "./data/master_butterfly_list.json";
 import newsData from "./data/institution_news.json";
 import institutionData from "./data/institution.json";
 import type { SpeciesFunFact } from "../src/types/butterfly";
+import { sanitizeText } from "../src/lib/validation/sanitize";
 
 type MasterSpeciesRecord = (typeof masterSpeciesData)[number];
 const DEFAULT_FUN_FACT_TITLE = "Fun Fact";
 
 function legacyFunFactsToStructured(funFacts: string | null | undefined): SpeciesFunFact[] | null {
   if (funFacts == null) return null;
-  if (funFacts.trim() === "") return null;
+  const sanitizedFunFacts = sanitizeText(funFacts);
+  if (sanitizedFunFacts === "") return null;
 
   return [
     {
       title: DEFAULT_FUN_FACT_TITLE,
-      fact: funFacts,
+      fact: sanitizedFunFacts,
     },
   ];
 }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -20,8 +20,22 @@ import suppliersData from "./data/suppliers.json";
 import masterSpeciesData from "./data/master_butterfly_list.json";
 import newsData from "./data/institution_news.json";
 import institutionData from "./data/institution.json";
+import type { SpeciesFunFact } from "../src/types/butterfly";
 
 type MasterSpeciesRecord = (typeof masterSpeciesData)[number];
+const DEFAULT_FUN_FACT_TITLE = "Fun Fact";
+
+function legacyFunFactsToStructured(funFacts: string | null | undefined): SpeciesFunFact[] | null {
+  if (funFacts == null) return null;
+  if (funFacts.trim() === "") return null;
+
+  return [
+    {
+      title: DEFAULT_FUN_FACT_TITLE,
+      fact: funFacts,
+    },
+  ];
+}
 
 async function main() {
   console.log("Starting seed...");
@@ -76,7 +90,7 @@ async function main() {
     range: species.range,
     host_plant: species.plant ?? null,
     habitat: species.habitat ?? null,
-    fun_facts: species.funFacts ?? null,
+    fun_facts: legacyFunFactsToStructured(species.funFacts),
     img_wings_open: species.imgWingsOpen ?? null,
     img_wings_closed: species.imgWingsClosed ?? null,
     extra_img_1: species.extraImg1 ?? null,

--- a/src/__test__/api/platform/species.route.test.ts
+++ b/src/__test__/api/platform/species.route.test.ts
@@ -73,7 +73,7 @@ function validCreatePayload() {
     description: "A striking yellow butterfly species",
     host_plant: "Willow",
     habitat: "Woodlands",
-    fun_facts: "Mimics toxic butterflies",
+    fun_facts: [{ title: "Fun Fact", fact: "Mimics toxic butterflies" }],
     img_wings_open: "https://example.com/open.jpg",
     img_wings_closed: "https://example.com/closed.jpg",
   };
@@ -141,6 +141,18 @@ describe("Platform Species API", () => {
 
     it("returns 400 for invalid request body", async () => {
       const response = (await postSpecies(makePostRequest({ scientific_name: "Only one field" })))!;
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.code).toBe("INVALID_REQUEST");
+    });
+
+    it("returns 400 when fun_facts uses the legacy string shape", async () => {
+      const response = (await postSpecies(
+        makePostRequest({
+          ...validCreatePayload(),
+          fun_facts: "Mimics toxic butterflies",
+        }),
+      ))!;
+
       expect(response.status).toBe(400);
       expect((await response.json()).error.code).toBe("INVALID_REQUEST");
     });

--- a/src/__test__/api/platform/species.route.test.ts
+++ b/src/__test__/api/platform/species.route.test.ts
@@ -289,6 +289,26 @@ describe("Platform Species API", () => {
       );
     });
 
+    it("allows clearing fun_facts with null", async () => {
+      mockUpdatePlatformSpecies.mockResolvedValueOnce({
+        id: 10,
+        scientificName: "Papilio glaucus",
+        commonName: "Eastern Tiger Swallowtail",
+        fun_facts: null,
+      });
+
+      const response = (await patchSpeciesById(
+        makePatchRequest("10", { fun_facts: null }),
+        routeContext("10"),
+      ))!;
+      expect(response.status).toBe(200);
+
+      expect(mockUpdatePlatformSpecies).toHaveBeenCalledWith(
+        10,
+        expect.objectContaining({ fun_facts: null }),
+      );
+    });
+
     it("returns 409 when scientific_name conflicts", async () => {
       mockUpdatePlatformSpecies.mockRejectedValueOnce(new Error("CONFLICT"));
 

--- a/src/components/public/species/species-accordion-sections.tsx
+++ b/src/components/public/species/species-accordion-sections.tsx
@@ -7,14 +7,18 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import type { SpeciesFunFact } from "@/types/butterfly";
 
 interface SpeciesAccordionSectionsProps {
   hostPlant: string | null;
-  funFacts: string | null;
+  funFacts: SpeciesFunFact[] | null;
 }
 
 export function SpeciesAccordionSections({ hostPlant, funFacts }: SpeciesAccordionSectionsProps) {
-  if (!hostPlant && !funFacts) return null;
+  const structuredFunFacts = funFacts ?? [];
+  const hasFunFacts = structuredFunFacts.length > 0;
+
+  if (!hostPlant && !hasFunFacts) return null;
 
   return (
     <Accordion type="multiple" className="w-full">
@@ -32,7 +36,7 @@ export function SpeciesAccordionSections({ hostPlant, funFacts }: SpeciesAccordi
         </AccordionItem>
       )}
 
-      {funFacts && (
+      {hasFunFacts && (
         <AccordionItem value="fun-facts">
           <AccordionTrigger>
             <span className="flex items-center gap-2">
@@ -41,11 +45,12 @@ export function SpeciesAccordionSections({ hostPlant, funFacts }: SpeciesAccordi
             </span>
           </AccordionTrigger>
           <AccordionContent>
-            <div className="space-y-2">
-              {funFacts.split(/\n\n+/).map((paragraph, i) => (
-                <p key={i} className="text-muted-foreground text-sm leading-relaxed">
-                  {paragraph}
-                </p>
+            <div className="space-y-4">
+              {structuredFunFacts.map((funFact, index) => (
+                <div key={`${funFact.title}-${index}`} className="space-y-1">
+                  <h3 className="text-sm font-medium">{funFact.title}</h3>
+                  <p className="text-muted-foreground text-sm leading-relaxed">{funFact.fact}</p>
+                </div>
               ))}
             </div>
           </AccordionContent>

--- a/src/lib/queries/species-detail.ts
+++ b/src/lib/queries/species-detail.ts
@@ -4,6 +4,7 @@ import { eq, and, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { butterfly_species, butterfly_species_institution } from "@/lib/schema";
 import { inFlightCountSubquery } from "@/lib/queries/subqueries";
+import type { SpeciesFunFact } from "@/types/butterfly";
 
 export interface SpeciesDetail {
   id: number;
@@ -16,7 +17,7 @@ export interface SpeciesDetail {
   description: string | null;
   host_plant: string | null;
   habitat: string | null;
-  fun_facts: string | null;
+  fun_facts: SpeciesFunFact[] | null;
   img_wings_open: string | null;
   img_wings_closed: string | null;
   extra_img_1: string | null;

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -11,6 +11,7 @@ import {
   foreignKey,
   unique,
 } from "drizzle-orm/pg-core";
+import type { SpeciesFunFact } from "@/types/butterfly";
 
 /**
  * Flutr V2 Schema
@@ -168,7 +169,7 @@ export const butterfly_species = pgTable("butterfly_species", {
 
   host_plant: text("host_plant"),
   habitat: text("habitat"),
-  fun_facts: text("fun_facts"),
+  fun_facts: jsonb("fun_facts").$type<SpeciesFunFact[]>(),
 
   img_wings_open: text("img_wings_open"),
   img_wings_closed: text("img_wings_closed"),

--- a/src/lib/validation/species.ts
+++ b/src/lib/validation/species.ts
@@ -2,6 +2,13 @@ import { z } from "zod";
 
 import { sanitizeText, sanitizedNonEmpty } from "@/lib/validation/sanitize";
 
+const speciesFunFactSchema = z
+  .object({
+    title: sanitizedNonEmpty(120),
+    fact: sanitizedNonEmpty(5000),
+  })
+  .strict();
+
 /**
  * Route param validation
  */
@@ -39,11 +46,7 @@ export const createSpeciesBodySchema = z
       .max(500)
       .transform((v) => sanitizeText(v))
       .optional(),
-    fun_facts: z
-      .string()
-      .max(5000)
-      .transform((v) => sanitizeText(v))
-      .optional(),
+    fun_facts: z.array(speciesFunFactSchema).min(1).optional(),
     img_wings_open: z
       .string()
       .trim()

--- a/src/lib/validation/species.ts
+++ b/src/lib/validation/species.ts
@@ -9,6 +9,8 @@ const speciesFunFactSchema = z
   })
   .strict();
 
+const speciesFunFactsArraySchema = z.array(speciesFunFactSchema).min(1);
+
 /**
  * Route param validation
  */
@@ -46,7 +48,7 @@ export const createSpeciesBodySchema = z
       .max(500)
       .transform((v) => sanitizeText(v))
       .optional(),
-    fun_facts: z.array(speciesFunFactSchema).min(1).optional(),
+    fun_facts: speciesFunFactsArraySchema.optional(),
     img_wings_open: z
       .string()
       .trim()
@@ -81,8 +83,55 @@ export type CreateSpeciesBody = z.infer<typeof createSpeciesBodySchema>;
  *
  * Prevent empty PATCH bodies.
  */
-export const updateSpeciesBodySchema = createSpeciesBodySchema
-  .partial()
+export const updateSpeciesBodySchema = z
+  .object({
+    scientific_name: sanitizedNonEmpty(200).optional(),
+    common_name: sanitizedNonEmpty(200).optional(),
+    family: sanitizedNonEmpty(200).optional(),
+    sub_family: sanitizedNonEmpty(200).optional(),
+    lifespan_days: z.coerce.number().int().positive().optional(),
+    range: z.array(sanitizedNonEmpty(200)).min(1).optional(),
+    description: z
+      .string()
+      .max(5000)
+      .transform((v) => sanitizeText(v))
+      .optional(),
+    host_plant: z
+      .string()
+      .max(500)
+      .transform((v) => sanitizeText(v))
+      .optional(),
+    habitat: z
+      .string()
+      .max(500)
+      .transform((v) => sanitizeText(v))
+      .optional(),
+    fun_facts: speciesFunFactsArraySchema.nullable().optional(),
+    img_wings_open: z
+      .string()
+      .trim()
+      .url()
+      .transform((v) => sanitizeText(v))
+      .optional(),
+    img_wings_closed: z
+      .string()
+      .trim()
+      .url()
+      .transform((v) => sanitizeText(v))
+      .optional(),
+    extra_img_1: z
+      .string()
+      .trim()
+      .url()
+      .transform((v) => sanitizeText(v))
+      .optional(),
+    extra_img_2: z
+      .string()
+      .trim()
+      .url()
+      .transform((v) => sanitizeText(v))
+      .optional(),
+  })
   .strict()
   .superRefine((data, ctx) => {
     if (Object.keys(data).length === 0) {

--- a/src/types/butterfly.ts
+++ b/src/types/butterfly.ts
@@ -1,0 +1,4 @@
+export interface SpeciesFunFact {
+  title: string;
+  fact: string;
+}


### PR DESCRIPTION
## Summary

Add a clean Drizzle migration history and convert `butterfly_species.fun_facts` from a legacy text blob to structured `jsonb`.

This PR establishes the migration baseline, updates the seed path, and aligns the platform species API/public species detail contract with the new structured fun-facts shape.

## Why

This change is intended to unblock PR #76, which depends on `fun_facts` being stored and returned as structured data rather than a single text blob.

## Changes

- add Drizzle baseline migration `0000`
- add follow-up `0001` migration for `butterfly_species.fun_facts`
- manually backfill legacy `fun_facts` text during migration:
  - `NULL -> NULL`
  - blank/whitespace text -> `NULL`
  - non-empty text -> `[{ "title": "Fun Fact", "fact": original_text }]`
- change `butterfly_species.fun_facts` schema type to `jsonb`
- update seed flow to write structured fun facts from legacy source JSON
- add shared `SpeciesFunFact` type
- update species validation to accept `fun_facts` as an array of `{ title, fact }`
- update species detail typing and current public rendering path to consume structured fun facts safely
- update API docs for platform species create/update and public species detail
- document fresh local DB reset flow using `pnpm db:migrate`

## API Contract

Platform create/update species now accepts:

```json
"fun_facts": [
  { "title": "Fun Fact", "fact": "Adults can glide for long distances." }
]
```

Public species detail now returns `fun_facts` in that same structured shape.

`PATCH /api/platform/species/[id]` replaces the full `fun_facts` array.

## Local Reset / Migration Flow

Because the team agreed to rebuild local dev DBs from scratch, the recommended flow for this PR is:

```bash
git pull
docker compose down -v
docker compose up -d
pnpm db:migrate
pnpm seed
```

## Test Plan

- `pnpm test -- --runTestsByPath src/lib/__test__/schema.test.ts src/__test__/api/platform/species.route.test.ts`
- ran fresh local validation flow successfully before PRing:
  - rebuild DB
  - migrate from `0000` + `0001`
  - reseed
- verified build passes

## Related

- Unblocks #76
- Related to #42