### PR TITLE
feat(shipments): release composer, in-flight tracking, and shipment status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,7 @@ src/
 │   │   ├── (tenant)/       # Protected tenant admin routes (sidebar + header + footer shell)
 │   │   │   ├── dashboard/  # Admin dashboard
 │   │   │   ├── organization/ # Institution organization management
-│   │   │   ├── shipments/  # Shipment tracking (list + add)
-│   │   │   └── releases/   # Butterfly release events
+│   │   │   └── shipments/  # Shipment list, detail (force-edit + release history), add, create release (shipments/[id]/release/new), edit release (shipments/[id]/release/[releaseId]/edit)
 │   │   └── (public)/       # Public-facing routes
 │   │       ├── gallery/    # Butterfly species gallery
 │   │       ├── stats/      # Institution statistics
@@ -54,10 +53,13 @@ src/
 │   │   └── detail/     # Institution detail tab components (DangerZone, FileDropZone, ImportResultsPanel, ShipmentViewer)
 │   │   ├── species/        # SpeciesTable, SpeciesGalleryCard, toolbar, row, utils
 │   │   └── suppliers/      # SuppliersTable, toolbar, row, utils
+│   ├── tenant/             # Tenant-facing feature components
+│   │   ├── shipments/      # SpeciesPickerDialog, ShipmentItemsTable, ShipmentStatusBadge, SupplierSelect, types
+│   │   └── releases/       # ReleaseComposer, ReleaseCategoryComposer, ReleaseQuantityControls
 │   ├── nav/                # Public navigation components (top-nav, mobile-nav, footer)
 │   ├── providers/          # Context providers (session, institution data, theme)
 │   ├── public/             # Public-facing components (gallery, home, species detail)
-│   ├── shared/             # Shared components used across public/admin (theme toggle, back button, nav card)
+│   ├── shared/             # Shared components used across public/admin (theme toggle, back button, nav card, DatePicker, species search toolbar)
 │   └── ui/                 # 55 Shadcn/UI primitives
 ├── hooks/                  # Custom React hooks
 │   ├── use-institution.ts  # Institution slug/basePath from URL params
@@ -167,6 +169,12 @@ Detailed documentation lives in `docs/`:
 | Schema                | `* from @/lib/schema`                                                                                                                       | All table definitions (institutions, users, species, etc.)                                                                                                                                     |
 | Auth                  | `auth` from `@/auth`                                                                                                                        | NextAuth session helper                                                                                                                                                                        |
 | Link (no prefetch)    | `Link` from `@/components/ui/link`                                                                                                          | Next.js Link without scroll-prefetch (hover/focus only). Used for large lists to reduce requests                                                                                               |
+| Date picker           | `DatePicker` from `@/components/shared/date-picker`                                                                                         | Popover + calendar that stores its value as a `YYYY-MM-DD` string; supports `minDate` / `maxDate` bounds and `aria-invalid` / `aria-describedby`                                               |
+| Supplier select       | `SupplierSelect` from `@/components/tenant/shipments/supplier-select`                                                                       | Tenant-scoped supplier combobox used by the shipment add/edit forms                                                                                                                            |
+| Shipment status badge | `ShipmentStatusBadge` from `@/components/tenant/shipments/shipment-status-badge`                                                            | Standard pill rendering for "In flight" / "Completed" shipment status                                                                                                                          |
+| Shipment items table  | `ShipmentItemsTable` from `@/components/tenant/shipments/shipment-items-table`                                                              | Read-only + inline-editable species table wrapped in the shared search toolbar; enforces per-metric min/max client-side                                                                        |
+| Species picker dialog | `SpeciesPickerDialog` from `@/components/tenant/shipments/species-picker-dialog`                                                            | Multi-select species picker backed by `useSpeciesSearch`; used by shipment add/edit                                                                                                            |
+| Remaining helper      | `computeItemRemaining` from `@/components/tenant/shipments/types`                                                                           | Mirrors the DB `calculateRemaining` formula so client caps match the server                                                                                                                    |
 
 ## Workflow Rules
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -106,6 +106,7 @@ All tenant routes use `x-tenant-slug` for tenant context:
 - `GET/PATCH/DELETE /api/tenant/shipments/[id]` — shipment detail, update, delete
 - `GET /api/tenant/species` — list tenant-visible species with applied overrides
 - `PATCH /api/tenant/species/[id]` — upsert tenant override fields for a species
+- `GET /api/tenant/releases` — list paginated release events for the institution
 - `POST /api/tenant/shipments/[id]/releases` — create release event with multiple shipment items
 - `POST /api/tenant/releases/[releaseId]/in-flight` — add one in-flight row to an existing release event
 - `PATCH/DELETE /api/tenant/in-flight/[id]` — update or remove an in-flight row
@@ -262,6 +263,41 @@ Returns `200 OK` with `{ "deleted": true }` when the shipment has no dependencie
 
 Returns `404 NOT_FOUND` if the shipment does not exist.
 
+### Tenant releases list contract
+
+`GET /api/tenant/releases` supports pagination with query params (mirrors the
+shipments list shape):
+
+- `page` (number, default `1`)
+- `limit` (number, default `50`, max `200`)
+
+Response shape:
+
+```json
+{
+  "releases": [
+    {
+      "id": 9,
+      "shipmentId": 55,
+      "supplierCode": "SUP-1",
+      "shipmentDate": "2026-03-01T00:00:00.000Z",
+      "releaseDate": "2026-03-13T00:00:00.000Z",
+      "releasedBy": "Alice",
+      "totalReleased": 25
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "limit": 50,
+    "total": 1,
+    "totalPages": 1
+  }
+}
+```
+
+Returns `400 INVALID_REQUEST` for non-numeric `page` / `limit` values or
+`limit` > 200.
+
 ### Tenant release detail contract
 
 `GET /api/tenant/releases/[releaseId]`, `PATCH /api/tenant/releases/[releaseId]`, and
@@ -384,6 +420,7 @@ All tenant routes use the `x-tenant-slug` header for tenant context. Missing hea
 | `/tenant/shipments`                      | GET, POST          | `x-tenant-slug` header |
 | `/tenant/shipments/[id]`                 | GET, PATCH, DELETE | `x-tenant-slug` header |
 | `/tenant/shipments/[id]/releases`        | GET, POST          | `x-tenant-slug` header |
+| `/tenant/releases`                       | GET                | `x-tenant-slug` header |
 | `/tenant/releases/[releaseId]`           | GET, PATCH, DELETE | `x-tenant-slug` header |
 | `/tenant/releases/[releaseId]/in-flight` | POST               | `x-tenant-slug` header |
 | `/tenant/in-flight/[id]`                 | PATCH, DELETE      | `x-tenant-slug` header |

--- a/src/__test__/api/tenant/releases.route.test.ts
+++ b/src/__test__/api/tenant/releases.route.test.ts
@@ -22,7 +22,10 @@ jest.mock("@/lib/services/tenant-releases", () => ({
     IN_FLIGHT_ALREADY_EXISTS: "In-flight row already exists for this release item",
     SHIPMENT_ITEM_RELEASE_MISMATCH: "Shipment item does not belong to the release shipment",
     QUANTITY_EXCEEDS_REMAINING: "Quantity exceeds remaining available butterflies",
+    RELEASE_ITEMS_MUST_MATCH:
+      "Release update must include every existing in-flight row for the release event",
   },
+  getTenantReleases: jest.fn(),
   getTenantReleaseById: jest.fn(),
   updateTenantRelease: jest.fn(),
   deleteTenantRelease: jest.fn(),
@@ -37,6 +40,7 @@ import {
   createTenantReleaseInFlight,
   deleteTenantRelease,
   getTenantReleaseById,
+  getTenantReleases,
   RELEASE_ERRORS as TENANT_RELEASE_ERRORS,
   updateTenantRelease,
 } from "@/lib/services/tenant-releases";
@@ -48,8 +52,10 @@ import {
   GET as getReleaseById,
   PATCH as patchReleaseById,
 } from "@/app/api/tenant/releases/[releaseId]/route";
+import { GET as getReleasesList } from "@/app/api/tenant/releases/route";
 
 const mockCreateTenantRelease = createTenantRelease as jest.Mock;
+const mockGetTenantReleases = getTenantReleases as jest.Mock;
 const mockGetTenantReleaseById = getTenantReleaseById as jest.Mock;
 const mockUpdateTenantRelease = updateTenantRelease as jest.Mock;
 const mockDeleteTenantRelease = deleteTenantRelease as jest.Mock;
@@ -108,6 +114,14 @@ function makeReleasePatchRequest(releaseId: string, body: Record<string, unknown
   });
 }
 
+function makeReleasesListRequest(slug?: string, query?: Record<string, string>) {
+  const headers: Record<string, string> = {};
+  if (slug) headers["x-tenant-slug"] = slug;
+  const search = new URLSearchParams(query ?? {});
+  const url = `http://localhost/api/tenant/releases${search.size ? `?${search.toString()}` : ""}`;
+  return new NextRequest(url, { headers });
+}
+
 function shipmentRouteContext(id: string) {
   return { params: Promise.resolve({ id }) };
 }
@@ -145,6 +159,87 @@ function validReleasePatchPayload() {
 describe("Tenant Releases API", () => {
   beforeEach(() => {
     jest.resetAllMocks();
+  });
+
+  describe("GET /api/tenant/releases", () => {
+    it("returns 400 when x-tenant-slug header is missing", async () => {
+      const response = (await getReleasesList(makeReleasesListRequest()))!;
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.code).toBe("INVALID_REQUEST");
+    });
+
+    it("returns 401 for unauthenticated requests", async () => {
+      mockGetTenantReleases.mockRejectedValueOnce(new Error("UNAUTHORIZED"));
+      const response = (await getReleasesList(makeReleasesListRequest(SLUG)))!;
+      expect(response.status).toBe(401);
+      expect((await response.json()).error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 403 when permission check fails", async () => {
+      mockGetTenantReleases.mockRejectedValueOnce(new Error("FORBIDDEN"));
+      const response = (await getReleasesList(makeReleasesListRequest(SLUG)))!;
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.code).toBe("FORBIDDEN");
+    });
+
+    it("returns 404 when tenant slug cannot be resolved", async () => {
+      mockGetTenantReleases.mockRejectedValueOnce(new Error("NOT_FOUND"));
+      const response = (await getReleasesList(makeReleasesListRequest(SLUG)))!;
+      expect(response.status).toBe(404);
+      expect((await response.json()).error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 200 with the institution releases list", async () => {
+      mockGetTenantReleases.mockResolvedValueOnce({
+        releases: [
+          {
+            id: 9,
+            shipmentId: 55,
+            supplierCode: "SUP-1",
+            shipmentDate: "2026-03-01",
+            releaseDate: "2026-03-13",
+            releasedBy: "Alice",
+            totalReleased: 25,
+          },
+        ],
+        pagination: { page: 1, limit: 50, total: 1, totalPages: 1 },
+      });
+
+      const response = (await getReleasesList(makeReleasesListRequest(SLUG)))!;
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(Array.isArray(body.releases)).toBe(true);
+      expect(body.releases).toHaveLength(1);
+      expect(body.releases[0].id).toBe(9);
+      expect(body.pagination).toEqual({ page: 1, limit: 50, total: 1, totalPages: 1 });
+      expect(mockGetTenantReleases).toHaveBeenCalledWith({ slug: SLUG, page: 1, limit: 50 });
+    });
+
+    it("forwards page and limit query params to the service", async () => {
+      mockGetTenantReleases.mockResolvedValueOnce({
+        releases: [],
+        pagination: { page: 3, limit: 25, total: 0, totalPages: 1 },
+      });
+
+      const response = (await getReleasesList(
+        makeReleasesListRequest(SLUG, { page: "3", limit: "25" }),
+      ))!;
+      expect(response.status).toBe(200);
+      expect(mockGetTenantReleases).toHaveBeenCalledWith({ slug: SLUG, page: 3, limit: 25 });
+    });
+
+    it("returns 400 for non-numeric pagination params", async () => {
+      const response = (await getReleasesList(makeReleasesListRequest(SLUG, { page: "abc" })))!;
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.code).toBe("INVALID_REQUEST");
+    });
+
+    it("returns 400 when limit exceeds the cap", async () => {
+      const response = (await getReleasesList(makeReleasesListRequest(SLUG, { limit: "9999" })))!;
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.code).toBe("INVALID_REQUEST");
+    });
   });
 
   describe("POST /api/tenant/shipments/[id]/releases", () => {
@@ -630,6 +725,19 @@ describe("Tenant Releases API", () => {
     it("returns 400 for duplicate shipment_item_id values", async () => {
       mockUpdateTenantRelease.mockRejectedValueOnce(
         new Error(TENANT_RELEASE_ERRORS.DUPLICATE_SHIPMENT_ITEM),
+      );
+
+      const response = (await patchReleaseById(
+        makeReleasePatchRequest("500", validReleasePatchPayload(), SLUG),
+        releaseRouteContext("500"),
+      ))!;
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.code).toBe("INVALID_REQUEST");
+    });
+
+    it("returns 400 when payload omits an existing release in-flight row", async () => {
+      mockUpdateTenantRelease.mockRejectedValueOnce(
+        new Error(TENANT_RELEASE_ERRORS.RELEASE_ITEMS_MUST_MATCH),
       );
 
       const response = (await patchReleaseById(

--- a/src/__test__/api/tenant/shipments.route.test.ts
+++ b/src/__test__/api/tenant/shipments.route.test.ts
@@ -189,7 +189,7 @@ describe("Shipments API", () => {
       expect((await response.json()).error.code).toBe("INVALID_REQUEST");
     });
 
-    it("returns 200 with paginated shipments list", async () => {
+    it("returns 200 with paginated shipments list including completion status", async () => {
       mockGetTenantShipments.mockResolvedValueOnce({
         shipments: [
           {
@@ -198,9 +198,20 @@ describe("Shipments API", () => {
             shipmentDate: "2026-01-10",
             arrivalDate: "2026-01-11",
             createdAt: "2026-01-12T00:00:00.000Z",
+            remaining: 12,
+            isCompleted: false,
+          },
+          {
+            id: 2,
+            supplierCode: "SUP-2",
+            shipmentDate: "2026-01-08",
+            arrivalDate: "2026-01-09",
+            createdAt: "2026-01-09T00:00:00.000Z",
+            remaining: 0,
+            isCompleted: true,
           },
         ],
-        pagination: { page: 1, limit: 50, total: 1, totalPages: 1 },
+        pagination: { page: 1, limit: 50, total: 2, totalPages: 1 },
       });
 
       const response = (await getShipments(makeListRequest({}, SLUG)))!;
@@ -208,7 +219,9 @@ describe("Shipments API", () => {
 
       const body = await response.json();
       expect(Array.isArray(body.shipments)).toBe(true);
-      expect(body.shipments).toHaveLength(1);
+      expect(body.shipments).toHaveLength(2);
+      expect(body.shipments[0]).toMatchObject({ remaining: 12, isCompleted: false });
+      expect(body.shipments[1]).toMatchObject({ remaining: 0, isCompleted: true });
       expect(mockGetTenantShipments).toHaveBeenCalledWith({ slug: SLUG, page: 1, limit: 50 });
     });
 

--- a/src/__test__/compute-item-remaining.test.ts
+++ b/src/__test__/compute-item-remaining.test.ts
@@ -1,0 +1,79 @@
+import { computeItemRemaining, type ShipmentItemRow } from "@/components/tenant/shipments/types";
+
+function makeItem(overrides: Partial<ShipmentItemRow> = {}): ShipmentItemRow {
+  return {
+    id: 1,
+    butterflySpeciesId: 100,
+    scientificName: "Danaus plexippus",
+    commonName: "Monarch",
+    imageOpen: null,
+    imageClosed: null,
+    numberReceived: 0,
+    emergedInTransit: 0,
+    damagedInTransit: 0,
+    diseasedInTransit: 0,
+    parasite: 0,
+    nonEmergence: 0,
+    poorEmergence: 0,
+    inFlightQuantity: 0,
+    ...overrides,
+  };
+}
+
+describe("computeItemRemaining", () => {
+  it("returns received minus losses minus in_flight in the normal case", () => {
+    const item = makeItem({
+      numberReceived: 50,
+      damagedInTransit: 2,
+      diseasedInTransit: 1,
+      parasite: 1,
+      nonEmergence: 3,
+      poorEmergence: 1,
+      inFlightQuantity: 10,
+    });
+    // 50 - (2+1+1+3+1) - 10 = 32
+    expect(computeItemRemaining(item)).toBe(32);
+  });
+
+  it("returns 0 when everything has been released", () => {
+    const item = makeItem({ numberReceived: 20, inFlightQuantity: 20 });
+    expect(computeItemRemaining(item)).toBe(0);
+  });
+
+  it("returns 0 (clamped) when losses + released exceed received", () => {
+    // Defensive: bad data shouldn't yield a negative remaining count that
+    // would confuse downstream UI math.
+    const item = makeItem({
+      numberReceived: 10,
+      damagedInTransit: 5,
+      diseasedInTransit: 5,
+      inFlightQuantity: 5,
+    });
+    expect(computeItemRemaining(item)).toBe(0);
+  });
+
+  it("returns 0 for an all-zero item", () => {
+    expect(computeItemRemaining(makeItem())).toBe(0);
+  });
+
+  it("ignores emergedInTransit (it is informational, not a loss)", () => {
+    // emerged_in_transit is a status indicator, not a deduction. The release
+    // formula must not subtract it or we'd undercount remaining inventory.
+    const item = makeItem({ numberReceived: 30, emergedInTransit: 12 });
+    expect(computeItemRemaining(item)).toBe(30);
+  });
+
+  it("treats every loss column equally", () => {
+    const lossColumns: Array<keyof ShipmentItemRow> = [
+      "damagedInTransit",
+      "diseasedInTransit",
+      "parasite",
+      "nonEmergence",
+      "poorEmergence",
+    ];
+    for (const column of lossColumns) {
+      const item = makeItem({ numberReceived: 10, [column]: 4 });
+      expect(computeItemRemaining(item)).toBe(6);
+    }
+  });
+});

--- a/src/__test__/middleware.test.ts
+++ b/src/__test__/middleware.test.ts
@@ -41,9 +41,7 @@ describe("middleware", () => {
     });
 
     it("matches actual admin route segments", () => {
-      expect(config.matcher[0]).toBe(
-        "/:institution/(dashboard|organization|shipments|releases)/:path*",
-      );
+      expect(config.matcher[0]).toBe("/:institution/(dashboard|organization|shipments)/:path*");
     });
   });
 
@@ -101,22 +99,6 @@ describe("middleware", () => {
     const response = await middleware(makeRequest("/monarch-house/dashboard"));
 
     expect(response.headers.get("location")).toContain("/unauthorized");
-  });
-
-  it("allows EMPLOYEE users on releases route (has VIEW_RELEASES)", async () => {
-    mockGetToken.mockResolvedValue(makeToken("EMPLOYEE", "monarch-house"));
-
-    const response = await middleware(makeRequest("/monarch-house/releases"));
-
-    expect(response.headers.get("location")).toBeNull();
-  });
-
-  it("allows ADMIN users on releases route", async () => {
-    mockGetToken.mockResolvedValue(makeToken("ADMIN", "monarch-house"));
-
-    const response = await middleware(makeRequest("/monarch-house/releases"));
-
-    expect(response.headers.get("location")).toBeNull();
   });
 
   it("allows SUPERUSER across institutions", async () => {

--- a/src/app/[institution]/(tenant)/dashboard/page.tsx
+++ b/src/app/[institution]/(tenant)/dashboard/page.tsx
@@ -1,4 +1,4 @@
-import { Building2, Package, Rocket } from "lucide-react";
+import { Building2, Package } from "lucide-react";
 
 import NavCard from "@/components/shared/nav-card";
 import { ROUTES } from "@/lib/routes";
@@ -19,7 +19,7 @@ export default async function DashboardPage({
         </p>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <NavCard
           href={ROUTES.tenant.organization(institution)}
           title="Organization"
@@ -30,15 +30,8 @@ export default async function DashboardPage({
         <NavCard
           href={ROUTES.tenant.shipments(institution)}
           title="Shipments"
-          description="Track and manage butterfly shipments"
+          description="Track shipments and record releases"
           icon={Package}
-        />
-
-        <NavCard
-          href={ROUTES.tenant.releases(institution)}
-          title="Releases"
-          description="Record and view butterfly release events"
-          icon={Rocket}
         />
       </div>
     </div>

--- a/src/app/[institution]/(tenant)/releases/page.tsx
+++ b/src/app/[institution]/(tenant)/releases/page.tsx
@@ -1,3 +1,0 @@
-export default function ReleasesPage() {
-  return <h1>Releases</h1>;
-}

--- a/src/app/[institution]/(tenant)/shipments/[id]/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/[id]/page.tsx
@@ -1,0 +1,2022 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Image from "next/image";
+import { useParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+type ShipmentHeader = {
+  id: number;
+  supplierCode: string;
+  shipmentDate: string;
+  arrivalDate: string;
+  createdAt: string;
+};
+
+type ShipmentItem = {
+  id: number;
+  butterflySpeciesId: number;
+  scientificName: string;
+  commonName?: string | null;
+  imageUrl?: string | null;
+  imageOpen?: string | null;
+  imageClosed?: string | null;
+  numberReceived: number;
+  emergedInTransit: number;
+  damagedInTransit: number;
+  diseasedInTransit: number;
+  parasite: number;
+  nonEmergence: number;
+  poorEmergence: number;
+  inFlightQuantity: number;
+};
+
+type ShipmentDetailResponse = {
+  shipment: ShipmentHeader;
+  items: ShipmentItem[];
+  releaseEvents?: Array<{
+    id?: number;
+    releaseId?: number;
+    release_date?: string;
+    releaseDate?: string;
+  }>;
+  releases?: Array<{
+    id?: number;
+    releaseId?: number;
+    release_date?: string;
+    releaseDate?: string;
+  }>;
+  inFlight?: Array<{ releaseEventId?: number; release_event_id?: number }>;
+};
+
+type ShipmentMetricField =
+  | "numberReceived"
+  | "emergedInTransit"
+  | "damagedInTransit"
+  | "diseasedInTransit"
+  | "parasite"
+  | "nonEmergence"
+  | "poorEmergence";
+
+type ReleaseDraft = {
+  goodEmergence: number;
+  poorEmergence: number;
+};
+
+type ReleaseEventItem = {
+  inFlightId: number | null;
+  shipmentItemId: number;
+  quantity: number;
+  goodEmergence: number;
+  poorEmergence: number;
+};
+
+type ReleaseEventDetail = {
+  id: number;
+  releaseDate: string;
+  items: ReleaseEventItem[];
+};
+
+type ReleaseEditorRow = {
+  inFlightId: number | null;
+  shipmentItemId: number;
+  goodEmergence: number;
+  poorEmergence: number;
+};
+
+type SpeciesOption = {
+  butterflySpeciesId: number;
+  scientificName: string;
+  commonName: string;
+  imageUrl?: string | null;
+  imageOpen?: string | null;
+  imageClosed?: string | null;
+};
+
+const formatDateTime = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return "-";
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+};
+
+const getRemaining = (item: ShipmentItem) => {
+  return (
+    item.numberReceived -
+    item.emergedInTransit -
+    item.damagedInTransit -
+    item.diseasedInTransit -
+    item.parasite -
+    item.nonEmergence -
+    item.poorEmergence -
+    item.inFlightQuantity
+  );
+};
+
+const getAvailableToRelease = (item: ShipmentItem) => {
+  return Math.max(0, getRemaining(item));
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== "object") return null;
+  return value as Record<string, unknown>;
+};
+
+const toNonNegativeInt = (value: unknown) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(0, Math.trunc(parsed));
+};
+
+const toPositiveInt = (value: unknown) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  const normalized = Math.trunc(parsed);
+  return normalized > 0 ? normalized : null;
+};
+
+const getShipmentItemImageUrl = (item: ShipmentItem) => {
+  return item.imageUrl ?? item.imageOpen ?? item.imageClosed ?? null;
+};
+
+const resolveCommonName = (commonName: string | null | undefined, scientificName: string) => {
+  if (typeof commonName !== "string") return scientificName;
+  const normalized = commonName.trim();
+  return normalized.length > 0 ? normalized : scientificName;
+};
+
+const uniquePositiveIds = (ids: Array<number | null>) => {
+  return Array.from(
+    new Set(
+      ids.filter((id): id is number => typeof id === "number" && Number.isInteger(id) && id > 0),
+    ),
+  );
+};
+
+type CreatedInFlightRow = {
+  inFlightId: number;
+  shipmentItemId: number;
+  quantity: number;
+};
+
+const extractCreatedInFlightRowsFromCreateResponse = (payload: unknown) => {
+  const root = asRecord(payload);
+  if (!root) return [] as CreatedInFlightRow[];
+
+  const release = asRecord(root.release);
+  const rows = Array.isArray(release?.items)
+    ? release.items
+    : Array.isArray(root.items)
+      ? root.items
+      : [];
+
+  return rows
+    .map((row) => {
+      const item = asRecord(row);
+      if (!item) return null;
+
+      const inFlightId = toPositiveInt(item.id);
+      const shipmentItemId =
+        toPositiveInt(item.shipmentItemId) ?? toPositiveInt(item.shipment_item_id);
+      const quantity = toNonNegativeInt(item.quantity);
+
+      if (!inFlightId || !shipmentItemId) return null;
+
+      return {
+        inFlightId,
+        shipmentItemId,
+        quantity,
+      } satisfies CreatedInFlightRow;
+    })
+    .filter((row): row is CreatedInFlightRow => row !== null);
+};
+
+const normalizeReleaseEvent = (payload: unknown, fallbackId: number): ReleaseEventDetail | null => {
+  const root = asRecord(payload);
+  if (!root) return null;
+
+  const event = asRecord(root.event) ?? asRecord(root.releaseEvent) ?? root;
+  const id = toPositiveInt(event.id) ?? toPositiveInt(root.releaseId) ?? fallbackId;
+
+  if (!id) return null;
+
+  const releaseDateValue =
+    event.releaseDate ?? event.release_date ?? root.releaseDate ?? root.release_date;
+
+  const releaseDate =
+    typeof releaseDateValue === "string" && releaseDateValue.length > 0
+      ? releaseDateValue
+      : new Date().toISOString();
+
+  const rows = Array.isArray(root.items) ? root.items : [];
+
+  const items: ReleaseEventItem[] = rows
+    .map((row) => {
+      const item = asRecord(row);
+      if (!item) return null;
+
+      const shipmentItemId =
+        toPositiveInt(item.shipmentItemId) ?? toPositiveInt(item.shipment_item_id);
+      if (!shipmentItemId) return null;
+
+      const quantity = toNonNegativeInt(item.quantity);
+      const goodEmergence = toNonNegativeInt(
+        item.goodEmergence ?? item.good_emergence ?? item.quantity,
+      );
+      const poorEmergence = toNonNegativeInt(item.poorEmergence ?? item.poor_emergence);
+      const inFlightId = toPositiveInt(item.id);
+
+      return {
+        inFlightId,
+        shipmentItemId,
+        quantity,
+        goodEmergence,
+        poorEmergence,
+      };
+    })
+    .filter((item): item is ReleaseEventItem => item !== null);
+
+  return {
+    id,
+    releaseDate,
+    items,
+  };
+};
+
+const readErrorMessage = async (response: Response, fallback: string) => {
+  try {
+    const payload = await response.json();
+    const root = asRecord(payload);
+    const nestedError = root ? asRecord(root.error) : null;
+
+    if (nestedError && typeof nestedError.message === "string" && nestedError.message.length > 0) {
+      return nestedError.message;
+    }
+
+    if (root && typeof root.message === "string" && root.message.length > 0) {
+      return root.message;
+    }
+  } catch {
+    return fallback;
+  }
+
+  return fallback;
+};
+
+function QuantityStepper({
+  value,
+  onDecrement,
+  onIncrement,
+  decrementLabel,
+  incrementLabel,
+  disabled,
+}: {
+  value: number;
+  onDecrement: () => void;
+  onIncrement: () => void;
+  decrementLabel: string;
+  incrementLabel: string;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        className="h-7 w-7 p-0 text-xs"
+        onClick={onDecrement}
+        disabled={disabled}
+        aria-label={decrementLabel}
+      >
+        -
+      </Button>
+      <span className="min-w-6 text-center text-xs font-medium">{value}</span>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        className="h-7 w-7 p-0 text-xs"
+        onClick={onIncrement}
+        disabled={disabled}
+        aria-label={incrementLabel}
+      >
+        +
+      </Button>
+    </div>
+  );
+}
+
+export default function ShipmentDetailPage() {
+  const params = useParams<{ institution: string; id: string }>();
+  const rawInstitutionSlug = params?.institution ?? "";
+  const institutionSlug = Array.isArray(rawInstitutionSlug)
+    ? (rawInstitutionSlug[0] ?? "")
+    : rawInstitutionSlug;
+  const rawShipmentId = params?.id ?? "";
+  const shipmentId = Array.isArray(rawShipmentId) ? rawShipmentId[0] : rawShipmentId;
+  const shipmentIdNumber = Number(shipmentId);
+  const [activeTab, setActiveTab] = useState<"items" | "releases" | "inflight">("items");
+
+  const [detail, setDetail] = useState<ShipmentDetailResponse | null>(null);
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const [saveItemsStatus, setSaveItemsStatus] = useState<"idle" | "saving" | "success" | "error">(
+    "idle",
+  );
+  const [saveItemsMessage, setSaveItemsMessage] = useState<string | null>(null);
+
+  const [releaseDrafts, setReleaseDrafts] = useState<Record<number, ReleaseDraft>>({});
+  const [releaseStatus, setReleaseStatus] = useState<"idle" | "saving" | "success" | "error">(
+    "idle",
+  );
+  const [releaseMessage, setReleaseMessage] = useState<string | null>(null);
+
+  const [releaseEvents, setReleaseEvents] = useState<ReleaseEventDetail[]>([]);
+  const [releaseHistoryStatus, setReleaseHistoryStatus] = useState<"idle" | "loading" | "error">(
+    "idle",
+  );
+  const [releaseHistoryMessage, setReleaseHistoryMessage] = useState<string | null>(null);
+
+  const [editingReleaseId, setEditingReleaseId] = useState<number | null>(null);
+  const [editingRows, setEditingRows] = useState<ReleaseEditorRow[]>([]);
+  const [editingDeleteInFlightIds, setEditingDeleteInFlightIds] = useState<number[]>([]);
+  const [editReleaseStatus, setEditReleaseStatus] = useState<
+    "idle" | "saving" | "success" | "error"
+  >("idle");
+  const [editReleaseMessage, setEditReleaseMessage] = useState<string | null>(null);
+
+  const [inFlightEdits, setInFlightEdits] = useState<Record<number, number>>({});
+  const [inFlightStatus, setInFlightStatus] = useState<"idle" | "saving" | "success" | "error">(
+    "idle",
+  );
+  const [inFlightMessage, setInFlightMessage] = useState<string | null>(null);
+  const [deletedItemIds, setDeletedItemIds] = useState<number[]>([]);
+  const [nextTempItemId, setNextTempItemId] = useState(-1);
+  const [speciesOptions, setSpeciesOptions] = useState<SpeciesOption[]>([]);
+  const [nameDisplayMode, setNameDisplayMode] = useState<"scientific" | "common">("scientific");
+
+  const tenantHeaders = useMemo(() => ({ "x-tenant-slug": institutionSlug }), [institutionSlug]);
+
+  const fetchDetail = useCallback(async () => {
+    const response = await fetch(`/api/tenant/shipments/${shipmentIdNumber}`, {
+      headers: tenantHeaders,
+    });
+    if (!response.ok) {
+      throw new Error(await readErrorMessage(response, "Unable to load shipment"));
+    }
+
+    const data = await response.json();
+    return data as ShipmentDetailResponse;
+  }, [shipmentIdNumber, tenantHeaders]);
+
+  const loadSpeciesOptions = useCallback(async () => {
+    try {
+      const response = await fetch("/api/tenant/species", {
+        headers: tenantHeaders,
+      });
+      if (!response.ok) return;
+
+      const payload = await response.json();
+      const root = asRecord(payload);
+      const rows = Array.isArray(root?.species) ? root.species : [];
+
+      const parsed = rows
+        .map((row): SpeciesOption | null => {
+          const item = asRecord(row);
+          if (!item) return null;
+
+          const id = toPositiveInt(item.id);
+          const scientificName =
+            typeof item.scientificName === "string" ? item.scientificName.trim() : "";
+
+          if (!id || scientificName.length === 0) return null;
+
+          const commonNameOverride =
+            typeof item.commonNameOverride === "string" ? item.commonNameOverride : null;
+          const commonNameBase = typeof item.commonName === "string" ? item.commonName : null;
+
+          return {
+            butterflySpeciesId: id,
+            scientificName,
+            commonName: resolveCommonName(commonNameOverride ?? commonNameBase, scientificName),
+            imageOpen:
+              typeof item.imgWingsOpen === "string" && item.imgWingsOpen.length > 0
+                ? item.imgWingsOpen
+                : null,
+            imageClosed:
+              typeof item.imgWingsClosed === "string" && item.imgWingsClosed.length > 0
+                ? item.imgWingsClosed
+                : null,
+            imageUrl:
+              typeof item.imgWingsOpen === "string" && item.imgWingsOpen.length > 0
+                ? item.imgWingsOpen
+                : typeof item.imgWingsClosed === "string" && item.imgWingsClosed.length > 0
+                  ? item.imgWingsClosed
+                  : null,
+          };
+        })
+        .filter((item): item is SpeciesOption => item !== null);
+
+      if (parsed.length > 0) {
+        setSpeciesOptions(parsed);
+      }
+    } catch {
+      // Keep existing fallback behavior from shipment-detail rows.
+    }
+  }, [tenantHeaders]);
+
+  const loadDetail = useCallback(async () => {
+    setStatus("loading");
+    setErrorMessage(null);
+
+    try {
+      const data = await fetchDetail();
+      setDetail(data);
+
+      const releaseDraftMap: Record<number, ReleaseDraft> = {};
+      data.items.forEach((item) => {
+        releaseDraftMap[item.id] = {
+          goodEmergence: 0,
+          poorEmergence: 0,
+        };
+      });
+      setReleaseDrafts(releaseDraftMap);
+
+      setDeletedItemIds([]);
+      setNextTempItemId(-1);
+
+      setStatus("idle");
+      return data;
+    } catch (error) {
+      setStatus("error");
+      setErrorMessage(error instanceof Error ? error.message : "Unable to load shipment");
+      return null;
+    }
+  }, [fetchDetail]);
+
+  useEffect(() => {
+    if (!institutionSlug) {
+      setStatus("error");
+      setErrorMessage("Missing institution slug");
+      return;
+    }
+
+    if (!Number.isFinite(shipmentIdNumber) || shipmentIdNumber <= 0) {
+      setStatus("error");
+      setErrorMessage("Invalid shipment id");
+      return;
+    }
+
+    void loadDetail();
+    void loadSpeciesOptions();
+  }, [institutionSlug, loadDetail, loadSpeciesOptions, shipmentIdNumber]);
+
+  const releaseRouteUrl = useCallback(
+    (releaseId: number) => `/api/tenant/releases/${releaseId}`,
+    [],
+  );
+
+  const fetchReleases = useCallback(async () => {
+    setReleaseHistoryStatus("loading");
+    setReleaseHistoryMessage(null);
+
+    try {
+      const listRes = await fetch(`/api/tenant/shipments/${shipmentIdNumber}/releases`, {
+        headers: tenantHeaders,
+      });
+      if (!listRes.ok) {
+        throw new Error(await readErrorMessage(listRes, "Failed to load releases"));
+      }
+
+      const listData = await listRes.json();
+      const releaseIds: number[] = (
+        Array.isArray(listData?.releaseEvents) ? listData.releaseEvents : []
+      )
+        .map((e: unknown) => toPositiveInt(asRecord(e)?.id))
+        .filter((id: number | null): id is number => id !== null);
+
+      if (releaseIds.length === 0) {
+        setReleaseEvents([]);
+        setReleaseHistoryStatus("idle");
+        setReleaseHistoryMessage(null);
+        return;
+      }
+
+      const responses = await Promise.all(
+        releaseIds.map(async (releaseId) => {
+          const response = await fetch(releaseRouteUrl(releaseId), {
+            headers: tenantHeaders,
+          });
+          if (!response.ok) {
+            throw new Error(
+              await readErrorMessage(response, `Failed to load release ${releaseId}`),
+            );
+          }
+
+          const payload = await response.json();
+          return normalizeReleaseEvent(payload, releaseId);
+        }),
+      );
+
+      const normalized = responses
+        .filter((event): event is ReleaseEventDetail => event !== null)
+        .sort((a, b) => new Date(b.releaseDate).valueOf() - new Date(a.releaseDate).valueOf());
+
+      setReleaseEvents(normalized);
+      setReleaseHistoryStatus("idle");
+    } catch (error) {
+      setReleaseHistoryStatus("error");
+      setReleaseHistoryMessage(
+        error instanceof Error ? error.message : "Failed to load release history",
+      );
+    }
+  }, [shipmentIdNumber, releaseRouteUrl, tenantHeaders]);
+
+  useEffect(() => {
+    if (!Number.isFinite(shipmentIdNumber) || shipmentIdNumber <= 0) return;
+    void fetchReleases();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shipmentIdNumber]);
+
+  const fallbackSpeciesOptions = useMemo(() => {
+    if (!detail) return [];
+
+    const map = new Map<number, SpeciesOption>();
+
+    detail.items.forEach((item) => {
+      if (!map.has(item.butterflySpeciesId)) {
+        map.set(item.butterflySpeciesId, {
+          butterflySpeciesId: item.butterflySpeciesId,
+          scientificName: item.scientificName,
+          commonName: resolveCommonName(item.commonName, item.scientificName),
+          imageUrl: item.imageUrl,
+          imageOpen: item.imageOpen,
+          imageClosed: item.imageClosed,
+        });
+      }
+    });
+
+    return Array.from(map.values());
+  }, [detail]);
+
+  const availableSpeciesOptions = useMemo(() => {
+    if (speciesOptions.length > 0) return speciesOptions;
+    return fallbackSpeciesOptions;
+  }, [fallbackSpeciesOptions, speciesOptions]);
+
+  const getDisplayName = useCallback(
+    (entry: { scientificName: string; commonName?: string | null }) => {
+      if (nameDisplayMode === "common") {
+        return resolveCommonName(entry.commonName, entry.scientificName);
+      }
+
+      return entry.scientificName;
+    },
+    [nameDisplayMode],
+  );
+
+  const updateItemSpecies = (itemId: number, butterflySpeciesId: number) => {
+    const selectedSpecies = availableSpeciesOptions.find(
+      (option) => option.butterflySpeciesId === butterflySpeciesId,
+    );
+    if (!selectedSpecies) return;
+
+    setDetail((prev) => {
+      if (!prev) return prev;
+
+      return {
+        ...prev,
+        items: prev.items.map((item) => {
+          if (item.id !== itemId) return item;
+
+          return {
+            ...item,
+            butterflySpeciesId: selectedSpecies.butterflySpeciesId,
+            scientificName: selectedSpecies.scientificName,
+            commonName: selectedSpecies.commonName,
+            imageUrl: selectedSpecies.imageUrl,
+            imageOpen: selectedSpecies.imageOpen,
+            imageClosed: selectedSpecies.imageClosed,
+          };
+        }),
+      };
+    });
+  };
+
+  const handleAddShipmentItem = () => {
+    if (!detail || availableSpeciesOptions.length === 0) return;
+
+    const selectedSpecies = availableSpeciesOptions[0];
+    const tempId = nextTempItemId;
+
+    setDetail((prev) => {
+      if (!prev) return prev;
+
+      return {
+        ...prev,
+        items: [
+          ...prev.items,
+          {
+            id: tempId,
+            butterflySpeciesId: selectedSpecies.butterflySpeciesId,
+            scientificName: selectedSpecies.scientificName,
+            commonName: selectedSpecies.commonName,
+            imageUrl: selectedSpecies.imageUrl,
+            imageOpen: selectedSpecies.imageOpen,
+            imageClosed: selectedSpecies.imageClosed,
+            numberReceived: 0,
+            emergedInTransit: 0,
+            damagedInTransit: 0,
+            diseasedInTransit: 0,
+            parasite: 0,
+            nonEmergence: 0,
+            poorEmergence: 0,
+            inFlightQuantity: 0,
+          },
+        ],
+      };
+    });
+
+    setNextTempItemId((prev) => prev - 1);
+  };
+
+  const handleDeleteShipmentItem = (itemId: number) => {
+    setDetail((prev) => {
+      if (!prev) return prev;
+
+      return {
+        ...prev,
+        items: prev.items.filter((item) => item.id !== itemId),
+      };
+    });
+
+    setReleaseDrafts((prev) => {
+      const next = { ...prev };
+      delete next[itemId];
+      return next;
+    });
+
+    if (itemId > 0) {
+      setDeletedItemIds((prev) => Array.from(new Set([...prev, itemId])));
+    }
+  };
+
+  const syncAfterMutation = useCallback(async () => {
+    await loadDetail();
+    await fetchReleases();
+  }, [loadDetail, fetchReleases]);
+
+  const updateMetric = (itemId: number, field: ShipmentMetricField, delta: number) => {
+    setDetail((prev) => {
+      if (!prev) return prev;
+
+      return {
+        ...prev,
+        items: prev.items.map((item) => {
+          if (item.id !== itemId) return item;
+
+          const nextValue = Math.max(0, item[field] + delta);
+          return {
+            ...item,
+            [field]: nextValue,
+          };
+        }),
+      };
+    });
+  };
+
+  const handleSaveShipmentItems = async () => {
+    if (!detail) return;
+
+    setSaveItemsStatus("saving");
+    setSaveItemsMessage(null);
+
+    try {
+      const persistedItems = detail.items.filter((item) => item.id > 0);
+      const newItems = detail.items.filter((item) => item.id <= 0);
+
+      const payload: {
+        update_items?: Array<{
+          id: number;
+          number_received: number;
+          emerged_in_transit: number;
+          damaged_in_transit: number;
+          diseased_in_transit: number;
+          parasite: number;
+          non_emergence: number;
+          poor_emergence: number;
+        }>;
+        add_items?: Array<{
+          butterfly_species_id: number;
+          number_received: number;
+          emerged_in_transit: number;
+          damaged_in_transit: number;
+          diseased_in_transit: number;
+          parasite: number;
+          non_emergence: number;
+          poor_emergence: number;
+        }>;
+        delete_items?: number[];
+      } = {};
+
+      if (persistedItems.length > 0) {
+        payload.update_items = persistedItems.map((item) => ({
+          id: item.id,
+          number_received: item.numberReceived,
+          emerged_in_transit: item.emergedInTransit,
+          damaged_in_transit: item.damagedInTransit,
+          diseased_in_transit: item.diseasedInTransit,
+          parasite: item.parasite,
+          non_emergence: item.nonEmergence,
+          poor_emergence: item.poorEmergence,
+        }));
+      }
+
+      if (newItems.length > 0) {
+        payload.add_items = newItems.map((item) => ({
+          butterfly_species_id: item.butterflySpeciesId,
+          number_received: item.numberReceived,
+          emerged_in_transit: item.emergedInTransit,
+          damaged_in_transit: item.damagedInTransit,
+          diseased_in_transit: item.diseasedInTransit,
+          parasite: item.parasite,
+          non_emergence: item.nonEmergence,
+          poor_emergence: item.poorEmergence,
+        }));
+      }
+
+      const normalizedDeleteItemIds = uniquePositiveIds(deletedItemIds);
+
+      if (normalizedDeleteItemIds.length > 0) {
+        payload.delete_items = normalizedDeleteItemIds;
+      }
+
+      if (!payload.update_items && !payload.add_items && !payload.delete_items) {
+        setSaveItemsStatus("success");
+        setSaveItemsMessage("No shipment item changes to save");
+        return;
+      }
+
+      console.log("Saving shipment PATCH payload", payload);
+
+      const response = await fetch(`/api/tenant/shipments/${shipmentIdNumber}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", ...tenantHeaders },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, "Failed to update shipment metrics"));
+      }
+
+      setDeletedItemIds([]);
+      setNextTempItemId(-1);
+
+      await syncAfterMutation();
+
+      setSaveItemsStatus("success");
+      setSaveItemsMessage("Shipment metrics updated");
+    } catch (error) {
+      setSaveItemsStatus("error");
+      setSaveItemsMessage(
+        error instanceof Error ? error.message : "Failed to update shipment metrics",
+      );
+    }
+  };
+
+  const releaseRows = useMemo(() => {
+    if (!detail) return [];
+
+    return detail.items
+      .filter((item) => item.id > 0)
+      .map((item) => {
+        const draft = releaseDrafts[item.id] ?? { goodEmergence: 0, poorEmergence: 0 };
+        return {
+          item,
+          available: getAvailableToRelease(item),
+          draft,
+        };
+      });
+  }, [detail, releaseDrafts]);
+
+  const shipmentItemById = useMemo(() => {
+    return new Map((detail?.items ?? []).map((item) => [item.id, item] as const));
+  }, [detail]);
+
+  const releaseSelections = useMemo(() => {
+    return releaseRows
+      .map((row) => ({
+        shipment_item_id: row.item.id,
+        quantity: row.draft.goodEmergence + row.draft.poorEmergence,
+      }))
+      .filter((row) => row.quantity > 0);
+  }, [releaseRows]);
+
+  const goodEmergenceByShipmentItemId = useMemo(() => {
+    return new Map(releaseRows.map((row) => [row.item.id, row.draft.goodEmergence] as const));
+  }, [releaseRows]);
+
+  const poorEmergenceSelections = useMemo(() => {
+    return releaseRows
+      .map((row) => ({
+        shipmentItemId: row.item.id,
+        poorEmergence: row.draft.poorEmergence,
+      }))
+      .filter((row) => row.poorEmergence > 0);
+  }, [releaseRows]);
+
+  const hasReleaseDraftValues = useMemo(() => {
+    return releaseRows.some((row) => row.draft.goodEmergence + row.draft.poorEmergence > 0);
+  }, [releaseRows]);
+
+  const updateReleaseDraft = (
+    itemId: number,
+    field: keyof ReleaseDraft,
+    delta: number,
+    available: number,
+  ) => {
+    setReleaseDrafts((prev) => {
+      const current = prev[itemId] ?? { goodEmergence: 0, poorEmergence: 0 };
+      const otherField: keyof ReleaseDraft =
+        field === "goodEmergence" ? "poorEmergence" : "goodEmergence";
+      const rawNextValue = Math.max(0, current[field] + delta);
+      const maxAllowed = Math.max(0, available - current[otherField]);
+
+      return {
+        ...prev,
+        [itemId]: {
+          ...current,
+          [field]: Math.min(rawNextValue, maxAllowed),
+        },
+      };
+    });
+  };
+
+  const handleCreateRelease = async () => {
+    if (!detail) return;
+    if (!hasReleaseDraftValues) return;
+
+    setReleaseStatus("saving");
+    setReleaseMessage(null);
+
+    try {
+      let createdRelease = false;
+      let normalizedInFlightToGoodOnly = false;
+      let updatedPoorEmergenceMetrics = false;
+
+      if (releaseSelections.length > 0) {
+        const response = await fetch(`/api/tenant/shipments/${shipmentIdNumber}/releases`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", ...tenantHeaders },
+          body: JSON.stringify({
+            items: releaseSelections,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(await readErrorMessage(response, "Failed to create release"));
+        }
+
+        const payload = await response.json();
+        const createdInFlightRows = extractCreatedInFlightRowsFromCreateResponse(payload);
+
+        for (const createdRow of createdInFlightRows) {
+          const goodEmergenceTarget =
+            goodEmergenceByShipmentItemId.get(createdRow.shipmentItemId) ?? 0;
+
+          if (goodEmergenceTarget <= 0) {
+            const deleteResponse = await fetch(`/api/tenant/in-flight/${createdRow.inFlightId}`, {
+              method: "DELETE",
+              headers: tenantHeaders,
+            });
+
+            if (!deleteResponse.ok) {
+              throw new Error(
+                await readErrorMessage(deleteResponse, "Failed to normalize in-flight rows"),
+              );
+            }
+
+            normalizedInFlightToGoodOnly = true;
+            continue;
+          }
+
+          if (goodEmergenceTarget !== createdRow.quantity) {
+            const patchResponse = await fetch(`/api/tenant/in-flight/${createdRow.inFlightId}`, {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json", ...tenantHeaders },
+              body: JSON.stringify({ quantity: goodEmergenceTarget }),
+            });
+
+            if (!patchResponse.ok) {
+              throw new Error(
+                await readErrorMessage(patchResponse, "Failed to normalize in-flight rows"),
+              );
+            }
+
+            normalizedInFlightToGoodOnly = true;
+          }
+        }
+
+        createdRelease = true;
+      }
+
+      if (poorEmergenceSelections.length > 0) {
+        const updateItems = poorEmergenceSelections
+          .map((selection) => {
+            const item = detail.items.find(
+              (shipmentItem) => shipmentItem.id === selection.shipmentItemId,
+            );
+            if (!item || item.id <= 0) return null;
+
+            return {
+              id: item.id,
+              number_received: item.numberReceived,
+              emerged_in_transit: item.emergedInTransit,
+              damaged_in_transit: item.damagedInTransit,
+              diseased_in_transit: item.diseasedInTransit,
+              parasite: item.parasite,
+              non_emergence: item.nonEmergence,
+              poor_emergence: item.poorEmergence + selection.poorEmergence,
+            };
+          })
+          .filter(
+            (
+              item,
+            ): item is {
+              id: number;
+              number_received: number;
+              emerged_in_transit: number;
+              damaged_in_transit: number;
+              diseased_in_transit: number;
+              parasite: number;
+              non_emergence: number;
+              poor_emergence: number;
+            } => item !== null,
+          );
+
+        if (updateItems.length > 0) {
+          const metricsResponse = await fetch(`/api/tenant/shipments/${shipmentIdNumber}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json", ...tenantHeaders },
+            body: JSON.stringify({
+              update_items: updateItems,
+            }),
+          });
+
+          if (!metricsResponse.ok) {
+            throw new Error(
+              await readErrorMessage(metricsResponse, "Failed to update poor emergence metrics"),
+            );
+          }
+
+          updatedPoorEmergenceMetrics = true;
+        }
+      }
+
+      await syncAfterMutation();
+
+      setReleaseDrafts((prev) => {
+        const next: Record<number, ReleaseDraft> = {};
+        Object.keys(prev).forEach((key) => {
+          const parsed = Number(key);
+          if (Number.isFinite(parsed) && parsed > 0) {
+            next[parsed] = { goodEmergence: 0, poorEmergence: 0 };
+          }
+        });
+        return next;
+      });
+
+      setReleaseStatus("success");
+      if (createdRelease && normalizedInFlightToGoodOnly && updatedPoorEmergenceMetrics) {
+        setReleaseMessage(
+          "Release created, in-flight normalized, and poor emergence metrics updated",
+        );
+      } else if (createdRelease && normalizedInFlightToGoodOnly) {
+        setReleaseMessage("Release created and in-flight normalized to good emergence");
+      } else if (createdRelease && updatedPoorEmergenceMetrics) {
+        setReleaseMessage("Release created and poor emergence metrics updated");
+      } else if (createdRelease) {
+        setReleaseMessage("Release created");
+      } else if (updatedPoorEmergenceMetrics) {
+        setReleaseMessage("Poor emergence metrics updated");
+      } else {
+        setReleaseMessage("No release changes to create");
+      }
+    } catch (error) {
+      setReleaseStatus("error");
+      setReleaseMessage(error instanceof Error ? error.message : "Failed to create release");
+    }
+  };
+
+  const releaseEventRows = useMemo(() => {
+    return [...releaseEvents].sort(
+      (a, b) => new Date(b.releaseDate).valueOf() - new Date(a.releaseDate).valueOf(),
+    );
+  }, [releaseEvents]);
+
+  const releaseInFlightByShipmentItemId = useMemo(() => {
+    const map = new Map<number, { inFlightId: number; quantity: number }>();
+
+    releaseEvents.forEach((event) => {
+      event.items.forEach((item) => {
+        if (!item.inFlightId) return;
+
+        const existing = map.get(item.shipmentItemId);
+        if (!existing || item.inFlightId > existing.inFlightId) {
+          map.set(item.shipmentItemId, {
+            inFlightId: item.inFlightId,
+            quantity: item.quantity,
+          });
+        }
+      });
+    });
+
+    return map;
+  }, [releaseEvents]);
+
+  useEffect(() => {
+    const next: Record<number, number> = {};
+
+    releaseInFlightByShipmentItemId.forEach((row) => {
+      next[row.inFlightId] = row.quantity;
+    });
+
+    setInFlightEdits(next);
+  }, [releaseInFlightByShipmentItemId]);
+
+  const handleDeleteRelease = async (releaseId: number) => {
+    setReleaseStatus("saving");
+    setReleaseMessage(null);
+
+    try {
+      const response = await fetch(releaseRouteUrl(releaseId), {
+        method: "DELETE",
+        headers: tenantHeaders,
+      });
+
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, "Failed to delete release"));
+      }
+      setReleaseEvents((prev) => prev.filter((event) => event.id !== releaseId));
+
+      if (editingReleaseId === releaseId) {
+        setEditingReleaseId(null);
+        setEditingRows([]);
+        setEditingDeleteInFlightIds([]);
+      }
+
+      await syncAfterMutation();
+
+      setReleaseStatus("success");
+      setReleaseMessage("Release deleted");
+    } catch (error) {
+      setReleaseStatus("error");
+      setReleaseMessage(error instanceof Error ? error.message : "Failed to delete release");
+    }
+  };
+
+  const startReleaseEditing = (releaseId: number) => {
+    const release = releaseEvents.find((event) => event.id === releaseId);
+    if (!release) return;
+
+    setEditingReleaseId(release.id);
+    setEditingDeleteInFlightIds([]);
+    setEditingRows(
+      release.items.map((item) => ({
+        inFlightId: item.inFlightId,
+        shipmentItemId: item.shipmentItemId,
+        goodEmergence: item.goodEmergence,
+        poorEmergence: item.poorEmergence,
+      })),
+    );
+
+    setEditReleaseStatus("idle");
+    setEditReleaseMessage(null);
+  };
+
+  const updateEditingRowMetric = (
+    rowIndex: number,
+    field: "goodEmergence" | "poorEmergence",
+    delta: number,
+  ) => {
+    setEditingRows((prev) =>
+      prev.map((row, index) => {
+        if (index !== rowIndex) return row;
+        return {
+          ...row,
+          [field]: Math.max(0, row[field] + delta),
+        };
+      }),
+    );
+  };
+
+  const updateEditingRowSpecies = (rowIndex: number, shipmentItemId: number) => {
+    setEditingRows((prev) =>
+      prev.map((row, index) => {
+        if (index !== rowIndex) return row;
+        return {
+          ...row,
+          shipmentItemId,
+        };
+      }),
+    );
+  };
+
+  const addEditingRow = () => {
+    if (!detail) return;
+
+    const availableRows = detail.items.filter((item) => item.id > 0);
+    if (availableRows.length === 0) return;
+
+    setEditingRows((prev) => {
+      const used = new Set(prev.map((row) => row.shipmentItemId));
+      const nextSpecies = availableRows.find((item) => !used.has(item.id)) ?? availableRows[0];
+
+      return [
+        ...prev,
+        {
+          inFlightId: null,
+          shipmentItemId: nextSpecies.id,
+          goodEmergence: 0,
+          poorEmergence: 0,
+        },
+      ];
+    });
+  };
+
+  const removeEditingRow = (rowIndex: number, inFlightId: number | null) => {
+    if (inFlightId) {
+      setEditingDeleteInFlightIds((prev) => uniquePositiveIds([...prev, inFlightId]));
+    }
+
+    setEditingRows((prev) => prev.filter((_, index) => index !== rowIndex));
+  };
+
+  const handleSaveReleaseEdit = async () => {
+    if (!editingReleaseId) return;
+
+    const rowsWithQuantity = editingRows
+      .map((row) => ({
+        inFlightId: row.inFlightId,
+        shipment_item_id: row.shipmentItemId,
+        quantity: row.goodEmergence + row.poorEmergence,
+      }))
+      .filter((row) => row.quantity > 0);
+
+    const updateItems = rowsWithQuantity
+      .filter((row) => row.inFlightId)
+      .map((row) => ({
+        shipment_item_id: row.shipment_item_id,
+        quantity: row.quantity,
+      }));
+
+    const addItems = rowsWithQuantity
+      .filter((row) => !row.inFlightId)
+      .map((row) => ({
+        shipment_item_id: row.shipment_item_id,
+        quantity: row.quantity,
+      }));
+
+    const deleteIdsFromZeroQuantityRows = editingRows
+      .filter((row) => row.inFlightId && row.goodEmergence + row.poorEmergence <= 0)
+      .map((row) => row.inFlightId);
+
+    const deleteInFlightIds = uniquePositiveIds([
+      ...editingDeleteInFlightIds,
+      ...deleteIdsFromZeroQuantityRows,
+    ]);
+
+    if (updateItems.length === 0 && addItems.length === 0 && deleteInFlightIds.length === 0) {
+      setEditReleaseStatus("success");
+      setEditReleaseMessage("No release changes to save");
+      return;
+    }
+
+    setEditReleaseStatus("saving");
+    setEditReleaseMessage(null);
+
+    try {
+      for (const inFlightId of deleteInFlightIds) {
+        const response = await fetch(`/api/tenant/in-flight/${inFlightId}`, {
+          method: "DELETE",
+          headers: tenantHeaders,
+        });
+
+        if (!response.ok) {
+          throw new Error(await readErrorMessage(response, "Failed to remove release row"));
+        }
+      }
+
+      if (updateItems.length > 0) {
+        const response = await fetch(releaseRouteUrl(editingReleaseId), {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json", ...tenantHeaders },
+          body: JSON.stringify({ items: updateItems }),
+        });
+
+        if (!response.ok) {
+          throw new Error(await readErrorMessage(response, "Failed to update release"));
+        }
+      }
+
+      for (const item of addItems) {
+        const response = await fetch(`/api/tenant/releases/${editingReleaseId}/in-flight`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", ...tenantHeaders },
+          body: JSON.stringify(item),
+        });
+
+        if (!response.ok) {
+          throw new Error(await readErrorMessage(response, "Failed to add release row"));
+        }
+      }
+
+      await syncAfterMutation();
+      setEditingDeleteInFlightIds([]);
+
+      setEditReleaseStatus("success");
+      setEditReleaseMessage("Release updated");
+    } catch (error) {
+      setEditReleaseStatus("error");
+      setEditReleaseMessage(error instanceof Error ? error.message : "Failed to update release");
+    }
+  };
+
+  const inFlightItems = useMemo(() => {
+    if (!detail) return [];
+    return detail.items.filter((item) => item.inFlightQuantity > 0);
+  }, [detail]);
+
+  const updateInFlightEdit = (inFlightId: number, delta: number, fallbackValue: number) => {
+    setInFlightEdits((prev) => {
+      const current = prev[inFlightId] ?? fallbackValue;
+      return {
+        ...prev,
+        [inFlightId]: Math.max(1, current + delta),
+      };
+    });
+  };
+
+  const handleUpdateInFlight = async (shipmentItemId: number, fallbackValue: number) => {
+    const releaseRow = releaseInFlightByShipmentItemId.get(shipmentItemId);
+    if (!releaseRow) return;
+
+    const quantity = Math.max(1, inFlightEdits[releaseRow.inFlightId] ?? fallbackValue);
+
+    setInFlightStatus("saving");
+    setInFlightMessage(null);
+
+    try {
+      const response = await fetch(`/api/tenant/in-flight/${releaseRow.inFlightId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", ...tenantHeaders },
+        body: JSON.stringify({ quantity }),
+      });
+
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, "Failed to update in-flight quantity"));
+      }
+
+      await syncAfterMutation();
+
+      setInFlightStatus("success");
+      setInFlightMessage("In-flight quantity updated");
+    } catch (error) {
+      setInFlightStatus("error");
+      setInFlightMessage(
+        error instanceof Error ? error.message : "Failed to update in-flight quantity",
+      );
+    }
+  };
+
+  const handleDeleteInFlight = async (shipmentItemId: number) => {
+    const releaseRow = releaseInFlightByShipmentItemId.get(shipmentItemId);
+    if (!releaseRow) return;
+
+    setInFlightStatus("saving");
+    setInFlightMessage(null);
+
+    try {
+      const response = await fetch(`/api/tenant/in-flight/${releaseRow.inFlightId}`, {
+        method: "DELETE",
+        headers: tenantHeaders,
+      });
+
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, "Failed to delete in-flight row"));
+      }
+
+      await syncAfterMutation();
+
+      setInFlightStatus("success");
+      setInFlightMessage("In-flight row deleted");
+    } catch (error) {
+      setInFlightStatus("error");
+      setInFlightMessage(error instanceof Error ? error.message : "Failed to delete in-flight row");
+    }
+  };
+
+  if (status === "loading" && !detail) {
+    return (
+      <div className="mx-auto flex w-full max-w-[1700px] flex-col gap-6 px-4 py-10 md:px-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Loading shipment</CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <div className="mx-auto flex w-full max-w-[1700px] flex-col gap-6 px-4 py-10 md:px-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Shipment not available</CardTitle>
+            <CardDescription>{errorMessage ?? "Unable to load shipment"}</CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1700px] flex-col gap-6 px-4 py-10 md:px-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Shipment Summary</CardTitle>
+        </CardHeader>
+
+        <CardContent>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded-md border p-3">
+              <p className="text-muted-foreground text-xs uppercase">Supplier</p>
+              <p className="text-sm font-semibold">{detail.shipment.supplierCode}</p>
+            </div>
+
+            <div className="rounded-md border p-3">
+              <p className="text-muted-foreground text-xs uppercase">Shipment Date</p>
+              <p className="text-sm font-semibold">
+                {formatDateTime(detail.shipment.shipmentDate)}
+              </p>
+            </div>
+
+            <div className="rounded-md border p-3">
+              <p className="text-muted-foreground text-xs uppercase">Arrival Date</p>
+              <p className="text-sm font-semibold">{formatDateTime(detail.shipment.arrivalDate)}</p>
+            </div>
+
+            <div className="rounded-md border p-3">
+              <p className="text-muted-foreground text-xs uppercase">Created</p>
+              <p className="text-sm font-semibold">{formatDateTime(detail.shipment.createdAt)}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap items-center gap-3 border-b pb-2">
+        <div className="flex gap-2">
+          <Button
+            variant={activeTab === "items" ? "default" : "outline"}
+            onClick={() => setActiveTab("items")}
+          >
+            Line Items
+          </Button>
+
+          <Button
+            variant={activeTab === "releases" ? "default" : "outline"}
+            onClick={() => setActiveTab("releases")}
+          >
+            Releases
+          </Button>
+
+          <Button
+            variant={activeTab === "inflight" ? "default" : "outline"}
+            onClick={() => setActiveTab("inflight")}
+          >
+            In-Flight
+          </Button>
+        </div>
+
+        <div className="ml-auto flex items-center gap-2">
+          <label className="text-sm" htmlFor="name-display-mode">
+            List Names By
+          </label>
+          <select
+            id="name-display-mode"
+            className="rounded-md border px-2 py-1 text-sm"
+            value={nameDisplayMode}
+            onChange={(event) => setNameDisplayMode(event.target.value as "scientific" | "common")}
+          >
+            <option value="scientific">Scientific Name</option>
+            <option value="common">Common Name</option>
+          </select>
+        </div>
+      </div>
+
+      {activeTab === "items" && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Shipment Items</CardTitle>
+            <CardDescription>
+              Use +/- controls to update shipment metrics for testing.
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent className="space-y-4">
+            <div className="flex items-center gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleAddShipmentItem}
+                disabled={availableSpeciesOptions.length === 0}
+              >
+                Add Shipment Item
+              </Button>
+            </div>
+
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Photo</TableHead>
+                  <TableHead>
+                    {nameDisplayMode === "scientific" ? "Scientific Name" : "Common Name"}
+                  </TableHead>
+                  <TableHead>Received</TableHead>
+                  <TableHead>Emerged</TableHead>
+                  <TableHead>Damaged</TableHead>
+                  <TableHead>Diseased</TableHead>
+                  <TableHead>Parasite</TableHead>
+                  <TableHead>Non-Emergence</TableHead>
+                  <TableHead>Poor Emergence</TableHead>
+                  <TableHead>In Flight</TableHead>
+                  <TableHead>Remaining</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+
+              <TableBody>
+                {detail.items.map((item) => {
+                  const imageUrl = getShipmentItemImageUrl(item);
+                  const displayName = getDisplayName(item);
+
+                  return (
+                    <TableRow key={item.id}>
+                      <TableCell>
+                        {imageUrl ? (
+                          <Image
+                            src={imageUrl}
+                            alt={displayName}
+                            width={40}
+                            height={40}
+                            className="rounded"
+                          />
+                        ) : (
+                          "-"
+                        )}
+                      </TableCell>
+
+                      <TableCell>
+                        {item.id > 0 ? (
+                          <span className="italic">{displayName}</span>
+                        ) : (
+                          <select
+                            className="w-full rounded-md border px-2 py-1 text-sm"
+                            value={item.butterflySpeciesId}
+                            onChange={(event) =>
+                              updateItemSpecies(item.id, Number(event.target.value))
+                            }
+                          >
+                            {availableSpeciesOptions.map((species) => (
+                              <option
+                                key={`${item.id}-${species.butterflySpeciesId}`}
+                                value={species.butterflySpeciesId}
+                              >
+                                {getDisplayName(species)}
+                              </option>
+                            ))}
+                          </select>
+                        )}
+                      </TableCell>
+
+                      <TableCell>
+                        <QuantityStepper
+                          value={item.numberReceived}
+                          onDecrement={() => updateMetric(item.id, "numberReceived", -1)}
+                          onIncrement={() => updateMetric(item.id, "numberReceived", 1)}
+                          decrementLabel={`Decrease number received for ${displayName}`}
+                          incrementLabel={`Increase number received for ${displayName}`}
+                        />
+                      </TableCell>
+
+                      <TableCell>
+                        <QuantityStepper
+                          value={item.emergedInTransit}
+                          onDecrement={() => updateMetric(item.id, "emergedInTransit", -1)}
+                          onIncrement={() => updateMetric(item.id, "emergedInTransit", 1)}
+                          decrementLabel={`Decrease emerged in transit for ${displayName}`}
+                          incrementLabel={`Increase emerged in transit for ${displayName}`}
+                        />
+                      </TableCell>
+
+                      <TableCell>
+                        <QuantityStepper
+                          value={item.damagedInTransit}
+                          onDecrement={() => updateMetric(item.id, "damagedInTransit", -1)}
+                          onIncrement={() => updateMetric(item.id, "damagedInTransit", 1)}
+                          decrementLabel={`Decrease damaged in transit for ${displayName}`}
+                          incrementLabel={`Increase damaged in transit for ${displayName}`}
+                        />
+                      </TableCell>
+
+                      <TableCell>
+                        <QuantityStepper
+                          value={item.diseasedInTransit}
+                          onDecrement={() => updateMetric(item.id, "diseasedInTransit", -1)}
+                          onIncrement={() => updateMetric(item.id, "diseasedInTransit", 1)}
+                          decrementLabel={`Decrease diseased in transit for ${displayName}`}
+                          incrementLabel={`Increase diseased in transit for ${displayName}`}
+                        />
+                      </TableCell>
+
+                      <TableCell>
+                        <QuantityStepper
+                          value={item.parasite}
+                          onDecrement={() => updateMetric(item.id, "parasite", -1)}
+                          onIncrement={() => updateMetric(item.id, "parasite", 1)}
+                          decrementLabel={`Decrease parasite count for ${displayName}`}
+                          incrementLabel={`Increase parasite count for ${displayName}`}
+                        />
+                      </TableCell>
+
+                      <TableCell>
+                        <QuantityStepper
+                          value={item.nonEmergence}
+                          onDecrement={() => updateMetric(item.id, "nonEmergence", -1)}
+                          onIncrement={() => updateMetric(item.id, "nonEmergence", 1)}
+                          decrementLabel={`Decrease non-emergence count for ${displayName}`}
+                          incrementLabel={`Increase non-emergence count for ${displayName}`}
+                        />
+                      </TableCell>
+
+                      <TableCell>
+                        <QuantityStepper
+                          value={item.poorEmergence}
+                          onDecrement={() => updateMetric(item.id, "poorEmergence", -1)}
+                          onIncrement={() => updateMetric(item.id, "poorEmergence", 1)}
+                          decrementLabel={`Decrease poor emergence count for ${displayName}`}
+                          incrementLabel={`Increase poor emergence count for ${displayName}`}
+                        />
+                      </TableCell>
+
+                      <TableCell>{item.inFlightQuantity}</TableCell>
+
+                      <TableCell className="font-semibold">{getRemaining(item)}</TableCell>
+
+                      <TableCell>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="destructive"
+                          onClick={() => handleDeleteShipmentItem(item.id)}
+                        >
+                          Delete
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+
+            <div className="flex items-center gap-3">
+              <Button onClick={handleSaveShipmentItems} disabled={saveItemsStatus === "saving"}>
+                Save Metrics
+              </Button>
+
+              {saveItemsMessage && <p className="text-sm">{saveItemsMessage}</p>}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {activeTab === "releases" && (
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Create Release</CardTitle>
+              <CardDescription>Use good and poor emergence controls per species.</CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-6">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Photo</TableHead>
+                    <TableHead>Species</TableHead>
+                    <TableHead>Available</TableHead>
+                    <TableHead>Good Emergence</TableHead>
+                    <TableHead>Poor Emergence</TableHead>
+                  </TableRow>
+                </TableHeader>
+
+                <TableBody>
+                  {releaseRows.map((row) => (
+                    <TableRow key={row.item.id}>
+                      <TableCell>
+                        {getShipmentItemImageUrl(row.item) ? (
+                          <Image
+                            src={getShipmentItemImageUrl(row.item)!}
+                            alt={getDisplayName(row.item)}
+                            width={40}
+                            height={40}
+                            className="rounded"
+                          />
+                        ) : (
+                          "-"
+                        )}
+                      </TableCell>
+                      <TableCell className="italic">{getDisplayName(row.item)}</TableCell>
+                      <TableCell>{row.available}</TableCell>
+
+                      <TableCell>
+                        <QuantityStepper
+                          value={row.draft.goodEmergence}
+                          onDecrement={() =>
+                            updateReleaseDraft(row.item.id, "goodEmergence", -1, row.available)
+                          }
+                          onIncrement={() =>
+                            updateReleaseDraft(row.item.id, "goodEmergence", 1, row.available)
+                          }
+                          decrementLabel={`Decrease good emergence for ${getDisplayName(row.item)}`}
+                          incrementLabel={`Increase good emergence for ${getDisplayName(row.item)}`}
+                        />
+                      </TableCell>
+
+                      <TableCell>
+                        <QuantityStepper
+                          value={row.draft.poorEmergence}
+                          onDecrement={() =>
+                            updateReleaseDraft(row.item.id, "poorEmergence", -1, row.available)
+                          }
+                          onIncrement={() =>
+                            updateReleaseDraft(row.item.id, "poorEmergence", 1, row.available)
+                          }
+                          decrementLabel={`Decrease poor emergence for ${getDisplayName(row.item)}`}
+                          incrementLabel={`Increase poor emergence for ${getDisplayName(row.item)}`}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+
+              <div className="flex items-center gap-3">
+                <Button
+                  onClick={handleCreateRelease}
+                  disabled={!hasReleaseDraftValues || releaseStatus === "saving"}
+                >
+                  Create Release
+                </Button>
+
+                {releaseMessage && <p className="text-sm">{releaseMessage}</p>}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Release Events</CardTitle>
+            </CardHeader>
+
+            <CardContent className="space-y-4">
+              {releaseHistoryStatus === "loading" && (
+                <p className="text-muted-foreground text-sm">Loading release events...</p>
+              )}
+
+              {releaseHistoryStatus === "error" && releaseHistoryMessage && (
+                <p className="text-sm">{releaseHistoryMessage}</p>
+              )}
+
+              {releaseEventRows.length === 0 ? (
+                <p className="text-muted-foreground text-sm">
+                  No release events available in this session.
+                </p>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Release ID</TableHead>
+                      <TableHead>Date</TableHead>
+                      <TableHead>Species Count</TableHead>
+                      <TableHead>Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+
+                  <TableBody>
+                    {releaseEventRows.map((event) => (
+                      <TableRow key={event.id}>
+                        <TableCell>{event.id}</TableCell>
+                        <TableCell>{formatDateTime(event.releaseDate)}</TableCell>
+                        <TableCell>{event.items.length}</TableCell>
+                        <TableCell className="flex gap-2">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            onClick={() => startReleaseEditing(event.id)}
+                          >
+                            Edit
+                          </Button>
+
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => handleDeleteRelease(event.id)}
+                            disabled={releaseStatus === "saving"}
+                          >
+                            Delete
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+
+          {editingReleaseId && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Edit Release {editingReleaseId}</CardTitle>
+              </CardHeader>
+
+              <CardContent className="space-y-4">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Photo</TableHead>
+                      <TableHead>Species</TableHead>
+                      <TableHead>Good Emergence</TableHead>
+                      <TableHead>Poor Emergence</TableHead>
+                      <TableHead>Remove Row</TableHead>
+                    </TableRow>
+                  </TableHeader>
+
+                  <TableBody>
+                    {editingRows.map((row, rowIndex) => {
+                      const rowItem = shipmentItemById.get(row.shipmentItemId);
+                      const rowImage = rowItem ? getShipmentItemImageUrl(rowItem) : null;
+
+                      return (
+                        <TableRow key={`${row.shipmentItemId}-${rowIndex}`}>
+                          <TableCell>
+                            {rowImage ? (
+                              <Image
+                                src={rowImage}
+                                alt={
+                                  rowItem
+                                    ? getDisplayName(rowItem)
+                                    : `Species ${row.shipmentItemId}`
+                                }
+                                width={40}
+                                height={40}
+                                className="rounded"
+                              />
+                            ) : (
+                              "-"
+                            )}
+                          </TableCell>
+
+                          <TableCell>
+                            {row.inFlightId ? (
+                              <span className="italic">
+                                {rowItem
+                                  ? getDisplayName(rowItem)
+                                  : `Species ${row.shipmentItemId}`}
+                              </span>
+                            ) : (
+                              <select
+                                className="w-full rounded-md border px-2 py-1 text-sm"
+                                value={row.shipmentItemId}
+                                onChange={(event) =>
+                                  updateEditingRowSpecies(rowIndex, Number(event.target.value))
+                                }
+                              >
+                                {detail.items
+                                  .filter((item) => item.id > 0)
+                                  .map((item) => (
+                                    <option key={item.id} value={item.id}>
+                                      {getDisplayName(item)}
+                                    </option>
+                                  ))}
+                              </select>
+                            )}
+                          </TableCell>
+
+                          <TableCell>
+                            <QuantityStepper
+                              value={row.goodEmergence}
+                              onDecrement={() =>
+                                updateEditingRowMetric(rowIndex, "goodEmergence", -1)
+                              }
+                              onIncrement={() =>
+                                updateEditingRowMetric(rowIndex, "goodEmergence", 1)
+                              }
+                              decrementLabel={`Decrease good emergence in row ${rowIndex + 1}`}
+                              incrementLabel={`Increase good emergence in row ${rowIndex + 1}`}
+                            />
+                          </TableCell>
+
+                          <TableCell>
+                            <QuantityStepper
+                              value={row.poorEmergence}
+                              onDecrement={() =>
+                                updateEditingRowMetric(rowIndex, "poorEmergence", -1)
+                              }
+                              onIncrement={() =>
+                                updateEditingRowMetric(rowIndex, "poorEmergence", 1)
+                              }
+                              decrementLabel={`Decrease poor emergence in row ${rowIndex + 1}`}
+                              incrementLabel={`Increase poor emergence in row ${rowIndex + 1}`}
+                            />
+                          </TableCell>
+
+                          <TableCell>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              onClick={() => removeEditingRow(rowIndex, row.inFlightId)}
+                            >
+                              Remove
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button type="button" variant="outline" onClick={addEditingRow}>
+                    Add Species Row
+                  </Button>
+
+                  <Button
+                    type="button"
+                    onClick={handleSaveReleaseEdit}
+                    disabled={editReleaseStatus === "saving"}
+                  >
+                    Save Release
+                  </Button>
+
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setEditingReleaseId(null);
+                      setEditingRows([]);
+                      setEditingDeleteInFlightIds([]);
+                      setEditReleaseStatus("idle");
+                      setEditReleaseMessage(null);
+                    }}
+                  >
+                    Cancel
+                  </Button>
+
+                  {editReleaseMessage && <p className="text-sm">{editReleaseMessage}</p>}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
+
+      {activeTab === "inflight" && (
+        <Card>
+          <CardHeader>
+            <CardTitle>In-Flight Butterflies</CardTitle>
+          </CardHeader>
+
+          <CardContent className="space-y-3">
+            {inFlightItems.length === 0 ? (
+              <p className="text-muted-foreground text-sm">No butterflies currently in flight.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Photo</TableHead>
+                    <TableHead>Species</TableHead>
+                    <TableHead>Quantity</TableHead>
+                  </TableRow>
+                </TableHeader>
+
+                <TableBody>
+                  {inFlightItems.map((item) => {
+                    const releaseRow = releaseInFlightByShipmentItemId.get(item.id);
+                    const displayName = getDisplayName(item);
+
+                    return (
+                      <TableRow key={item.id}>
+                        <TableCell>
+                          {getShipmentItemImageUrl(item) ? (
+                            <Image
+                              src={getShipmentItemImageUrl(item)!}
+                              alt={displayName}
+                              width={40}
+                              height={40}
+                              className="rounded"
+                            />
+                          ) : (
+                            "-"
+                          )}
+                        </TableCell>
+                        <TableCell className="italic">{displayName}</TableCell>
+
+                        <TableCell className="space-y-2">
+                          {releaseRow ? (
+                            <>
+                              <QuantityStepper
+                                value={
+                                  inFlightEdits[releaseRow.inFlightId] ?? item.inFlightQuantity
+                                }
+                                onDecrement={() =>
+                                  updateInFlightEdit(
+                                    releaseRow.inFlightId,
+                                    -1,
+                                    item.inFlightQuantity,
+                                  )
+                                }
+                                onIncrement={() =>
+                                  updateInFlightEdit(
+                                    releaseRow.inFlightId,
+                                    1,
+                                    item.inFlightQuantity,
+                                  )
+                                }
+                                decrementLabel={`Decrease in-flight quantity for ${displayName}`}
+                                incrementLabel={`Increase in-flight quantity for ${displayName}`}
+                              />
+
+                              <div className="flex flex-wrap items-center gap-2">
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  onClick={() =>
+                                    handleUpdateInFlight(item.id, item.inFlightQuantity)
+                                  }
+                                  disabled={inFlightStatus === "saving"}
+                                >
+                                  Save
+                                </Button>
+
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="destructive"
+                                  onClick={() => handleDeleteInFlight(item.id)}
+                                  disabled={inFlightStatus === "saving"}
+                                >
+                                  Delete
+                                </Button>
+                              </div>
+                            </>
+                          ) : (
+                            <span>{item.inFlightQuantity}</span>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            )}
+
+            {inFlightMessage && <p className="text-sm">{inFlightMessage}</p>}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/[institution]/(tenant)/shipments/[id]/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/[id]/page.tsx
@@ -1,10 +1,29 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import Image from "next/image";
-import { useParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { notFound, useParams, useRouter } from "next/navigation";
+import { ArrowLeft, Pencil, Plus, Trash2 } from "lucide-react";
+
+import { Link } from "@/components/ui/link";
+import { logger } from "@/lib/logger";
+import { ROUTES } from "@/lib/routes";
+
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+import { ShipmentItemsTable } from "@/components/tenant/shipments/shipment-items-table";
+import { ShipmentStatusBadge } from "@/components/tenant/shipments/shipment-status-badge";
+import { SpeciesPickerDialog } from "@/components/tenant/shipments/species-picker-dialog";
 import {
   Table,
   TableBody,
@@ -13,52 +32,33 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  computeItemRemaining,
+  type ShipmentDetailResponse,
+  type ShipmentItemRow,
+  type SpeciesPickerOption,
+} from "@/components/tenant/shipments/types";
 
-type ShipmentHeader = {
+type ShipmentReleaseRow = {
   id: number;
-  supplierCode: string;
-  shipmentDate: string;
-  arrivalDate: string;
-  createdAt: string;
+  releaseDate: string;
+  releasedBy: string;
+  totalReleased: number;
 };
 
-type ShipmentItem = {
-  id: number;
-  butterflySpeciesId: number;
-  scientificName: string;
-  commonName?: string | null;
-  imageUrl?: string | null;
-  imageOpen?: string | null;
-  imageClosed?: string | null;
-  numberReceived: number;
-  emergedInTransit: number;
-  damagedInTransit: number;
-  diseasedInTransit: number;
-  parasite: number;
-  nonEmergence: number;
-  poorEmergence: number;
-  inFlightQuantity: number;
-};
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "2-digit",
+  year: "numeric",
+});
 
-type ShipmentDetailResponse = {
-  shipment: ShipmentHeader;
-  items: ShipmentItem[];
-  releaseEvents?: Array<{
-    id?: number;
-    releaseId?: number;
-    release_date?: string;
-    releaseDate?: string;
-  }>;
-  releases?: Array<{
-    id?: number;
-    releaseId?: number;
-    release_date?: string;
-    releaseDate?: string;
-  }>;
-  inFlight?: Array<{ releaseEventId?: number; release_event_id?: number }>;
-};
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return "—";
+  return dateFormatter.format(date);
+}
 
-type ShipmentMetricField =
+type MetricKey =
   | "numberReceived"
   | "emergedInTransit"
   | "damagedInTransit"
@@ -67,580 +67,213 @@ type ShipmentMetricField =
   | "nonEmergence"
   | "poorEmergence";
 
-type ReleaseDraft = {
-  goodEmergence: number;
-  poorEmergence: number;
+const METRIC_TO_API: Record<MetricKey, string> = {
+  numberReceived: "number_received",
+  emergedInTransit: "emerged_in_transit",
+  damagedInTransit: "damaged_in_transit",
+  diseasedInTransit: "diseased_in_transit",
+  parasite: "parasite",
+  nonEmergence: "non_emergence",
+  poorEmergence: "poor_emergence",
 };
-
-type ReleaseEventItem = {
-  inFlightId: number | null;
-  shipmentItemId: number;
-  quantity: number;
-  goodEmergence: number;
-  poorEmergence: number;
-};
-
-type ReleaseEventDetail = {
-  id: number;
-  releaseDate: string;
-  items: ReleaseEventItem[];
-};
-
-type ReleaseEditorRow = {
-  inFlightId: number | null;
-  shipmentItemId: number;
-  goodEmergence: number;
-  poorEmergence: number;
-};
-
-type SpeciesOption = {
-  butterflySpeciesId: number;
-  scientificName: string;
-  commonName: string;
-  imageUrl?: string | null;
-  imageOpen?: string | null;
-  imageClosed?: string | null;
-};
-
-const formatDateTime = (value: string) => {
-  const date = new Date(value);
-  if (Number.isNaN(date.valueOf())) return "-";
-
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "2-digit",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
-};
-
-const getRemaining = (item: ShipmentItem) => {
-  return (
-    item.numberReceived -
-    item.emergedInTransit -
-    item.damagedInTransit -
-    item.diseasedInTransit -
-    item.parasite -
-    item.nonEmergence -
-    item.poorEmergence -
-    item.inFlightQuantity
-  );
-};
-
-const getAvailableToRelease = (item: ShipmentItem) => {
-  return Math.max(0, getRemaining(item));
-};
-
-const asRecord = (value: unknown): Record<string, unknown> | null => {
-  if (!value || typeof value !== "object") return null;
-  return value as Record<string, unknown>;
-};
-
-const toNonNegativeInt = (value: unknown) => {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) return 0;
-  return Math.max(0, Math.trunc(parsed));
-};
-
-const toPositiveInt = (value: unknown) => {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) return null;
-  const normalized = Math.trunc(parsed);
-  return normalized > 0 ? normalized : null;
-};
-
-const getShipmentItemImageUrl = (item: ShipmentItem) => {
-  return item.imageUrl ?? item.imageOpen ?? item.imageClosed ?? null;
-};
-
-const resolveCommonName = (commonName: string | null | undefined, scientificName: string) => {
-  if (typeof commonName !== "string") return scientificName;
-  const normalized = commonName.trim();
-  return normalized.length > 0 ? normalized : scientificName;
-};
-
-const uniquePositiveIds = (ids: Array<number | null>) => {
-  return Array.from(
-    new Set(
-      ids.filter((id): id is number => typeof id === "number" && Number.isInteger(id) && id > 0),
-    ),
-  );
-};
-
-type CreatedInFlightRow = {
-  inFlightId: number;
-  shipmentItemId: number;
-  quantity: number;
-};
-
-const extractCreatedInFlightRowsFromCreateResponse = (payload: unknown) => {
-  const root = asRecord(payload);
-  if (!root) return [] as CreatedInFlightRow[];
-
-  const release = asRecord(root.release);
-  const rows = Array.isArray(release?.items)
-    ? release.items
-    : Array.isArray(root.items)
-      ? root.items
-      : [];
-
-  return rows
-    .map((row) => {
-      const item = asRecord(row);
-      if (!item) return null;
-
-      const inFlightId = toPositiveInt(item.id);
-      const shipmentItemId =
-        toPositiveInt(item.shipmentItemId) ?? toPositiveInt(item.shipment_item_id);
-      const quantity = toNonNegativeInt(item.quantity);
-
-      if (!inFlightId || !shipmentItemId) return null;
-
-      return {
-        inFlightId,
-        shipmentItemId,
-        quantity,
-      } satisfies CreatedInFlightRow;
-    })
-    .filter((row): row is CreatedInFlightRow => row !== null);
-};
-
-const normalizeReleaseEvent = (payload: unknown, fallbackId: number): ReleaseEventDetail | null => {
-  const root = asRecord(payload);
-  if (!root) return null;
-
-  const event = asRecord(root.event) ?? asRecord(root.releaseEvent) ?? root;
-  const id = toPositiveInt(event.id) ?? toPositiveInt(root.releaseId) ?? fallbackId;
-
-  if (!id) return null;
-
-  const releaseDateValue =
-    event.releaseDate ?? event.release_date ?? root.releaseDate ?? root.release_date;
-
-  const releaseDate =
-    typeof releaseDateValue === "string" && releaseDateValue.length > 0
-      ? releaseDateValue
-      : new Date().toISOString();
-
-  const rows = Array.isArray(root.items) ? root.items : [];
-
-  const items: ReleaseEventItem[] = rows
-    .map((row) => {
-      const item = asRecord(row);
-      if (!item) return null;
-
-      const shipmentItemId =
-        toPositiveInt(item.shipmentItemId) ?? toPositiveInt(item.shipment_item_id);
-      if (!shipmentItemId) return null;
-
-      const quantity = toNonNegativeInt(item.quantity);
-      const goodEmergence = toNonNegativeInt(
-        item.goodEmergence ?? item.good_emergence ?? item.quantity,
-      );
-      const poorEmergence = toNonNegativeInt(item.poorEmergence ?? item.poor_emergence);
-      const inFlightId = toPositiveInt(item.id);
-
-      return {
-        inFlightId,
-        shipmentItemId,
-        quantity,
-        goodEmergence,
-        poorEmergence,
-      };
-    })
-    .filter((item): item is ReleaseEventItem => item !== null);
-
-  return {
-    id,
-    releaseDate,
-    items,
-  };
-};
-
-const readErrorMessage = async (response: Response, fallback: string) => {
-  try {
-    const payload = await response.json();
-    const root = asRecord(payload);
-    const nestedError = root ? asRecord(root.error) : null;
-
-    if (nestedError && typeof nestedError.message === "string" && nestedError.message.length > 0) {
-      return nestedError.message;
-    }
-
-    if (root && typeof root.message === "string" && root.message.length > 0) {
-      return root.message;
-    }
-  } catch {
-    return fallback;
-  }
-
-  return fallback;
-};
-
-function QuantityStepper({
-  value,
-  onDecrement,
-  onIncrement,
-  decrementLabel,
-  incrementLabel,
-  disabled,
-}: {
-  value: number;
-  onDecrement: () => void;
-  onIncrement: () => void;
-  decrementLabel: string;
-  incrementLabel: string;
-  disabled?: boolean;
-}) {
-  return (
-    <div className="flex items-center gap-1">
-      <Button
-        type="button"
-        size="sm"
-        variant="outline"
-        className="h-7 w-7 p-0 text-xs"
-        onClick={onDecrement}
-        disabled={disabled}
-        aria-label={decrementLabel}
-      >
-        -
-      </Button>
-      <span className="min-w-6 text-center text-xs font-medium">{value}</span>
-      <Button
-        type="button"
-        size="sm"
-        variant="outline"
-        className="h-7 w-7 p-0 text-xs"
-        onClick={onIncrement}
-        disabled={disabled}
-        aria-label={incrementLabel}
-      >
-        +
-      </Button>
-    </div>
-  );
-}
 
 export default function ShipmentDetailPage() {
   const params = useParams<{ institution: string; id: string }>();
-  const rawInstitutionSlug = params?.institution ?? "";
-  const institutionSlug = Array.isArray(rawInstitutionSlug)
-    ? (rawInstitutionSlug[0] ?? "")
-    : rawInstitutionSlug;
-  const rawShipmentId = params?.id ?? "";
-  const shipmentId = Array.isArray(rawShipmentId) ? rawShipmentId[0] : rawShipmentId;
-  const shipmentIdNumber = Number(shipmentId);
-  const [activeTab, setActiveTab] = useState<"items" | "releases" | "inflight">("items");
+  const router = useRouter();
+  const slug = params?.institution ?? "";
+  const shipmentId = Number(params?.id);
 
-  const [detail, setDetail] = useState<ShipmentDetailResponse | null>(null);
+  const [data, setData] = useState<ShipmentDetailResponse | null>(null);
+  const [releases, setReleases] = useState<ShipmentReleaseRow[]>([]);
   const [status, setStatus] = useState<"idle" | "loading" | "error">("loading");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const [saveItemsStatus, setSaveItemsStatus] = useState<"idle" | "saving" | "success" | "error">(
-    "idle",
+  const [forceEditPrompted, setForceEditPrompted] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draftItems, setDraftItems] = useState<ShipmentItemRow[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  // Species catalog for the picker is lazy-loaded the first time the user
+  // opens it from edit mode. We keep it in state so re-opening is instant.
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [species, setSpecies] = useState<SpeciesPickerOption[]>([]);
+  const [speciesLoaded, setSpeciesLoaded] = useState(false);
+
+  // Counter for temporary IDs assigned to newly added (unsaved) items.
+  // Real shipment item ids are positive serials, so negative ids are an
+  // unambiguous "this is a draft, send via add_items" marker.
+  const tempIdCounter = useRef(0);
+
+  const tenantHeaders = useMemo(() => ({ "x-tenant-slug": slug }), [slug]);
+
+  const loadShipment = useCallback(
+    async (signal?: AbortSignal) => {
+      setStatus("loading");
+      setErrorMessage(null);
+      try {
+        // Fetch the shipment + its release history in parallel. The release
+        // endpoint already returns totalReleased per event so the history table
+        // can render without an extra round-trip.
+        const [detailResponse, releasesResponse] = await Promise.all([
+          fetch(`/api/tenant/shipments/${shipmentId}`, { headers: tenantHeaders, signal }),
+          fetch(`/api/tenant/shipments/${shipmentId}/releases`, {
+            headers: tenantHeaders,
+            signal,
+          }),
+        ]);
+
+        const detailResult = await detailResponse.json().catch(() => null);
+        if (signal?.aborted) return;
+        if (!detailResponse.ok) {
+          setStatus("error");
+          setErrorMessage(detailResult?.error?.message ?? "Failed to load shipment.");
+          return;
+        }
+        setData(detailResult);
+        setDraftItems(detailResult.items ?? []);
+
+        // Releases are non-essential — if they fail to load, surface the
+        // shipment anyway and just leave the history empty.
+        if (releasesResponse.ok) {
+          const releasesResult = await releasesResponse.json().catch(() => null);
+          if (signal?.aborted) return;
+          const events = Array.isArray(releasesResult?.releaseEvents)
+            ? releasesResult.releaseEvents
+            : [];
+          setReleases(events);
+        } else {
+          setReleases([]);
+        }
+
+        setStatus("idle");
+      } catch (err) {
+        if (signal?.aborted) return;
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setStatus("error");
+        setErrorMessage("Failed to load shipment.");
+      }
+    },
+    [shipmentId, tenantHeaders],
   );
-  const [saveItemsMessage, setSaveItemsMessage] = useState<string | null>(null);
 
-  const [releaseDrafts, setReleaseDrafts] = useState<Record<number, ReleaseDraft>>({});
-  const [releaseStatus, setReleaseStatus] = useState<"idle" | "saving" | "success" | "error">(
-    "idle",
-  );
-  const [releaseMessage, setReleaseMessage] = useState<string | null>(null);
+  useEffect(() => {
+    const ac = new AbortController();
+    void loadShipment(ac.signal);
+    return () => ac.abort();
+  }, [loadShipment]);
 
-  const [releaseEvents, setReleaseEvents] = useState<ReleaseEventDetail[]>([]);
-  const [releaseHistoryStatus, setReleaseHistoryStatus] = useState<"idle" | "loading" | "error">(
-    "idle",
-  );
-  const [releaseHistoryMessage, setReleaseHistoryMessage] = useState<string | null>(null);
+  const totals = useMemo(() => {
+    const items = data?.items ?? [];
+    const totalReceived = items.reduce((acc, item) => acc + item.numberReceived, 0);
+    const totalLosses = items.reduce(
+      (acc, item) =>
+        acc +
+        item.damagedInTransit +
+        item.diseasedInTransit +
+        item.parasite +
+        item.nonEmergence +
+        item.poorEmergence,
+      0,
+    );
+    const totalReleased = items.reduce((acc, item) => acc + item.inFlightQuantity, 0);
+    const remaining = items.reduce((acc, item) => acc + computeItemRemaining(item), 0);
+    return {
+      totalReceived,
+      totalLosses,
+      totalReleased,
+      remaining,
+      isCompleted: items.length > 0 && remaining === 0,
+    };
+  }, [data]);
 
-  const [editingReleaseId, setEditingReleaseId] = useState<number | null>(null);
-  const [editingRows, setEditingRows] = useState<ReleaseEditorRow[]>([]);
-  const [editingDeleteInFlightIds, setEditingDeleteInFlightIds] = useState<number[]>([]);
-  const [editReleaseStatus, setEditReleaseStatus] = useState<
-    "idle" | "saving" | "success" | "error"
-  >("idle");
-  const [editReleaseMessage, setEditReleaseMessage] = useState<string | null>(null);
+  const speciesAbortRef = useRef<AbortController | null>(null);
 
-  const [inFlightEdits, setInFlightEdits] = useState<Record<number, number>>({});
-  const [inFlightStatus, setInFlightStatus] = useState<"idle" | "saving" | "success" | "error">(
-    "idle",
-  );
-  const [inFlightMessage, setInFlightMessage] = useState<string | null>(null);
-  const [deletedItemIds, setDeletedItemIds] = useState<number[]>([]);
-  const [nextTempItemId, setNextTempItemId] = useState(-1);
-  const [speciesOptions, setSpeciesOptions] = useState<SpeciesOption[]>([]);
-  const [nameDisplayMode, setNameDisplayMode] = useState<"scientific" | "common">("scientific");
-
-  const tenantHeaders = useMemo(() => ({ "x-tenant-slug": institutionSlug }), [institutionSlug]);
-
-  const fetchDetail = useCallback(async () => {
-    const response = await fetch(`/api/tenant/shipments/${shipmentIdNumber}`, {
-      headers: tenantHeaders,
-    });
-    if (!response.ok) {
-      throw new Error(await readErrorMessage(response, "Unable to load shipment"));
-    }
-
-    const data = await response.json();
-    return data as ShipmentDetailResponse;
-  }, [shipmentIdNumber, tenantHeaders]);
-
-  const loadSpeciesOptions = useCallback(async () => {
+  const loadSpecies = useCallback(async () => {
+    if (speciesLoaded) return;
+    speciesAbortRef.current?.abort();
+    const ac = new AbortController();
+    speciesAbortRef.current = ac;
     try {
       const response = await fetch("/api/tenant/species", {
         headers: tenantHeaders,
+        signal: ac.signal,
       });
-      if (!response.ok) return;
-
-      const payload = await response.json();
-      const root = asRecord(payload);
-      const rows = Array.isArray(root?.species) ? root.species : [];
-
-      const parsed = rows
-        .map((row): SpeciesOption | null => {
-          const item = asRecord(row);
-          if (!item) return null;
-
-          const id = toPositiveInt(item.id);
-          const scientificName =
-            typeof item.scientificName === "string" ? item.scientificName.trim() : "";
-
-          if (!id || scientificName.length === 0) return null;
-
-          const commonNameOverride =
-            typeof item.commonNameOverride === "string" ? item.commonNameOverride : null;
-          const commonNameBase = typeof item.commonName === "string" ? item.commonName : null;
-
-          return {
-            butterflySpeciesId: id,
-            scientificName,
-            commonName: resolveCommonName(commonNameOverride ?? commonNameBase, scientificName),
-            imageOpen:
-              typeof item.imgWingsOpen === "string" && item.imgWingsOpen.length > 0
-                ? item.imgWingsOpen
-                : null,
-            imageClosed:
-              typeof item.imgWingsClosed === "string" && item.imgWingsClosed.length > 0
-                ? item.imgWingsClosed
-                : null,
-            imageUrl:
-              typeof item.imgWingsOpen === "string" && item.imgWingsOpen.length > 0
-                ? item.imgWingsOpen
-                : typeof item.imgWingsClosed === "string" && item.imgWingsClosed.length > 0
-                  ? item.imgWingsClosed
-                  : null,
-          };
-        })
-        .filter((item): item is SpeciesOption => item !== null);
-
-      if (parsed.length > 0) {
-        setSpeciesOptions(parsed);
-      }
-    } catch {
-      // Keep existing fallback behavior from shipment-detail rows.
-    }
-  }, [tenantHeaders]);
-
-  const loadDetail = useCallback(async () => {
-    setStatus("loading");
-    setErrorMessage(null);
-
-    try {
-      const data = await fetchDetail();
-      setDetail(data);
-
-      const releaseDraftMap: Record<number, ReleaseDraft> = {};
-      data.items.forEach((item) => {
-        releaseDraftMap[item.id] = {
-          goodEmergence: 0,
-          poorEmergence: 0,
-        };
-      });
-      setReleaseDrafts(releaseDraftMap);
-
-      setDeletedItemIds([]);
-      setNextTempItemId(-1);
-
-      setStatus("idle");
-      return data;
+      const result = await response.json().catch(() => null);
+      if (ac.signal.aborted) return;
+      const rows = Array.isArray(result?.species) ? result.species : [];
+      const options: SpeciesPickerOption[] = rows
+        .map(
+          (row: {
+            id?: number;
+            scientificName?: string;
+            commonName?: string;
+            commonNameOverride?: string;
+            family?: string;
+            imgWingsOpen?: string | null;
+          }) => {
+            const id = typeof row.id === "number" ? row.id : Number(row.id);
+            const sci = (row.scientificName ?? "").trim();
+            if (!Number.isFinite(id) || id <= 0 || !sci) return null;
+            const common =
+              (row.commonNameOverride ?? "").trim() || (row.commonName ?? "").trim() || sci;
+            return {
+              id,
+              scientificName: sci,
+              commonName: common,
+              family: (row.family ?? "").trim() || "—",
+              imgWingsOpen: row.imgWingsOpen ?? null,
+            };
+          },
+        )
+        .filter((row: SpeciesPickerOption | null): row is SpeciesPickerOption => row !== null);
+      setSpecies(options);
+      setSpeciesLoaded(true);
     } catch (error) {
-      setStatus("error");
-      setErrorMessage(error instanceof Error ? error.message : "Unable to load shipment");
-      return null;
+      if (ac.signal.aborted) return;
+      if (error instanceof DOMException && error.name === "AbortError") return;
+      // Picker will show an empty list; user can close and reopen to retry.
+      logger.error("Failed to load species for picker:", error);
     }
-  }, [fetchDetail]);
+  }, [speciesLoaded, tenantHeaders]);
 
   useEffect(() => {
-    if (!institutionSlug) {
-      setStatus("error");
-      setErrorMessage("Missing institution slug");
-      return;
-    }
+    return () => speciesAbortRef.current?.abort();
+  }, []);
 
-    if (!Number.isFinite(shipmentIdNumber) || shipmentIdNumber <= 0) {
-      setStatus("error");
-      setErrorMessage("Invalid shipment id");
-      return;
-    }
-
-    void loadDetail();
-    void loadSpeciesOptions();
-  }, [institutionSlug, loadDetail, loadSpeciesOptions, shipmentIdNumber]);
-
-  const releaseRouteUrl = useCallback(
-    (releaseId: number) => `/api/tenant/releases/${releaseId}`,
-    [],
-  );
-
-  const fetchReleases = useCallback(async () => {
-    setReleaseHistoryStatus("loading");
-    setReleaseHistoryMessage(null);
-
-    try {
-      const listRes = await fetch(`/api/tenant/shipments/${shipmentIdNumber}/releases`, {
-        headers: tenantHeaders,
-      });
-      if (!listRes.ok) {
-        throw new Error(await readErrorMessage(listRes, "Failed to load releases"));
-      }
-
-      const listData = await listRes.json();
-      const releaseIds: number[] = (
-        Array.isArray(listData?.releaseEvents) ? listData.releaseEvents : []
-      )
-        .map((e: unknown) => toPositiveInt(asRecord(e)?.id))
-        .filter((id: number | null): id is number => id !== null);
-
-      if (releaseIds.length === 0) {
-        setReleaseEvents([]);
-        setReleaseHistoryStatus("idle");
-        setReleaseHistoryMessage(null);
-        return;
-      }
-
-      const responses = await Promise.all(
-        releaseIds.map(async (releaseId) => {
-          const response = await fetch(releaseRouteUrl(releaseId), {
-            headers: tenantHeaders,
-          });
-          if (!response.ok) {
-            throw new Error(
-              await readErrorMessage(response, `Failed to load release ${releaseId}`),
-            );
-          }
-
-          const payload = await response.json();
-          return normalizeReleaseEvent(payload, releaseId);
-        }),
-      );
-
-      const normalized = responses
-        .filter((event): event is ReleaseEventDetail => event !== null)
-        .sort((a, b) => new Date(b.releaseDate).valueOf() - new Date(a.releaseDate).valueOf());
-
-      setReleaseEvents(normalized);
-      setReleaseHistoryStatus("idle");
-    } catch (error) {
-      setReleaseHistoryStatus("error");
-      setReleaseHistoryMessage(
-        error instanceof Error ? error.message : "Failed to load release history",
-      );
-    }
-  }, [shipmentIdNumber, releaseRouteUrl, tenantHeaders]);
-
-  useEffect(() => {
-    if (!Number.isFinite(shipmentIdNumber) || shipmentIdNumber <= 0) return;
-    void fetchReleases();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shipmentIdNumber]);
-
-  const fallbackSpeciesOptions = useMemo(() => {
-    if (!detail) return [];
-
-    const map = new Map<number, SpeciesOption>();
-
-    detail.items.forEach((item) => {
-      if (!map.has(item.butterflySpeciesId)) {
-        map.set(item.butterflySpeciesId, {
-          butterflySpeciesId: item.butterflySpeciesId,
-          scientificName: item.scientificName,
-          commonName: resolveCommonName(item.commonName, item.scientificName),
-          imageUrl: item.imageUrl,
-          imageOpen: item.imageOpen,
-          imageClosed: item.imageClosed,
-        });
-      }
-    });
-
-    return Array.from(map.values());
-  }, [detail]);
-
-  const availableSpeciesOptions = useMemo(() => {
-    if (speciesOptions.length > 0) return speciesOptions;
-    return fallbackSpeciesOptions;
-  }, [fallbackSpeciesOptions, speciesOptions]);
-
-  const getDisplayName = useCallback(
-    (entry: { scientificName: string; commonName?: string | null }) => {
-      if (nameDisplayMode === "common") {
-        return resolveCommonName(entry.commonName, entry.scientificName);
-      }
-
-      return entry.scientificName;
-    },
-    [nameDisplayMode],
-  );
-
-  const updateItemSpecies = (itemId: number, butterflySpeciesId: number) => {
-    const selectedSpecies = availableSpeciesOptions.find(
-      (option) => option.butterflySpeciesId === butterflySpeciesId,
-    );
-    if (!selectedSpecies) return;
-
-    setDetail((prev) => {
-      if (!prev) return prev;
-
-      return {
-        ...prev,
-        items: prev.items.map((item) => {
-          if (item.id !== itemId) return item;
-
-          return {
-            ...item,
-            butterflySpeciesId: selectedSpecies.butterflySpeciesId,
-            scientificName: selectedSpecies.scientificName,
-            commonName: selectedSpecies.commonName,
-            imageUrl: selectedSpecies.imageUrl,
-            imageOpen: selectedSpecies.imageOpen,
-            imageClosed: selectedSpecies.imageClosed,
-          };
-        }),
-      };
-    });
+  const handleStartEditing = () => {
+    setForceEditPrompted(false);
+    setDraftItems(data?.items ?? []);
+    setEditing(true);
   };
 
-  const handleAddShipmentItem = () => {
-    if (!detail || availableSpeciesOptions.length === 0) return;
+  const handleCancelEditing = () => {
+    setEditing(false);
+    setDraftItems(data?.items ?? []);
+    // Reset the temp id counter so a fresh edit session starts at -1.
+    tempIdCounter.current = 0;
+  };
 
-    const selectedSpecies = availableSpeciesOptions[0];
-    const tempId = nextTempItemId;
+  const handleOpenPicker = () => {
+    void loadSpecies();
+    setPickerOpen(true);
+  };
 
-    setDetail((prev) => {
-      if (!prev) return prev;
-
-      return {
-        ...prev,
-        items: [
-          ...prev.items,
-          {
-            id: tempId,
-            butterflySpeciesId: selectedSpecies.butterflySpeciesId,
-            scientificName: selectedSpecies.scientificName,
-            commonName: selectedSpecies.commonName,
-            imageUrl: selectedSpecies.imageUrl,
-            imageOpen: selectedSpecies.imageOpen,
-            imageClosed: selectedSpecies.imageClosed,
+  const handlePickerConfirm = useCallback((chosen: SpeciesPickerOption[]) => {
+    setDraftItems((current) => {
+      const existingSpeciesIds = new Set(current.map((item) => item.butterflySpeciesId));
+      const additions: ShipmentItemRow[] = chosen
+        .filter((option) => !existingSpeciesIds.has(option.id))
+        .map((option) => {
+          tempIdCounter.current -= 1;
+          return {
+            id: tempIdCounter.current,
+            butterflySpeciesId: option.id,
+            scientificName: option.scientificName,
+            commonName: option.commonName,
+            imageOpen: option.imgWingsOpen,
+            imageClosed: null,
             numberReceived: 0,
             emergedInTransit: 0,
             damagedInTransit: 0,
@@ -649,1374 +282,343 @@ export default function ShipmentDetailPage() {
             nonEmergence: 0,
             poorEmergence: 0,
             inFlightQuantity: 0,
-          },
-        ],
-      };
-    });
-
-    setNextTempItemId((prev) => prev - 1);
-  };
-
-  const handleDeleteShipmentItem = (itemId: number) => {
-    setDetail((prev) => {
-      if (!prev) return prev;
-
-      return {
-        ...prev,
-        items: prev.items.filter((item) => item.id !== itemId),
-      };
-    });
-
-    setReleaseDrafts((prev) => {
-      const next = { ...prev };
-      delete next[itemId];
-      return next;
-    });
-
-    if (itemId > 0) {
-      setDeletedItemIds((prev) => Array.from(new Set([...prev, itemId])));
-    }
-  };
-
-  const syncAfterMutation = useCallback(async () => {
-    await loadDetail();
-    await fetchReleases();
-  }, [loadDetail, fetchReleases]);
-
-  const updateMetric = (itemId: number, field: ShipmentMetricField, delta: number) => {
-    setDetail((prev) => {
-      if (!prev) return prev;
-
-      return {
-        ...prev,
-        items: prev.items.map((item) => {
-          if (item.id !== itemId) return item;
-
-          const nextValue = Math.max(0, item[field] + delta);
-          return {
-            ...item,
-            [field]: nextValue,
           };
-        }),
-      };
-    });
-  };
-
-  const handleSaveShipmentItems = async () => {
-    if (!detail) return;
-
-    setSaveItemsStatus("saving");
-    setSaveItemsMessage(null);
-
-    try {
-      const persistedItems = detail.items.filter((item) => item.id > 0);
-      const newItems = detail.items.filter((item) => item.id <= 0);
-
-      const payload: {
-        update_items?: Array<{
-          id: number;
-          number_received: number;
-          emerged_in_transit: number;
-          damaged_in_transit: number;
-          diseased_in_transit: number;
-          parasite: number;
-          non_emergence: number;
-          poor_emergence: number;
-        }>;
-        add_items?: Array<{
-          butterfly_species_id: number;
-          number_received: number;
-          emerged_in_transit: number;
-          damaged_in_transit: number;
-          diseased_in_transit: number;
-          parasite: number;
-          non_emergence: number;
-          poor_emergence: number;
-        }>;
-        delete_items?: number[];
-      } = {};
-
-      if (persistedItems.length > 0) {
-        payload.update_items = persistedItems.map((item) => ({
-          id: item.id,
-          number_received: item.numberReceived,
-          emerged_in_transit: item.emergedInTransit,
-          damaged_in_transit: item.damagedInTransit,
-          diseased_in_transit: item.diseasedInTransit,
-          parasite: item.parasite,
-          non_emergence: item.nonEmergence,
-          poor_emergence: item.poorEmergence,
-        }));
-      }
-
-      if (newItems.length > 0) {
-        payload.add_items = newItems.map((item) => ({
-          butterfly_species_id: item.butterflySpeciesId,
-          number_received: item.numberReceived,
-          emerged_in_transit: item.emergedInTransit,
-          damaged_in_transit: item.damagedInTransit,
-          diseased_in_transit: item.diseasedInTransit,
-          parasite: item.parasite,
-          non_emergence: item.nonEmergence,
-          poor_emergence: item.poorEmergence,
-        }));
-      }
-
-      const normalizedDeleteItemIds = uniquePositiveIds(deletedItemIds);
-
-      if (normalizedDeleteItemIds.length > 0) {
-        payload.delete_items = normalizedDeleteItemIds;
-      }
-
-      if (!payload.update_items && !payload.add_items && !payload.delete_items) {
-        setSaveItemsStatus("success");
-        setSaveItemsMessage("No shipment item changes to save");
-        return;
-      }
-
-      console.log("Saving shipment PATCH payload", payload);
-
-      const response = await fetch(`/api/tenant/shipments/${shipmentIdNumber}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json", ...tenantHeaders },
-        body: JSON.stringify(payload),
-      });
-
-      if (!response.ok) {
-        throw new Error(await readErrorMessage(response, "Failed to update shipment metrics"));
-      }
-
-      setDeletedItemIds([]);
-      setNextTempItemId(-1);
-
-      await syncAfterMutation();
-
-      setSaveItemsStatus("success");
-      setSaveItemsMessage("Shipment metrics updated");
-    } catch (error) {
-      setSaveItemsStatus("error");
-      setSaveItemsMessage(
-        error instanceof Error ? error.message : "Failed to update shipment metrics",
-      );
-    }
-  };
-
-  const releaseRows = useMemo(() => {
-    if (!detail) return [];
-
-    return detail.items
-      .filter((item) => item.id > 0)
-      .map((item) => {
-        const draft = releaseDrafts[item.id] ?? { goodEmergence: 0, poorEmergence: 0 };
-        return {
-          item,
-          available: getAvailableToRelease(item),
-          draft,
-        };
-      });
-  }, [detail, releaseDrafts]);
-
-  const shipmentItemById = useMemo(() => {
-    return new Map((detail?.items ?? []).map((item) => [item.id, item] as const));
-  }, [detail]);
-
-  const releaseSelections = useMemo(() => {
-    return releaseRows
-      .map((row) => ({
-        shipment_item_id: row.item.id,
-        quantity: row.draft.goodEmergence + row.draft.poorEmergence,
-      }))
-      .filter((row) => row.quantity > 0);
-  }, [releaseRows]);
-
-  const goodEmergenceByShipmentItemId = useMemo(() => {
-    return new Map(releaseRows.map((row) => [row.item.id, row.draft.goodEmergence] as const));
-  }, [releaseRows]);
-
-  const poorEmergenceSelections = useMemo(() => {
-    return releaseRows
-      .map((row) => ({
-        shipmentItemId: row.item.id,
-        poorEmergence: row.draft.poorEmergence,
-      }))
-      .filter((row) => row.poorEmergence > 0);
-  }, [releaseRows]);
-
-  const hasReleaseDraftValues = useMemo(() => {
-    return releaseRows.some((row) => row.draft.goodEmergence + row.draft.poorEmergence > 0);
-  }, [releaseRows]);
-
-  const updateReleaseDraft = (
-    itemId: number,
-    field: keyof ReleaseDraft,
-    delta: number,
-    available: number,
-  ) => {
-    setReleaseDrafts((prev) => {
-      const current = prev[itemId] ?? { goodEmergence: 0, poorEmergence: 0 };
-      const otherField: keyof ReleaseDraft =
-        field === "goodEmergence" ? "poorEmergence" : "goodEmergence";
-      const rawNextValue = Math.max(0, current[field] + delta);
-      const maxAllowed = Math.max(0, available - current[otherField]);
-
-      return {
-        ...prev,
-        [itemId]: {
-          ...current,
-          [field]: Math.min(rawNextValue, maxAllowed),
-        },
-      };
-    });
-  };
-
-  const handleCreateRelease = async () => {
-    if (!detail) return;
-    if (!hasReleaseDraftValues) return;
-
-    setReleaseStatus("saving");
-    setReleaseMessage(null);
-
-    try {
-      let createdRelease = false;
-      let normalizedInFlightToGoodOnly = false;
-      let updatedPoorEmergenceMetrics = false;
-
-      if (releaseSelections.length > 0) {
-        const response = await fetch(`/api/tenant/shipments/${shipmentIdNumber}/releases`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json", ...tenantHeaders },
-          body: JSON.stringify({
-            items: releaseSelections,
-          }),
         });
-
-        if (!response.ok) {
-          throw new Error(await readErrorMessage(response, "Failed to create release"));
-        }
-
-        const payload = await response.json();
-        const createdInFlightRows = extractCreatedInFlightRowsFromCreateResponse(payload);
-
-        for (const createdRow of createdInFlightRows) {
-          const goodEmergenceTarget =
-            goodEmergenceByShipmentItemId.get(createdRow.shipmentItemId) ?? 0;
-
-          if (goodEmergenceTarget <= 0) {
-            const deleteResponse = await fetch(`/api/tenant/in-flight/${createdRow.inFlightId}`, {
-              method: "DELETE",
-              headers: tenantHeaders,
-            });
-
-            if (!deleteResponse.ok) {
-              throw new Error(
-                await readErrorMessage(deleteResponse, "Failed to normalize in-flight rows"),
-              );
-            }
-
-            normalizedInFlightToGoodOnly = true;
-            continue;
-          }
-
-          if (goodEmergenceTarget !== createdRow.quantity) {
-            const patchResponse = await fetch(`/api/tenant/in-flight/${createdRow.inFlightId}`, {
-              method: "PATCH",
-              headers: { "Content-Type": "application/json", ...tenantHeaders },
-              body: JSON.stringify({ quantity: goodEmergenceTarget }),
-            });
-
-            if (!patchResponse.ok) {
-              throw new Error(
-                await readErrorMessage(patchResponse, "Failed to normalize in-flight rows"),
-              );
-            }
-
-            normalizedInFlightToGoodOnly = true;
-          }
-        }
-
-        createdRelease = true;
-      }
-
-      if (poorEmergenceSelections.length > 0) {
-        const updateItems = poorEmergenceSelections
-          .map((selection) => {
-            const item = detail.items.find(
-              (shipmentItem) => shipmentItem.id === selection.shipmentItemId,
-            );
-            if (!item || item.id <= 0) return null;
-
-            return {
-              id: item.id,
-              number_received: item.numberReceived,
-              emerged_in_transit: item.emergedInTransit,
-              damaged_in_transit: item.damagedInTransit,
-              diseased_in_transit: item.diseasedInTransit,
-              parasite: item.parasite,
-              non_emergence: item.nonEmergence,
-              poor_emergence: item.poorEmergence + selection.poorEmergence,
-            };
-          })
-          .filter(
-            (
-              item,
-            ): item is {
-              id: number;
-              number_received: number;
-              emerged_in_transit: number;
-              damaged_in_transit: number;
-              diseased_in_transit: number;
-              parasite: number;
-              non_emergence: number;
-              poor_emergence: number;
-            } => item !== null,
-          );
-
-        if (updateItems.length > 0) {
-          const metricsResponse = await fetch(`/api/tenant/shipments/${shipmentIdNumber}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json", ...tenantHeaders },
-            body: JSON.stringify({
-              update_items: updateItems,
-            }),
-          });
-
-          if (!metricsResponse.ok) {
-            throw new Error(
-              await readErrorMessage(metricsResponse, "Failed to update poor emergence metrics"),
-            );
-          }
-
-          updatedPoorEmergenceMetrics = true;
-        }
-      }
-
-      await syncAfterMutation();
-
-      setReleaseDrafts((prev) => {
-        const next: Record<number, ReleaseDraft> = {};
-        Object.keys(prev).forEach((key) => {
-          const parsed = Number(key);
-          if (Number.isFinite(parsed) && parsed > 0) {
-            next[parsed] = { goodEmergence: 0, poorEmergence: 0 };
-          }
-        });
-        return next;
-      });
-
-      setReleaseStatus("success");
-      if (createdRelease && normalizedInFlightToGoodOnly && updatedPoorEmergenceMetrics) {
-        setReleaseMessage(
-          "Release created, in-flight normalized, and poor emergence metrics updated",
-        );
-      } else if (createdRelease && normalizedInFlightToGoodOnly) {
-        setReleaseMessage("Release created and in-flight normalized to good emergence");
-      } else if (createdRelease && updatedPoorEmergenceMetrics) {
-        setReleaseMessage("Release created and poor emergence metrics updated");
-      } else if (createdRelease) {
-        setReleaseMessage("Release created");
-      } else if (updatedPoorEmergenceMetrics) {
-        setReleaseMessage("Poor emergence metrics updated");
-      } else {
-        setReleaseMessage("No release changes to create");
-      }
-    } catch (error) {
-      setReleaseStatus("error");
-      setReleaseMessage(error instanceof Error ? error.message : "Failed to create release");
-    }
-  };
-
-  const releaseEventRows = useMemo(() => {
-    return [...releaseEvents].sort(
-      (a, b) => new Date(b.releaseDate).valueOf() - new Date(a.releaseDate).valueOf(),
-    );
-  }, [releaseEvents]);
-
-  const releaseInFlightByShipmentItemId = useMemo(() => {
-    const map = new Map<number, { inFlightId: number; quantity: number }>();
-
-    releaseEvents.forEach((event) => {
-      event.items.forEach((item) => {
-        if (!item.inFlightId) return;
-
-        const existing = map.get(item.shipmentItemId);
-        if (!existing || item.inFlightId > existing.inFlightId) {
-          map.set(item.shipmentItemId, {
-            inFlightId: item.inFlightId,
-            quantity: item.quantity,
-          });
-        }
-      });
+      return [...current, ...additions];
     });
+  }, []);
 
-    return map;
-  }, [releaseEvents]);
+  const handleMetricChange = useCallback((itemId: number, field: MetricKey, value: number) => {
+    setDraftItems((current) =>
+      current.map((item) => (item.id === itemId ? { ...item, [field]: value } : item)),
+    );
+  }, []);
 
-  useEffect(() => {
-    const next: Record<number, number> = {};
+  const handleRemoveDraftItem = useCallback((itemId: number) => {
+    setDraftItems((current) => current.filter((item) => item.id !== itemId));
+  }, []);
 
-    releaseInFlightByShipmentItemId.forEach((row) => {
-      next[row.inFlightId] = row.quantity;
-    });
+  const handleSave = async () => {
+    if (!data) return;
 
-    setInFlightEdits(next);
-  }, [releaseInFlightByShipmentItemId]);
-
-  const handleDeleteRelease = async (releaseId: number) => {
-    setReleaseStatus("saving");
-    setReleaseMessage(null);
-
-    try {
-      const response = await fetch(releaseRouteUrl(releaseId), {
-        method: "DELETE",
-        headers: tenantHeaders,
-      });
-
-      if (!response.ok) {
-        throw new Error(await readErrorMessage(response, "Failed to delete release"));
-      }
-      setReleaseEvents((prev) => prev.filter((event) => event.id !== releaseId));
-
-      if (editingReleaseId === releaseId) {
-        setEditingReleaseId(null);
-        setEditingRows([]);
-        setEditingDeleteInFlightIds([]);
-      }
-
-      await syncAfterMutation();
-
-      setReleaseStatus("success");
-      setReleaseMessage("Release deleted");
-    } catch (error) {
-      setReleaseStatus("error");
-      setReleaseMessage(error instanceof Error ? error.message : "Failed to delete release");
-    }
-  };
-
-  const startReleaseEditing = (releaseId: number) => {
-    const release = releaseEvents.find((event) => event.id === releaseId);
-    if (!release) return;
-
-    setEditingReleaseId(release.id);
-    setEditingDeleteInFlightIds([]);
-    setEditingRows(
-      release.items.map((item) => ({
-        inFlightId: item.inFlightId,
-        shipmentItemId: item.shipmentItemId,
-        goodEmergence: item.goodEmergence,
-        poorEmergence: item.poorEmergence,
-      })),
+    const original = new Map(data.items.map((item) => [item.id, item]));
+    // Only consider real (positive id) draft rows when computing deletions —
+    // negative ids are session-local additions, not existing rows.
+    const existingDraftIds = new Set(
+      draftItems.filter((item) => item.id > 0).map((item) => item.id),
     );
 
-    setEditReleaseStatus("idle");
-    setEditReleaseMessage(null);
-  };
-
-  const updateEditingRowMetric = (
-    rowIndex: number,
-    field: "goodEmergence" | "poorEmergence",
-    delta: number,
-  ) => {
-    setEditingRows((prev) =>
-      prev.map((row, index) => {
-        if (index !== rowIndex) return row;
-        return {
-          ...row,
-          [field]: Math.max(0, row[field] + delta),
-        };
-      }),
-    );
-  };
-
-  const updateEditingRowSpecies = (rowIndex: number, shipmentItemId: number) => {
-    setEditingRows((prev) =>
-      prev.map((row, index) => {
-        if (index !== rowIndex) return row;
-        return {
-          ...row,
-          shipmentItemId,
-        };
-      }),
-    );
-  };
-
-  const addEditingRow = () => {
-    if (!detail) return;
-
-    const availableRows = detail.items.filter((item) => item.id > 0);
-    if (availableRows.length === 0) return;
-
-    setEditingRows((prev) => {
-      const used = new Set(prev.map((row) => row.shipmentItemId));
-      const nextSpecies = availableRows.find((item) => !used.has(item.id)) ?? availableRows[0];
-
-      return [
-        ...prev,
-        {
-          inFlightId: null,
-          shipmentItemId: nextSpecies.id,
-          goodEmergence: 0,
-          poorEmergence: 0,
-        },
-      ];
-    });
-  };
-
-  const removeEditingRow = (rowIndex: number, inFlightId: number | null) => {
-    if (inFlightId) {
-      setEditingDeleteInFlightIds((prev) => uniquePositiveIds([...prev, inFlightId]));
-    }
-
-    setEditingRows((prev) => prev.filter((_, index) => index !== rowIndex));
-  };
-
-  const handleSaveReleaseEdit = async () => {
-    if (!editingReleaseId) return;
-
-    const rowsWithQuantity = editingRows
-      .map((row) => ({
-        inFlightId: row.inFlightId,
-        shipment_item_id: row.shipmentItemId,
-        quantity: row.goodEmergence + row.poorEmergence,
-      }))
-      .filter((row) => row.quantity > 0);
-
-    const updateItems = rowsWithQuantity
-      .filter((row) => row.inFlightId)
-      .map((row) => ({
-        shipment_item_id: row.shipment_item_id,
-        quantity: row.quantity,
+    const updateItems = draftItems
+      .filter((draft) => {
+        if (draft.id <= 0) return false;
+        const orig = original.get(draft.id);
+        if (!orig) return false;
+        return (Object.keys(METRIC_TO_API) as MetricKey[]).some((k) => orig[k] !== draft[k]);
+      })
+      .map((draft) => ({
+        id: draft.id,
+        number_received: draft.numberReceived,
+        emerged_in_transit: draft.emergedInTransit,
+        damaged_in_transit: draft.damagedInTransit,
+        diseased_in_transit: draft.diseasedInTransit,
+        parasite: draft.parasite,
+        non_emergence: draft.nonEmergence,
+        poor_emergence: draft.poorEmergence,
       }));
 
-    const addItems = rowsWithQuantity
-      .filter((row) => !row.inFlightId)
-      .map((row) => ({
-        shipment_item_id: row.shipment_item_id,
-        quantity: row.quantity,
+    const addItems = draftItems
+      .filter((draft) => draft.id <= 0)
+      .map((draft) => ({
+        butterfly_species_id: draft.butterflySpeciesId,
+        number_received: draft.numberReceived,
+        emerged_in_transit: draft.emergedInTransit,
+        damaged_in_transit: draft.damagedInTransit,
+        diseased_in_transit: draft.diseasedInTransit,
+        parasite: draft.parasite,
+        non_emergence: draft.nonEmergence,
+        poor_emergence: draft.poorEmergence,
       }));
 
-    const deleteIdsFromZeroQuantityRows = editingRows
-      .filter((row) => row.inFlightId && row.goodEmergence + row.poorEmergence <= 0)
-      .map((row) => row.inFlightId);
+    const deleteItems = data.items
+      .filter((item) => !existingDraftIds.has(item.id))
+      .map((item) => item.id);
 
-    const deleteInFlightIds = uniquePositiveIds([
-      ...editingDeleteInFlightIds,
-      ...deleteIdsFromZeroQuantityRows,
-    ]);
-
-    if (updateItems.length === 0 && addItems.length === 0 && deleteInFlightIds.length === 0) {
-      setEditReleaseStatus("success");
-      setEditReleaseMessage("No release changes to save");
+    if (updateItems.length === 0 && addItems.length === 0 && deleteItems.length === 0) {
+      setEditing(false);
       return;
     }
 
-    setEditReleaseStatus("saving");
-    setEditReleaseMessage(null);
-
+    setSaving(true);
+    setErrorMessage(null);
     try {
-      for (const inFlightId of deleteInFlightIds) {
-        const response = await fetch(`/api/tenant/in-flight/${inFlightId}`, {
-          method: "DELETE",
-          headers: tenantHeaders,
-        });
+      const body: Record<string, unknown> = {};
+      if (updateItems.length > 0) body.update_items = updateItems;
+      if (addItems.length > 0) body.add_items = addItems;
+      if (deleteItems.length > 0) body.delete_items = deleteItems;
 
-        if (!response.ok) {
-          throw new Error(await readErrorMessage(response, "Failed to remove release row"));
-        }
-      }
-
-      if (updateItems.length > 0) {
-        const response = await fetch(releaseRouteUrl(editingReleaseId), {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json", ...tenantHeaders },
-          body: JSON.stringify({ items: updateItems }),
-        });
-
-        if (!response.ok) {
-          throw new Error(await readErrorMessage(response, "Failed to update release"));
-        }
-      }
-
-      for (const item of addItems) {
-        const response = await fetch(`/api/tenant/releases/${editingReleaseId}/in-flight`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json", ...tenantHeaders },
-          body: JSON.stringify(item),
-        });
-
-        if (!response.ok) {
-          throw new Error(await readErrorMessage(response, "Failed to add release row"));
-        }
-      }
-
-      await syncAfterMutation();
-      setEditingDeleteInFlightIds([]);
-
-      setEditReleaseStatus("success");
-      setEditReleaseMessage("Release updated");
-    } catch (error) {
-      setEditReleaseStatus("error");
-      setEditReleaseMessage(error instanceof Error ? error.message : "Failed to update release");
-    }
-  };
-
-  const inFlightItems = useMemo(() => {
-    if (!detail) return [];
-    return detail.items.filter((item) => item.inFlightQuantity > 0);
-  }, [detail]);
-
-  const updateInFlightEdit = (inFlightId: number, delta: number, fallbackValue: number) => {
-    setInFlightEdits((prev) => {
-      const current = prev[inFlightId] ?? fallbackValue;
-      return {
-        ...prev,
-        [inFlightId]: Math.max(1, current + delta),
-      };
-    });
-  };
-
-  const handleUpdateInFlight = async (shipmentItemId: number, fallbackValue: number) => {
-    const releaseRow = releaseInFlightByShipmentItemId.get(shipmentItemId);
-    if (!releaseRow) return;
-
-    const quantity = Math.max(1, inFlightEdits[releaseRow.inFlightId] ?? fallbackValue);
-
-    setInFlightStatus("saving");
-    setInFlightMessage(null);
-
-    try {
-      const response = await fetch(`/api/tenant/in-flight/${releaseRow.inFlightId}`, {
+      const response = await fetch(`/api/tenant/shipments/${shipmentId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json", ...tenantHeaders },
-        body: JSON.stringify({ quantity }),
+        body: JSON.stringify(body),
       });
-
+      const result = await response.json().catch(() => null);
       if (!response.ok) {
-        throw new Error(await readErrorMessage(response, "Failed to update in-flight quantity"));
+        setErrorMessage(result?.error?.message ?? "Unable to save changes.");
+        return;
       }
-
-      await syncAfterMutation();
-
-      setInFlightStatus("success");
-      setInFlightMessage("In-flight quantity updated");
-    } catch (error) {
-      setInFlightStatus("error");
-      setInFlightMessage(
-        error instanceof Error ? error.message : "Failed to update in-flight quantity",
-      );
+      setEditing(false);
+      tempIdCounter.current = 0;
+      await loadShipment();
+      // loadShipment without a signal is fine here — the post-save reload
+      // is short-lived and intentionally outlives the original effect.
+    } finally {
+      setSaving(false);
     }
   };
 
-  const handleDeleteInFlight = async (shipmentItemId: number) => {
-    const releaseRow = releaseInFlightByShipmentItemId.get(shipmentItemId);
-    if (!releaseRow) return;
-
-    setInFlightStatus("saving");
-    setInFlightMessage(null);
-
+  const confirmDelete = async () => {
+    setDeleteOpen(false);
     try {
-      const response = await fetch(`/api/tenant/in-flight/${releaseRow.inFlightId}`, {
+      const response = await fetch(`/api/tenant/shipments/${shipmentId}`, {
         method: "DELETE",
         headers: tenantHeaders,
       });
-
       if (!response.ok) {
-        throw new Error(await readErrorMessage(response, "Failed to delete in-flight row"));
+        const result = await response.json().catch(() => null);
+        setErrorMessage(result?.error?.message ?? "Unable to delete shipment.");
+        return;
       }
-
-      await syncAfterMutation();
-
-      setInFlightStatus("success");
-      setInFlightMessage("In-flight row deleted");
-    } catch (error) {
-      setInFlightStatus("error");
-      setInFlightMessage(error instanceof Error ? error.message : "Failed to delete in-flight row");
+      router.push(ROUTES.tenant.shipments(slug));
+    } catch {
+      setErrorMessage("Unable to delete shipment.");
     }
   };
 
-  if (status === "loading" && !detail) {
+  // Bad URL ids — bail to the nearest not-found boundary instead of showing a
+  // bespoke "invalid id" message inside the tenant shell.
+  if (!Number.isFinite(shipmentId) || shipmentId <= 0) {
+    notFound();
+  }
+
+  if (status === "loading") {
     return (
-      <div className="mx-auto flex w-full max-w-[1700px] flex-col gap-6 px-4 py-10 md:px-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Loading shipment</CardTitle>
-          </CardHeader>
-        </Card>
+      <div className="text-muted-foreground" role="status" aria-live="polite" aria-busy="true">
+        Loading shipment…
       </div>
     );
   }
-
-  if (!detail) {
+  if (status === "error" || !data) {
     return (
-      <div className="mx-auto flex w-full max-w-[1700px] flex-col gap-6 px-4 py-10 md:px-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Shipment not available</CardTitle>
-            <CardDescription>{errorMessage ?? "Unable to load shipment"}</CardDescription>
-          </CardHeader>
-        </Card>
+      <div className="flex flex-col gap-4">
+        <p className="text-destructive">{errorMessage ?? "Shipment not available."}</p>
+        <Button asChild variant="outline">
+          <Link href={ROUTES.tenant.shipments(slug)}>
+            <ArrowLeft className="size-4" />
+            Back to shipments
+          </Link>
+        </Button>
       </div>
     );
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-[1700px] flex-col gap-6 px-4 py-10 md:px-6">
-      <Card>
-        <CardHeader>
-          <CardTitle>Shipment Summary</CardTitle>
-        </CardHeader>
-
-        <CardContent>
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            <div className="rounded-md border p-3">
-              <p className="text-muted-foreground text-xs uppercase">Supplier</p>
-              <p className="text-sm font-semibold">{detail.shipment.supplierCode}</p>
-            </div>
-
-            <div className="rounded-md border p-3">
-              <p className="text-muted-foreground text-xs uppercase">Shipment Date</p>
-              <p className="text-sm font-semibold">
-                {formatDateTime(detail.shipment.shipmentDate)}
-              </p>
-            </div>
-
-            <div className="rounded-md border p-3">
-              <p className="text-muted-foreground text-xs uppercase">Arrival Date</p>
-              <p className="text-sm font-semibold">{formatDateTime(detail.shipment.arrivalDate)}</p>
-            </div>
-
-            <div className="rounded-md border p-3">
-              <p className="text-muted-foreground text-xs uppercase">Created</p>
-              <p className="text-sm font-semibold">{formatDateTime(detail.shipment.createdAt)}</p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      <div className="flex flex-wrap items-center gap-3 border-b pb-2">
-        <div className="flex gap-2">
-          <Button
-            variant={activeTab === "items" ? "default" : "outline"}
-            onClick={() => setActiveTab("items")}
-          >
-            Line Items
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-1">
+          <Button asChild variant="ghost" size="sm" className="-ml-2">
+            <Link href={ROUTES.tenant.shipments(slug)}>
+              <ArrowLeft className="size-4" />
+              All shipments
+            </Link>
           </Button>
-
-          <Button
-            variant={activeTab === "releases" ? "default" : "outline"}
-            onClick={() => setActiveTab("releases")}
-          >
-            Releases
-          </Button>
-
-          <Button
-            variant={activeTab === "inflight" ? "default" : "outline"}
-            onClick={() => setActiveTab("inflight")}
-          >
-            In-Flight
-          </Button>
+          <h1 className="text-3xl font-semibold">Shipment from {data.shipment.supplierCode}</h1>
+          <p className="text-muted-foreground">
+            Shipped {formatDate(data.shipment.shipmentDate)} · Arrived{" "}
+            {formatDate(data.shipment.arrivalDate)}
+          </p>
         </div>
-
-        <div className="ml-auto flex items-center gap-2">
-          <label className="text-sm" htmlFor="name-display-mode">
-            List Names By
-          </label>
-          <select
-            id="name-display-mode"
-            className="rounded-md border px-2 py-1 text-sm"
-            value={nameDisplayMode}
-            onChange={(event) => setNameDisplayMode(event.target.value as "scientific" | "common")}
-          >
-            <option value="scientific">Scientific Name</option>
-            <option value="common">Common Name</option>
-          </select>
+        <div className="flex items-center gap-2">
+          {!editing && !totals.isCompleted && data.items.length > 0 && (
+            <Button asChild>
+              <Link href={ROUTES.tenant.shipmentReleaseNew(slug, shipmentId)}>Add release</Link>
+            </Button>
+          )}
+          {!editing && (
+            <Button variant="outline" onClick={() => setForceEditPrompted(true)}>
+              <Pencil className="size-4" />
+              Edit items
+            </Button>
+          )}
+          {!editing && (
+            <Button variant="destructive" onClick={() => setDeleteOpen(true)}>
+              <Trash2 className="size-4" />
+              Delete
+            </Button>
+          )}
         </div>
       </div>
 
-      {activeTab === "items" && (
+      <div className="grid gap-4 md:grid-cols-4">
         <Card>
           <CardHeader>
-            <CardTitle>Shipment Items</CardTitle>
-            <CardDescription>
-              Use +/- controls to update shipment metrics for testing.
-            </CardDescription>
+            <CardDescription>Status</CardDescription>
           </CardHeader>
-
-          <CardContent className="space-y-4">
-            <div className="flex items-center gap-3">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={handleAddShipmentItem}
-                disabled={availableSpeciesOptions.length === 0}
-              >
-                Add Shipment Item
-              </Button>
-            </div>
-
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Photo</TableHead>
-                  <TableHead>
-                    {nameDisplayMode === "scientific" ? "Scientific Name" : "Common Name"}
-                  </TableHead>
-                  <TableHead>Received</TableHead>
-                  <TableHead>Emerged</TableHead>
-                  <TableHead>Damaged</TableHead>
-                  <TableHead>Diseased</TableHead>
-                  <TableHead>Parasite</TableHead>
-                  <TableHead>Non-Emergence</TableHead>
-                  <TableHead>Poor Emergence</TableHead>
-                  <TableHead>In Flight</TableHead>
-                  <TableHead>Remaining</TableHead>
-                  <TableHead>Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-
-              <TableBody>
-                {detail.items.map((item) => {
-                  const imageUrl = getShipmentItemImageUrl(item);
-                  const displayName = getDisplayName(item);
-
-                  return (
-                    <TableRow key={item.id}>
-                      <TableCell>
-                        {imageUrl ? (
-                          <Image
-                            src={imageUrl}
-                            alt={displayName}
-                            width={40}
-                            height={40}
-                            className="rounded"
-                          />
-                        ) : (
-                          "-"
-                        )}
-                      </TableCell>
-
-                      <TableCell>
-                        {item.id > 0 ? (
-                          <span className="italic">{displayName}</span>
-                        ) : (
-                          <select
-                            className="w-full rounded-md border px-2 py-1 text-sm"
-                            value={item.butterflySpeciesId}
-                            onChange={(event) =>
-                              updateItemSpecies(item.id, Number(event.target.value))
-                            }
-                          >
-                            {availableSpeciesOptions.map((species) => (
-                              <option
-                                key={`${item.id}-${species.butterflySpeciesId}`}
-                                value={species.butterflySpeciesId}
-                              >
-                                {getDisplayName(species)}
-                              </option>
-                            ))}
-                          </select>
-                        )}
-                      </TableCell>
-
-                      <TableCell>
-                        <QuantityStepper
-                          value={item.numberReceived}
-                          onDecrement={() => updateMetric(item.id, "numberReceived", -1)}
-                          onIncrement={() => updateMetric(item.id, "numberReceived", 1)}
-                          decrementLabel={`Decrease number received for ${displayName}`}
-                          incrementLabel={`Increase number received for ${displayName}`}
-                        />
-                      </TableCell>
-
-                      <TableCell>
-                        <QuantityStepper
-                          value={item.emergedInTransit}
-                          onDecrement={() => updateMetric(item.id, "emergedInTransit", -1)}
-                          onIncrement={() => updateMetric(item.id, "emergedInTransit", 1)}
-                          decrementLabel={`Decrease emerged in transit for ${displayName}`}
-                          incrementLabel={`Increase emerged in transit for ${displayName}`}
-                        />
-                      </TableCell>
-
-                      <TableCell>
-                        <QuantityStepper
-                          value={item.damagedInTransit}
-                          onDecrement={() => updateMetric(item.id, "damagedInTransit", -1)}
-                          onIncrement={() => updateMetric(item.id, "damagedInTransit", 1)}
-                          decrementLabel={`Decrease damaged in transit for ${displayName}`}
-                          incrementLabel={`Increase damaged in transit for ${displayName}`}
-                        />
-                      </TableCell>
-
-                      <TableCell>
-                        <QuantityStepper
-                          value={item.diseasedInTransit}
-                          onDecrement={() => updateMetric(item.id, "diseasedInTransit", -1)}
-                          onIncrement={() => updateMetric(item.id, "diseasedInTransit", 1)}
-                          decrementLabel={`Decrease diseased in transit for ${displayName}`}
-                          incrementLabel={`Increase diseased in transit for ${displayName}`}
-                        />
-                      </TableCell>
-
-                      <TableCell>
-                        <QuantityStepper
-                          value={item.parasite}
-                          onDecrement={() => updateMetric(item.id, "parasite", -1)}
-                          onIncrement={() => updateMetric(item.id, "parasite", 1)}
-                          decrementLabel={`Decrease parasite count for ${displayName}`}
-                          incrementLabel={`Increase parasite count for ${displayName}`}
-                        />
-                      </TableCell>
-
-                      <TableCell>
-                        <QuantityStepper
-                          value={item.nonEmergence}
-                          onDecrement={() => updateMetric(item.id, "nonEmergence", -1)}
-                          onIncrement={() => updateMetric(item.id, "nonEmergence", 1)}
-                          decrementLabel={`Decrease non-emergence count for ${displayName}`}
-                          incrementLabel={`Increase non-emergence count for ${displayName}`}
-                        />
-                      </TableCell>
-
-                      <TableCell>
-                        <QuantityStepper
-                          value={item.poorEmergence}
-                          onDecrement={() => updateMetric(item.id, "poorEmergence", -1)}
-                          onIncrement={() => updateMetric(item.id, "poorEmergence", 1)}
-                          decrementLabel={`Decrease poor emergence count for ${displayName}`}
-                          incrementLabel={`Increase poor emergence count for ${displayName}`}
-                        />
-                      </TableCell>
-
-                      <TableCell>{item.inFlightQuantity}</TableCell>
-
-                      <TableCell className="font-semibold">{getRemaining(item)}</TableCell>
-
-                      <TableCell>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="destructive"
-                          onClick={() => handleDeleteShipmentItem(item.id)}
-                        >
-                          Delete
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-
-            <div className="flex items-center gap-3">
-              <Button onClick={handleSaveShipmentItems} disabled={saveItemsStatus === "saving"}>
-                Save Metrics
-              </Button>
-
-              {saveItemsMessage && <p className="text-sm">{saveItemsMessage}</p>}
-            </div>
+          <CardContent>
+            <ShipmentStatusBadge remaining={totals.remaining} isCompleted={totals.isCompleted} />
           </CardContent>
         </Card>
+        <SummaryCard label="Received" value={totals.totalReceived} />
+        <SummaryCard label="Losses" value={totals.totalLosses} />
+        <SummaryCard label="Released" value={totals.totalReleased} />
+      </div>
+
+      {errorMessage && (
+        <div className="text-destructive text-sm" role="alert">
+          {errorMessage}
+        </div>
       )}
 
-      {activeTab === "releases" && (
-        <div className="space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Create Release</CardTitle>
-              <CardDescription>Use good and poor emergence controls per species.</CardDescription>
-            </CardHeader>
+      <Card>
+        {/*
+          Sticky so the title and (most importantly) the Save / Cancel buttons
+          remain visible while the user scrolls through a long species list.
+          The nearest scroll ancestor is the tenant `<main>` so `top-0` pins
+          this just below the tenant header.
+        */}
+        <CardHeader className="bg-card sticky top-0 z-10 flex flex-row items-center justify-between gap-4 space-y-0 rounded-t-xl border-b">
+          <div>
+            <CardTitle>Butterflies</CardTitle>
+            <CardDescription>
+              {editing
+                ? "Editing the shipment items directly. Be careful — this bypasses release tracking."
+                : "Search and review the species in this shipment."}
+            </CardDescription>
+          </div>
+          {editing && (
+            <div className="flex flex-wrap items-center gap-2">
+              <Button variant="secondary" onClick={handleOpenPicker} disabled={saving}>
+                <Plus className="size-4" />
+                Add butterflies
+              </Button>
+              <Button variant="outline" onClick={handleCancelEditing} disabled={saving}>
+                Cancel
+              </Button>
+              <Button onClick={handleSave} disabled={saving}>
+                {saving ? "Saving…" : "Save changes"}
+              </Button>
+            </div>
+          )}
+        </CardHeader>
+        <CardContent>
+          <ShipmentItemsTable
+            items={editing ? draftItems : data.items}
+            editing={editing}
+            onMetricChange={handleMetricChange}
+            onRemoveItem={handleRemoveDraftItem}
+          />
+        </CardContent>
+      </Card>
 
-            <CardContent className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Release history</CardTitle>
+          <CardDescription>
+            All releases recorded against this shipment, newest first.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {releases.length === 0 ? (
+            <p className="text-muted-foreground rounded-md border p-6 text-center text-sm">
+              No releases yet.
+            </p>
+          ) : (
+            <div className="overflow-x-auto rounded-md border">
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Photo</TableHead>
-                    <TableHead>Species</TableHead>
-                    <TableHead>Available</TableHead>
-                    <TableHead>Good Emergence</TableHead>
-                    <TableHead>Poor Emergence</TableHead>
+                    <TableHead>Release date</TableHead>
+                    <TableHead>Released by</TableHead>
+                    <TableHead className="text-right">Released</TableHead>
+                    <TableHead className="text-right">Action</TableHead>
                   </TableRow>
                 </TableHeader>
-
                 <TableBody>
-                  {releaseRows.map((row) => (
-                    <TableRow key={row.item.id}>
-                      <TableCell>
-                        {getShipmentItemImageUrl(row.item) ? (
-                          <Image
-                            src={getShipmentItemImageUrl(row.item)!}
-                            alt={getDisplayName(row.item)}
-                            width={40}
-                            height={40}
-                            className="rounded"
-                          />
-                        ) : (
-                          "-"
-                        )}
+                  {releases.map((release) => (
+                    <TableRow key={release.id}>
+                      <TableCell className="font-medium">
+                        {formatDate(release.releaseDate)}
                       </TableCell>
-                      <TableCell className="italic">{getDisplayName(row.item)}</TableCell>
-                      <TableCell>{row.available}</TableCell>
-
-                      <TableCell>
-                        <QuantityStepper
-                          value={row.draft.goodEmergence}
-                          onDecrement={() =>
-                            updateReleaseDraft(row.item.id, "goodEmergence", -1, row.available)
-                          }
-                          onIncrement={() =>
-                            updateReleaseDraft(row.item.id, "goodEmergence", 1, row.available)
-                          }
-                          decrementLabel={`Decrease good emergence for ${getDisplayName(row.item)}`}
-                          incrementLabel={`Increase good emergence for ${getDisplayName(row.item)}`}
-                        />
-                      </TableCell>
-
-                      <TableCell>
-                        <QuantityStepper
-                          value={row.draft.poorEmergence}
-                          onDecrement={() =>
-                            updateReleaseDraft(row.item.id, "poorEmergence", -1, row.available)
-                          }
-                          onIncrement={() =>
-                            updateReleaseDraft(row.item.id, "poorEmergence", 1, row.available)
-                          }
-                          decrementLabel={`Decrease poor emergence for ${getDisplayName(row.item)}`}
-                          incrementLabel={`Increase poor emergence for ${getDisplayName(row.item)}`}
-                        />
+                      <TableCell>{release.releasedBy}</TableCell>
+                      <TableCell className="text-right">{release.totalReleased}</TableCell>
+                      <TableCell className="text-right">
+                        <Button asChild size="sm" variant="outline">
+                          <Link
+                            href={ROUTES.tenant.shipmentReleaseEdit(slug, shipmentId, release.id)}
+                          >
+                            Edit
+                          </Link>
+                        </Button>
                       </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
               </Table>
-
-              <div className="flex items-center gap-3">
-                <Button
-                  onClick={handleCreateRelease}
-                  disabled={!hasReleaseDraftValues || releaseStatus === "saving"}
-                >
-                  Create Release
-                </Button>
-
-                {releaseMessage && <p className="text-sm">{releaseMessage}</p>}
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Release Events</CardTitle>
-            </CardHeader>
-
-            <CardContent className="space-y-4">
-              {releaseHistoryStatus === "loading" && (
-                <p className="text-muted-foreground text-sm">Loading release events...</p>
-              )}
-
-              {releaseHistoryStatus === "error" && releaseHistoryMessage && (
-                <p className="text-sm">{releaseHistoryMessage}</p>
-              )}
-
-              {releaseEventRows.length === 0 ? (
-                <p className="text-muted-foreground text-sm">
-                  No release events available in this session.
-                </p>
-              ) : (
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Release ID</TableHead>
-                      <TableHead>Date</TableHead>
-                      <TableHead>Species Count</TableHead>
-                      <TableHead>Actions</TableHead>
-                    </TableRow>
-                  </TableHeader>
-
-                  <TableBody>
-                    {releaseEventRows.map((event) => (
-                      <TableRow key={event.id}>
-                        <TableCell>{event.id}</TableCell>
-                        <TableCell>{formatDateTime(event.releaseDate)}</TableCell>
-                        <TableCell>{event.items.length}</TableCell>
-                        <TableCell className="flex gap-2">
-                          <Button
-                            type="button"
-                            size="sm"
-                            variant="outline"
-                            onClick={() => startReleaseEditing(event.id)}
-                          >
-                            Edit
-                          </Button>
-
-                          <Button
-                            type="button"
-                            size="sm"
-                            variant="destructive"
-                            onClick={() => handleDeleteRelease(event.id)}
-                            disabled={releaseStatus === "saving"}
-                          >
-                            Delete
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              )}
-            </CardContent>
-          </Card>
-
-          {editingReleaseId && (
-            <Card>
-              <CardHeader>
-                <CardTitle>Edit Release {editingReleaseId}</CardTitle>
-              </CardHeader>
-
-              <CardContent className="space-y-4">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Photo</TableHead>
-                      <TableHead>Species</TableHead>
-                      <TableHead>Good Emergence</TableHead>
-                      <TableHead>Poor Emergence</TableHead>
-                      <TableHead>Remove Row</TableHead>
-                    </TableRow>
-                  </TableHeader>
-
-                  <TableBody>
-                    {editingRows.map((row, rowIndex) => {
-                      const rowItem = shipmentItemById.get(row.shipmentItemId);
-                      const rowImage = rowItem ? getShipmentItemImageUrl(rowItem) : null;
-
-                      return (
-                        <TableRow key={`${row.shipmentItemId}-${rowIndex}`}>
-                          <TableCell>
-                            {rowImage ? (
-                              <Image
-                                src={rowImage}
-                                alt={
-                                  rowItem
-                                    ? getDisplayName(rowItem)
-                                    : `Species ${row.shipmentItemId}`
-                                }
-                                width={40}
-                                height={40}
-                                className="rounded"
-                              />
-                            ) : (
-                              "-"
-                            )}
-                          </TableCell>
-
-                          <TableCell>
-                            {row.inFlightId ? (
-                              <span className="italic">
-                                {rowItem
-                                  ? getDisplayName(rowItem)
-                                  : `Species ${row.shipmentItemId}`}
-                              </span>
-                            ) : (
-                              <select
-                                className="w-full rounded-md border px-2 py-1 text-sm"
-                                value={row.shipmentItemId}
-                                onChange={(event) =>
-                                  updateEditingRowSpecies(rowIndex, Number(event.target.value))
-                                }
-                              >
-                                {detail.items
-                                  .filter((item) => item.id > 0)
-                                  .map((item) => (
-                                    <option key={item.id} value={item.id}>
-                                      {getDisplayName(item)}
-                                    </option>
-                                  ))}
-                              </select>
-                            )}
-                          </TableCell>
-
-                          <TableCell>
-                            <QuantityStepper
-                              value={row.goodEmergence}
-                              onDecrement={() =>
-                                updateEditingRowMetric(rowIndex, "goodEmergence", -1)
-                              }
-                              onIncrement={() =>
-                                updateEditingRowMetric(rowIndex, "goodEmergence", 1)
-                              }
-                              decrementLabel={`Decrease good emergence in row ${rowIndex + 1}`}
-                              incrementLabel={`Increase good emergence in row ${rowIndex + 1}`}
-                            />
-                          </TableCell>
-
-                          <TableCell>
-                            <QuantityStepper
-                              value={row.poorEmergence}
-                              onDecrement={() =>
-                                updateEditingRowMetric(rowIndex, "poorEmergence", -1)
-                              }
-                              onIncrement={() =>
-                                updateEditingRowMetric(rowIndex, "poorEmergence", 1)
-                              }
-                              decrementLabel={`Decrease poor emergence in row ${rowIndex + 1}`}
-                              incrementLabel={`Increase poor emergence in row ${rowIndex + 1}`}
-                            />
-                          </TableCell>
-
-                          <TableCell>
-                            <Button
-                              type="button"
-                              size="sm"
-                              variant="outline"
-                              onClick={() => removeEditingRow(rowIndex, row.inFlightId)}
-                            >
-                              Remove
-                            </Button>
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
-
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button type="button" variant="outline" onClick={addEditingRow}>
-                    Add Species Row
-                  </Button>
-
-                  <Button
-                    type="button"
-                    onClick={handleSaveReleaseEdit}
-                    disabled={editReleaseStatus === "saving"}
-                  >
-                    Save Release
-                  </Button>
-
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => {
-                      setEditingReleaseId(null);
-                      setEditingRows([]);
-                      setEditingDeleteInFlightIds([]);
-                      setEditReleaseStatus("idle");
-                      setEditReleaseMessage(null);
-                    }}
-                  >
-                    Cancel
-                  </Button>
-
-                  {editReleaseMessage && <p className="text-sm">{editReleaseMessage}</p>}
-                </div>
-              </CardContent>
-            </Card>
+            </div>
           )}
-        </div>
-      )}
+        </CardContent>
+      </Card>
 
-      {activeTab === "inflight" && (
-        <Card>
-          <CardHeader>
-            <CardTitle>In-Flight Butterflies</CardTitle>
-          </CardHeader>
+      <AlertDialog open={forceEditPrompted} onOpenChange={setForceEditPrompted}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Edit shipment items?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This bypasses release tracking. Use it only when correcting data entry mistakes. Any
+              reduction below already-released quantities will be rejected.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleStartEditing}>Continue</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
-          <CardContent className="space-y-3">
-            {inFlightItems.length === 0 ? (
-              <p className="text-muted-foreground text-sm">No butterflies currently in flight.</p>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Photo</TableHead>
-                    <TableHead>Species</TableHead>
-                    <TableHead>Quantity</TableHead>
-                  </TableRow>
-                </TableHeader>
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this shipment?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Shipments with line items or releases cannot be deleted. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDelete}>Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
-                <TableBody>
-                  {inFlightItems.map((item) => {
-                    const releaseRow = releaseInFlightByShipmentItemId.get(item.id);
-                    const displayName = getDisplayName(item);
-
-                    return (
-                      <TableRow key={item.id}>
-                        <TableCell>
-                          {getShipmentItemImageUrl(item) ? (
-                            <Image
-                              src={getShipmentItemImageUrl(item)!}
-                              alt={displayName}
-                              width={40}
-                              height={40}
-                              className="rounded"
-                            />
-                          ) : (
-                            "-"
-                          )}
-                        </TableCell>
-                        <TableCell className="italic">{displayName}</TableCell>
-
-                        <TableCell className="space-y-2">
-                          {releaseRow ? (
-                            <>
-                              <QuantityStepper
-                                value={
-                                  inFlightEdits[releaseRow.inFlightId] ?? item.inFlightQuantity
-                                }
-                                onDecrement={() =>
-                                  updateInFlightEdit(
-                                    releaseRow.inFlightId,
-                                    -1,
-                                    item.inFlightQuantity,
-                                  )
-                                }
-                                onIncrement={() =>
-                                  updateInFlightEdit(
-                                    releaseRow.inFlightId,
-                                    1,
-                                    item.inFlightQuantity,
-                                  )
-                                }
-                                decrementLabel={`Decrease in-flight quantity for ${displayName}`}
-                                incrementLabel={`Increase in-flight quantity for ${displayName}`}
-                              />
-
-                              <div className="flex flex-wrap items-center gap-2">
-                                <Button
-                                  type="button"
-                                  size="sm"
-                                  onClick={() =>
-                                    handleUpdateInFlight(item.id, item.inFlightQuantity)
-                                  }
-                                  disabled={inFlightStatus === "saving"}
-                                >
-                                  Save
-                                </Button>
-
-                                <Button
-                                  type="button"
-                                  size="sm"
-                                  variant="destructive"
-                                  onClick={() => handleDeleteInFlight(item.id)}
-                                  disabled={inFlightStatus === "saving"}
-                                >
-                                  Delete
-                                </Button>
-                              </div>
-                            </>
-                          ) : (
-                            <span>{item.inFlightQuantity}</span>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            )}
-
-            {inFlightMessage && <p className="text-sm">{inFlightMessage}</p>}
-          </CardContent>
-        </Card>
-      )}
+      <SpeciesPickerDialog
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        species={species}
+        excludeIds={draftItems.map((item) => item.butterflySpeciesId)}
+        onConfirm={handlePickerConfirm}
+      />
     </div>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: number }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardDescription>{label}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-semibold">{value}</div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/[institution]/(tenant)/shipments/[id]/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/[id]/page.tsx
@@ -22,7 +22,6 @@ import {
 } from "@/components/ui/alert-dialog";
 
 import { ShipmentItemsTable } from "@/components/tenant/shipments/shipment-items-table";
-import { ShipmentStatusBadge } from "@/components/tenant/shipments/shipment-status-badge";
 import { SpeciesPickerDialog } from "@/components/tenant/shipments/species-picker-dialog";
 import {
   Table,
@@ -458,13 +457,15 @@ export default function ShipmentDetailPage() {
         </div>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-4">
-        <Card>
-          <CardHeader>
-            <CardDescription>Status</CardDescription>
+      <div className="grid grid-cols-4 gap-3">
+        <Card className="gap-1 py-3">
+          <CardHeader className="px-3">
+            <CardDescription className="text-xs">Status</CardDescription>
           </CardHeader>
-          <CardContent>
-            <ShipmentStatusBadge remaining={totals.remaining} isCompleted={totals.isCompleted} />
+          <CardContent className="px-3">
+            <div className="text-base font-semibold">
+              {totals.isCompleted ? "Completed" : `${totals.remaining} remaining`}
+            </div>
           </CardContent>
         </Card>
         <SummaryCard label="Received" value={totals.totalReceived} />
@@ -532,7 +533,7 @@ export default function ShipmentDetailPage() {
               No releases yet.
             </p>
           ) : (
-            <div className="overflow-x-auto rounded-md border">
+            <div className="overflow-x-auto">
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -612,12 +613,12 @@ export default function ShipmentDetailPage() {
 
 function SummaryCard({ label, value }: { label: string; value: number }) {
   return (
-    <Card>
-      <CardHeader>
-        <CardDescription>{label}</CardDescription>
+    <Card className="gap-1 py-3">
+      <CardHeader className="px-3">
+        <CardDescription className="text-xs">{label}</CardDescription>
       </CardHeader>
-      <CardContent>
-        <div className="text-2xl font-semibold">{value}</div>
+      <CardContent className="px-3">
+        <div className="text-base font-semibold">{value}</div>
       </CardContent>
     </Card>
   );

--- a/src/app/[institution]/(tenant)/shipments/[id]/release/[releaseId]/edit/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/[id]/release/[releaseId]/edit/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { notFound, useParams, useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ROUTES } from "@/lib/routes";
+
+import {
+  ReleaseComposer,
+  type ReleaseQuantities,
+} from "@/components/tenant/releases/release-composer";
+import type {
+  ReleaseEventDetail,
+  ShipmentDetailResponse,
+} from "@/components/tenant/shipments/types";
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "2-digit",
+  year: "numeric",
+});
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return "—";
+  return dateFormatter.format(date);
+}
+
+export default function EditReleasePage() {
+  const params = useParams<{ institution: string; id: string; releaseId: string }>();
+  const router = useRouter();
+  const slug = params?.institution ?? "";
+  const shipmentId = Number(params?.id);
+  const releaseId = Number(params?.releaseId);
+
+  const [release, setRelease] = useState<ReleaseEventDetail | null>(null);
+  const [shipment, setShipment] = useState<ShipmentDetailResponse | null>(null);
+  const [values, setValues] = useState<ReleaseQuantities>({});
+  const [originalValues, setOriginalValues] = useState<ReleaseQuantities>({});
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const tenantHeaders = useMemo(() => ({ "x-tenant-slug": slug }), [slug]);
+  const detailHref = ROUTES.tenant.shipmentById(slug, shipmentId);
+
+  const handleGoBack = () => router.back();
+
+  useEffect(() => {
+    const ac = new AbortController();
+    void (async () => {
+      setStatus("loading");
+      setErrorMessage(null);
+      try {
+        const releaseRes = await fetch(`/api/tenant/releases/${releaseId}`, {
+          headers: tenantHeaders,
+          signal: ac.signal,
+        });
+        const releaseJson = await releaseRes.json().catch(() => null);
+        if (!releaseRes.ok) {
+          setStatus("error");
+          setErrorMessage(releaseJson?.error?.message ?? "Failed to load release.");
+          return;
+        }
+
+        // Defensive: the release_event must belong to the shipment in the URL.
+        // The API already enforces tenant scoping, but mismatched ids would be
+        // a bug worth surfacing rather than silently editing the wrong row.
+        if (releaseJson.event.shipmentId !== shipmentId) {
+          setStatus("error");
+          setErrorMessage("This release does not belong to that shipment.");
+          return;
+        }
+
+        const shRes = await fetch(`/api/tenant/shipments/${shipmentId}`, {
+          headers: tenantHeaders,
+          signal: ac.signal,
+        });
+        const shJson = await shRes.json().catch(() => null);
+        if (!shRes.ok) {
+          setStatus("error");
+          setErrorMessage(shJson?.error?.message ?? "Failed to load shipment.");
+          return;
+        }
+
+        setRelease(releaseJson);
+        setShipment(shJson);
+
+        const initialValues: ReleaseQuantities = {};
+        for (const item of releaseJson.items as ReleaseEventDetail["items"]) {
+          initialValues[item.shipmentItemId] = item.quantity;
+        }
+        setValues(initialValues);
+        setOriginalValues(initialValues);
+        setStatus("idle");
+      } catch (err) {
+        if (ac.signal.aborted) return;
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setStatus("error");
+        setErrorMessage("Failed to load release.");
+      }
+    })();
+    return () => ac.abort();
+  }, [releaseId, shipmentId, tenantHeaders]);
+
+  const handleChange = useCallback((itemId: number, quantity: number) => {
+    setValues((current) => ({ ...current, [itemId]: quantity }));
+  }, []);
+
+  const total = useMemo(
+    () => Object.values(values).reduce((acc, value) => acc + (value || 0), 0),
+    [values],
+  );
+
+  const handleSave = async () => {
+    if (!release) return;
+
+    // The PATCH endpoint can only update existing in_flight rows; it cannot
+    // add or remove species. Restrict to the original shipment_item_ids and
+    // require quantity > 0 (positive integer per release validation).
+    const items = release.items
+      .map((row) => ({
+        shipment_item_id: row.shipmentItemId,
+        quantity: values[row.shipmentItemId] ?? 0,
+      }))
+      .filter((item) => item.quantity > 0);
+
+    if (items.length !== release.items.length) {
+      setErrorMessage(
+        "Quantities must remain positive for every species in this release. To remove a species, delete and recreate the release.",
+      );
+      return;
+    }
+
+    setSaving(true);
+    setErrorMessage(null);
+    try {
+      const response = await fetch(`/api/tenant/releases/${releaseId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", ...tenantHeaders },
+        body: JSON.stringify({ items }),
+      });
+      const result = await response.json().catch(() => null);
+      if (!response.ok) {
+        setErrorMessage(result?.error?.message ?? "Unable to update release.");
+        return;
+      }
+      router.push(detailHref);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Bad URL ids — bail to the nearest not-found boundary instead of rendering
+  // a custom error state.
+  if (
+    !Number.isFinite(shipmentId) ||
+    shipmentId <= 0 ||
+    !Number.isFinite(releaseId) ||
+    releaseId <= 0
+  ) {
+    notFound();
+  }
+
+  if (status === "loading") {
+    return (
+      <div className="text-muted-foreground" role="status" aria-live="polite" aria-busy="true">
+        Loading release…
+      </div>
+    );
+  }
+  if (status === "error" || !release || !shipment) {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-destructive">{errorMessage ?? "Release not available."}</p>
+        <Button variant="outline" onClick={handleGoBack}>
+          <ArrowLeft className="size-4" />
+          Back
+        </Button>
+      </div>
+    );
+  }
+
+  // Restrict the composer to the species that are part of this release so
+  // users don't see species they cannot interact with via the PATCH API.
+  const composerItems = shipment.items.filter((item) =>
+    release.items.some((row) => row.shipmentItemId === item.id),
+  );
+
+  return (
+    <div className="flex flex-col gap-6 pb-32">
+      <div>
+        <Button variant="ghost" size="sm" className="-ml-2" onClick={handleGoBack}>
+          <ArrowLeft className="size-4" />
+          Back
+        </Button>
+        <h1 className="text-3xl font-semibold">Edit release</h1>
+        <p className="text-muted-foreground">
+          {shipment.shipment.supplierCode} · Released {formatDate(release.event.releaseDate)} by{" "}
+          {release.event.releasedBy}
+        </p>
+      </div>
+
+      {errorMessage && (
+        <div className="text-destructive text-sm" role="alert">
+          {errorMessage}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Released butterflies</CardTitle>
+          <CardDescription>
+            Adjust the per-species counts. The release date and operator are read-only.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ReleaseComposer
+            items={composerItems}
+            values={values}
+            onChange={handleChange}
+            alreadyAllocated={originalValues}
+          />
+        </CardContent>
+      </Card>
+
+      <div className="bg-background sticky bottom-0 -mx-4 border-t px-4 py-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
+        <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-4">
+          <div>
+            <div className="text-muted-foreground text-xs uppercase">Total released</div>
+            <div className="text-2xl font-semibold">{total}</div>
+          </div>
+          <Button size="lg" onClick={handleSave} disabled={saving || total === 0}>
+            {saving ? "Saving…" : "Save changes"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[institution]/(tenant)/shipments/[id]/release/new/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/[id]/release/new/page.tsx
@@ -202,8 +202,12 @@ export default function CreateReleasePage() {
     );
   }
 
+  // -mb-6 lets the page-root's padding box reach the wrapper layout's padding
+  // box bottom, so the sticky footer below stays pinned to the very bottom of
+  // `main` even at maximum scroll (without it the footer rises by the
+  // wrapper's py-6 at the end of the page).
   return (
-    <div className="flex flex-col gap-6 pb-32">
+    <div className="-mb-6 flex flex-col gap-6 pb-32">
       <div>
         <Button variant="ghost" size="sm" className="-ml-2" onClick={handleGoBack}>
           <ArrowLeft className="size-4" />
@@ -249,9 +253,9 @@ export default function CreateReleasePage() {
 
 /**
  * Compact summary of what the release will save: a prominent "Releasing N"
- * primary line with a single muted breakdown line for any loss buckets that
- * have been allocated. Designed to live next to the Save button in the sticky
- * footer so the user can confirm the totals at a glance.
+ * primary line plus a muted per-category breakdown for any "Other" buckets
+ * that have been allocated. Lives next to the Save button in the sticky
+ * footer so the user can confirm totals at a glance.
  */
 function ReleaseSummary({
   totalGood,
@@ -260,10 +264,9 @@ function ReleaseSummary({
   totalGood: number;
   categoryTotals: Record<ReleaseCategory, number>;
 }) {
-  const populatedLosses = RELEASE_CATEGORIES.filter(
+  const populatedOther = RELEASE_CATEGORIES.filter(
     (c) => c !== "goodEmergence" && categoryTotals[c] > 0,
   );
-  const totalLosses = populatedLosses.reduce((acc, c) => acc + categoryTotals[c], 0);
 
   return (
     <div className="min-w-0 space-y-0.5">
@@ -273,15 +276,13 @@ function ReleaseSummary({
           {totalGood === 1 ? "butterfly to release" : "butterflies to release"}
         </span>
       </div>
-      {totalLosses > 0 ? (
+      {populatedOther.length > 0 && (
         <p className="text-muted-foreground truncate text-xs">
-          + {totalLosses} loss{totalLosses === 1 ? "" : "es"} ·{" "}
-          {populatedLosses
+          +{" "}
+          {populatedOther
             .map((category) => `${CATEGORY_LABELS[category]} ${categoryTotals[category]}`)
-            .join(", ")}
+            .join(" · ")}
         </p>
-      ) : (
-        <p className="text-muted-foreground text-xs">No losses recorded</p>
       )}
     </div>
   );

--- a/src/app/[institution]/(tenant)/shipments/[id]/release/new/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/[id]/release/new/page.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { notFound, useParams, useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ROUTES } from "@/lib/routes";
+
+import {
+  CATEGORY_LABELS,
+  RELEASE_CATEGORIES,
+  ReleaseCategoryComposer,
+  type CategoryQuantities,
+  type ReleaseCategory,
+} from "@/components/tenant/releases/release-category-composer";
+import {
+  computeItemRemaining,
+  type ShipmentDetailResponse,
+  type ShipmentItemRow,
+} from "@/components/tenant/shipments/types";
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "2-digit",
+  year: "numeric",
+});
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return "—";
+  return dateFormatter.format(date);
+}
+
+function sumCategories(values: CategoryQuantities[number] | undefined): number {
+  if (!values) return 0;
+  let total = 0;
+  for (const value of Object.values(values)) {
+    if (typeof value === "number") total += value;
+  }
+  return total;
+}
+
+export default function CreateReleasePage() {
+  const params = useParams<{ institution: string; id: string }>();
+  const router = useRouter();
+  const slug = params?.institution ?? "";
+  const shipmentId = Number(params?.id);
+
+  const [data, setData] = useState<ShipmentDetailResponse | null>(null);
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [values, setValues] = useState<CategoryQuantities>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  const tenantHeaders = useMemo(() => ({ "x-tenant-slug": slug }), [slug]);
+  const detailHref = ROUTES.tenant.shipmentById(slug, shipmentId);
+
+  const handleGoBack = () => router.back();
+
+  useEffect(() => {
+    const ac = new AbortController();
+    void (async () => {
+      setStatus("loading");
+      setErrorMessage(null);
+      try {
+        const response = await fetch(`/api/tenant/shipments/${shipmentId}`, {
+          headers: tenantHeaders,
+          signal: ac.signal,
+        });
+        const result = await response.json().catch(() => null);
+        if (!response.ok) {
+          setStatus("error");
+          setErrorMessage(result?.error?.message ?? "Failed to load shipment.");
+          return;
+        }
+        setData(result);
+        setStatus("idle");
+      } catch (err) {
+        if (ac.signal.aborted) return;
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setStatus("error");
+        setErrorMessage("Failed to load shipment.");
+      }
+    })();
+    return () => ac.abort();
+  }, [shipmentId, tenantHeaders]);
+
+  const handleChange = useCallback((itemId: number, category: ReleaseCategory, value: number) => {
+    setValues((current) => ({
+      ...current,
+      [itemId]: { ...(current[itemId] ?? {}), [category]: value },
+    }));
+  }, []);
+
+  /** Per-category totals across the whole shipment, for the sticky bar. */
+  const categoryTotals = useMemo(() => {
+    const totals: Record<ReleaseCategory, number> = {
+      goodEmergence: 0,
+      poorEmergence: 0,
+      diseased: 0,
+      parasite: 0,
+      nonEmergence: 0,
+    };
+    for (const itemValues of Object.values(values)) {
+      for (const category of RELEASE_CATEGORIES) {
+        totals[category] += itemValues?.[category] ?? 0;
+      }
+    }
+    return totals;
+  }, [values]);
+
+  const totalGood = categoryTotals.goodEmergence;
+
+  /** Validate that no item has been over-allocated relative to its cap. */
+  const validate = useCallback((): string | null => {
+    if (!data) return "Shipment not loaded yet.";
+    if (totalGood === 0) {
+      return "Set a Good Emergence quantity on at least one species before saving.";
+    }
+    for (const item of data.items) {
+      const allocated = sumCategories(values[item.id]);
+      const cap = computeItemRemaining(item);
+      if (allocated > cap) {
+        return `${item.commonName}: allocated ${allocated} but only ${cap} remain.`;
+      }
+    }
+    return null;
+  }, [data, totalGood, values]);
+
+  const handleSubmit = async () => {
+    const validationError = validate();
+    if (validationError) {
+      setErrorMessage(validationError);
+      return;
+    }
+    if (!data) return;
+
+    // Build the release items from Good Emergence and a single atomic
+    // loss_updates payload from all loss category buckets. The backend
+    // applies loss corrections and creates the release event inside one
+    // transaction so a partial failure cannot leave losses persisted
+    // without a release event.
+    const releaseItems = Object.entries(values)
+      .map(([id, itemValues]) => ({
+        shipment_item_id: Number(id),
+        quantity: itemValues?.goodEmergence ?? 0,
+      }))
+      .filter((row) => row.quantity > 0);
+
+    const lossUpdates = data.items
+      .map((item) => buildLossUpdate(item, values[item.id]))
+      .filter((row): row is NonNullable<ReturnType<typeof buildLossUpdate>> => row !== null);
+
+    setSubmitting(true);
+    setErrorMessage(null);
+    try {
+      const releaseResponse = await fetch(`/api/tenant/shipments/${shipmentId}/releases`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...tenantHeaders },
+        body: JSON.stringify({
+          items: releaseItems,
+          ...(lossUpdates.length > 0 ? { loss_updates: lossUpdates } : {}),
+        }),
+      });
+      if (!releaseResponse.ok) {
+        const result = await releaseResponse.json().catch(() => null);
+        setErrorMessage(result?.error?.message ?? "Unable to save release.");
+        return;
+      }
+
+      router.push(detailHref);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Bad URL ids — bail to the nearest not-found boundary instead of rendering
+  // a custom error state.
+  if (!Number.isFinite(shipmentId) || shipmentId <= 0) {
+    notFound();
+  }
+
+  if (status === "loading") {
+    return (
+      <div className="text-muted-foreground" role="status" aria-live="polite" aria-busy="true">
+        Loading shipment…
+      </div>
+    );
+  }
+
+  if (status === "error" || !data) {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-destructive">{errorMessage ?? "Shipment not available."}</p>
+        <Button variant="outline" onClick={handleGoBack}>
+          <ArrowLeft className="size-4" />
+          Back
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 pb-32">
+      <div>
+        <Button variant="ghost" size="sm" className="-ml-2" onClick={handleGoBack}>
+          <ArrowLeft className="size-4" />
+          Back
+        </Button>
+        <h1 className="text-3xl font-semibold">New release</h1>
+        <p className="text-muted-foreground">
+          {data.shipment.supplierCode} · Shipped {formatDate(data.shipment.shipmentDate)} · Arrived{" "}
+          {formatDate(data.shipment.arrivalDate)}
+        </p>
+      </div>
+
+      {errorMessage && (
+        <div className="text-destructive text-sm" role="alert">
+          {errorMessage}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Sort the butterflies</CardTitle>
+          <CardDescription>
+            Tap a category, then set per-species counts. Good Emergence will be released; the other
+            categories are recorded as losses on the shipment.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ReleaseCategoryComposer items={data.items} values={values} onChange={handleChange} />
+        </CardContent>
+      </Card>
+
+      <div className="bg-background sticky bottom-0 -mx-4 border-t px-4 py-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
+        <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-4">
+          <ReleaseSummary totalGood={totalGood} categoryTotals={categoryTotals} />
+          <Button size="lg" onClick={handleSubmit} disabled={submitting || totalGood === 0}>
+            {submitting ? "Saving…" : "Save release"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Compact summary of what the release will save: a prominent "Releasing N"
+ * primary line with a single muted breakdown line for any loss buckets that
+ * have been allocated. Designed to live next to the Save button in the sticky
+ * footer so the user can confirm the totals at a glance.
+ */
+function ReleaseSummary({
+  totalGood,
+  categoryTotals,
+}: {
+  totalGood: number;
+  categoryTotals: Record<ReleaseCategory, number>;
+}) {
+  const populatedLosses = RELEASE_CATEGORIES.filter(
+    (c) => c !== "goodEmergence" && categoryTotals[c] > 0,
+  );
+  const totalLosses = populatedLosses.reduce((acc, c) => acc + categoryTotals[c], 0);
+
+  return (
+    <div className="min-w-0 space-y-0.5">
+      <div className="flex items-baseline gap-2">
+        <span className="text-3xl leading-none font-semibold tabular-nums">{totalGood}</span>
+        <span className="text-muted-foreground text-sm">
+          {totalGood === 1 ? "butterfly to release" : "butterflies to release"}
+        </span>
+      </div>
+      {totalLosses > 0 ? (
+        <p className="text-muted-foreground truncate text-xs">
+          + {totalLosses} loss{totalLosses === 1 ? "" : "es"} ·{" "}
+          {populatedLosses
+            .map((category) => `${CATEGORY_LABELS[category]} ${categoryTotals[category]}`)
+            .join(", ")}
+        </p>
+      ) : (
+        <p className="text-muted-foreground text-xs">No losses recorded</p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Build a `loss_updates` payload row for a single shipment item if any of its
+ * loss categories were touched. The backend accepts absolute new values and
+ * applies them inside the release transaction, so we send the existing loss
+ * column plus the newly composed delta.
+ */
+function buildLossUpdate(
+  item: ShipmentItemRow,
+  itemValues: CategoryQuantities[number] | undefined,
+): {
+  shipment_item_id: number;
+  diseased_in_transit: number;
+  parasite: number;
+  non_emergence: number;
+  poor_emergence: number;
+} | null {
+  if (!itemValues) return null;
+
+  const deltas = {
+    diseased: itemValues.diseased ?? 0,
+    parasite: itemValues.parasite ?? 0,
+    nonEmergence: itemValues.nonEmergence ?? 0,
+    poorEmergence: itemValues.poorEmergence ?? 0,
+  };
+
+  const hasAnyLoss = Object.values(deltas).some((value) => value > 0);
+  if (!hasAnyLoss) return null;
+
+  return {
+    shipment_item_id: item.id,
+    diseased_in_transit: item.diseasedInTransit + deltas.diseased,
+    parasite: item.parasite + deltas.parasite,
+    non_emergence: item.nonEmergence + deltas.nonEmergence,
+    poor_emergence: item.poorEmergence + deltas.poorEmergence,
+  };
+}

--- a/src/app/[institution]/(tenant)/shipments/add/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/add/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import { useParams, useRouter } from "next/navigation";
-import { Bug, Minus, Plus, Trash2 } from "lucide-react";
+import { ArrowLeft, Bug, Minus, Plus, Trash2 } from "lucide-react";
 
 import {
   AlertDialog,
@@ -361,6 +361,10 @@ export default function AddShipmentPage() {
   return (
     <div className="flex flex-col gap-6">
       <div className="space-y-1">
+        <Button variant="ghost" size="sm" className="-ml-2" onClick={() => router.back()}>
+          <ArrowLeft className="size-4" />
+          Back
+        </Button>
         <h1 className="text-3xl font-semibold">Add shipment</h1>
         <p className="text-muted-foreground">
           Record a new shipment and the butterflies that arrived.

--- a/src/app/[institution]/(tenant)/shipments/add/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/add/page.tsx
@@ -1,3 +1,684 @@
+"use client";
+
+import { useEffect, useMemo, useState, type ChangeEvent } from "react";
+import { useParams } from "next/navigation";
+import { useFieldArray, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { createShipmentBodySchema } from "@/lib/validation/shipments";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+type ShipmentFormValues = z.input<typeof createShipmentBodySchema>;
+
+type ApiErrorBody = {
+  error?: {
+    message?: string;
+  };
+  message?: string;
+};
+
+type SpeciesOption = {
+  id: number;
+  scientificName: string;
+  commonName: string;
+};
+
+const getApiErrorMessage = (payload: unknown, fallback: string) => {
+  const body = payload as ApiErrorBody | null;
+  return body?.error?.message ?? body?.message ?? fallback;
+};
+
+const toLocalInputValue = (value: unknown) => {
+  if (!value) return "";
+  const date = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(date.valueOf())) return "";
+
+  const tzOffset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - tzOffset).toISOString().slice(0, 16);
+};
+
+const toIsoString = (localValue: string) => {
+  if (!localValue) return "";
+  const date = new Date(localValue);
+  if (Number.isNaN(date.valueOf())) return localValue;
+  return date.toISOString();
+};
+
+const getSpeciesLabel = (option: SpeciesOption) => {
+  return `${option.scientificName} — ${option.commonName}`;
+};
+
+const defaultItem = {
+  butterfly_species_id: 0,
+  number_received: 0,
+  emerged_in_transit: 0,
+  damaged_in_transit: 0,
+  diseased_in_transit: 0,
+  parasite: 0,
+  non_emergence: 0,
+  poor_emergence: 0,
+};
+
 export default function AddShipmentPage() {
-  return <h1>Add Shipment</h1>;
+  const params = useParams<{ institution: string }>();
+  const rawInstitutionSlug = params?.institution ?? "";
+  const institutionSlug = Array.isArray(rawInstitutionSlug)
+    ? (rawInstitutionSlug[0] ?? "")
+    : rawInstitutionSlug;
+
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [supplierOptions, setSupplierOptions] = useState<
+    { id: number; name: string; code: string; isActive: boolean }[]
+  >([]);
+  const [suppliersStatus, setSuppliersStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [speciesOptions, setSpeciesOptions] = useState<SpeciesOption[]>([]);
+  const [speciesStatus, setSpeciesStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [speciesSearchByRowId, setSpeciesSearchByRowId] = useState<Record<string, string>>({});
+  const [activeSpeciesRowId, setActiveSpeciesRowId] = useState<string | null>(null);
+
+  const tenantHeaders = useMemo(() => ({ "x-tenant-slug": institutionSlug }), [institutionSlug]);
+
+  const defaultValues = useMemo(
+    () => ({
+      supplier_code: "",
+      shipment_date: "",
+      arrival_date: "",
+      items: [{ ...defaultItem }],
+    }),
+    [],
+  );
+
+  const form = useForm<ShipmentFormValues>({
+    resolver: zodResolver(createShipmentBodySchema),
+    defaultValues,
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "items",
+  });
+
+  const handleNumberChange = (onChange: (value: number) => void) => {
+    return (event: ChangeEvent<HTMLInputElement>) => {
+      const next = Number(event.target.value);
+      onChange(Number.isNaN(next) ? 0 : next);
+    };
+  };
+
+  const getFilteredSpeciesOptions = (searchTerm: string) => {
+    const normalized = searchTerm.trim().toLowerCase();
+    if (!normalized) return speciesOptions;
+
+    return speciesOptions.filter((option) => {
+      return (
+        option.scientificName.toLowerCase().includes(normalized) ||
+        option.commonName.toLowerCase().includes(normalized)
+      );
+    });
+  };
+
+  const onSubmit = async (values: ShipmentFormValues) => {
+    setServerError(null);
+    setSuccessMessage(null);
+
+    if (!institutionSlug) {
+      setServerError("Missing institution slug");
+      return;
+    }
+
+    const payload = {
+      ...values,
+      items: values.items.map((item) => ({
+        ...item,
+        emerged_in_transit: item.emerged_in_transit ?? 0,
+        damaged_in_transit: item.damaged_in_transit ?? 0,
+        diseased_in_transit: item.diseased_in_transit ?? 0,
+        parasite: item.parasite ?? 0,
+        non_emergence: item.non_emergence ?? 0,
+        poor_emergence: item.poor_emergence ?? 0,
+      })),
+    };
+
+    try {
+      const response = await fetch("/api/tenant/shipments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...tenantHeaders },
+        body: JSON.stringify(payload),
+      });
+
+      const result = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        setServerError(getApiErrorMessage(result, "Unable to create shipment"));
+        return;
+      }
+
+      form.reset(defaultValues);
+      setSpeciesSearchByRowId({});
+      setActiveSpeciesRowId(null);
+      setSuccessMessage("Shipment created successfully.");
+    } catch {
+      setServerError("Unable to create shipment");
+    }
+  };
+
+  useEffect(() => {
+    const loadSuppliers = async () => {
+      if (!institutionSlug) {
+        setSuppliersStatus("error");
+        return;
+      }
+
+      setSuppliersStatus("loading");
+      try {
+        const response = await fetch("/api/tenant/suppliers", {
+          headers: tenantHeaders,
+        });
+        const result = await response.json().catch(() => null);
+
+        if (!response.ok) {
+          setSuppliersStatus("error");
+          return;
+        }
+
+        const rows =
+          result && typeof result === "object" && "suppliers" in result ? result.suppliers : null;
+
+        const options = Array.isArray(rows)
+          ? rows
+              .filter((item) => item && typeof item.code === "string")
+              .map((item) => ({
+                id: item.id,
+                name: item.name ?? item.code,
+                code: item.code,
+                isActive: item.isActive ?? true,
+              }))
+          : [];
+
+        setSupplierOptions(options);
+        setSuppliersStatus("idle");
+      } catch {
+        setSuppliersStatus("error");
+      }
+    };
+
+    void loadSuppliers();
+  }, [institutionSlug, tenantHeaders]);
+
+  useEffect(() => {
+    const loadSpecies = async () => {
+      if (!institutionSlug) {
+        setSpeciesStatus("error");
+        return;
+      }
+
+      setSpeciesStatus("loading");
+
+      try {
+        const response = await fetch("/api/tenant/species", {
+          headers: tenantHeaders,
+        });
+        const result = await response.json().catch(() => null);
+
+        if (!response.ok) {
+          setSpeciesStatus("error");
+          return;
+        }
+
+        const rows =
+          result && typeof result === "object" && "species" in result ? result.species : null;
+
+        const options = Array.isArray(rows)
+          ? rows
+              .map((row) => {
+                if (!row || typeof row !== "object") return null;
+
+                const id = typeof row.id === "number" ? row.id : Number(row.id);
+                const scientificName =
+                  typeof row.scientificName === "string" ? row.scientificName.trim() : "";
+                const commonNameOverride =
+                  typeof row.commonNameOverride === "string" ? row.commonNameOverride.trim() : "";
+                const commonNameBase =
+                  typeof row.commonName === "string" ? row.commonName.trim() : "";
+                const commonName = commonNameOverride || commonNameBase || scientificName;
+
+                if (!Number.isFinite(id) || id <= 0 || !scientificName) return null;
+
+                return {
+                  id,
+                  scientificName,
+                  commonName,
+                } satisfies SpeciesOption;
+              })
+              .filter((option): option is SpeciesOption => option !== null)
+          : [];
+
+        setSpeciesOptions(options);
+        setSpeciesStatus("idle");
+      } catch {
+        setSpeciesStatus("error");
+      }
+    };
+
+    void loadSpecies();
+  }, [institutionSlug, tenantHeaders]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 py-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold">Add shipment</h1>
+        <p className="text-muted-foreground">
+          Record shipment details and quality metrics for each species in the delivery.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Shipment details</CardTitle>
+          <CardDescription>Provide the shipment header and line items.</CardDescription>
+        </CardHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <CardContent className="space-y-6">
+              <div className="grid gap-4 md:grid-cols-3">
+                <FormField
+                  control={form.control}
+                  name="supplier_code"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Supplier code</FormLabel>
+                      <FormControl>
+                        <NativeSelect
+                          value={field.value}
+                          onChange={field.onChange}
+                          aria-label="Select supplier"
+                        >
+                          <NativeSelectOption value="">
+                            {suppliersStatus === "loading"
+                              ? "Loading suppliers..."
+                              : "Select a supplier"}
+                          </NativeSelectOption>
+                          {supplierOptions.map((supplier) => (
+                            <NativeSelectOption key={supplier.id} value={supplier.code}>
+                              {supplier.code} — {supplier.name}
+                              {supplier.isActive ? "" : " (inactive)"}
+                            </NativeSelectOption>
+                          ))}
+                        </NativeSelect>
+                      </FormControl>
+                      <FormDescription>Use the USDA supplier abbreviation.</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="shipment_date"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Shipment date</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="datetime-local"
+                          value={toLocalInputValue(field.value)}
+                          onChange={(event) => field.onChange(toIsoString(event.target.value))}
+                        />
+                      </FormControl>
+                      <FormDescription>When the shipment left the supplier.</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="arrival_date"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Arrival date</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="datetime-local"
+                          value={toLocalInputValue(field.value)}
+                          onChange={(event) => field.onChange(toIsoString(event.target.value))}
+                        />
+                      </FormControl>
+                      <FormDescription>When the shipment arrived on-site.</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-lg font-semibold">Shipment items</h2>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => append({ ...defaultItem })}
+                  >
+                    Add item
+                  </Button>
+                </div>
+
+                <div className="space-y-4">
+                  {fields.map((itemField, index) => (
+                    <div key={itemField.id} className="rounded-lg border p-4">
+                      <div className="grid gap-4 md:grid-cols-4">
+                        <FormField
+                          control={form.control}
+                          name={`items.${index}.butterfly_species_id`}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Species</FormLabel>
+                              <FormControl>
+                                <div className="relative space-y-2">
+                                  <Input
+                                    type="text"
+                                    value={speciesSearchByRowId[itemField.id] ?? ""}
+                                    placeholder="Type scientific or common name"
+                                    role="combobox"
+                                    aria-expanded={activeSpeciesRowId === itemField.id}
+                                    aria-controls={`species-options-${itemField.id}`}
+                                    aria-autocomplete="list"
+                                    onFocus={() => setActiveSpeciesRowId(itemField.id)}
+                                    onBlur={() => {
+                                      window.setTimeout(() => {
+                                        setActiveSpeciesRowId((current) =>
+                                          current === itemField.id ? null : current,
+                                        );
+                                      }, 120);
+                                    }}
+                                    onChange={(event) => {
+                                      field.onChange(0);
+                                      setActiveSpeciesRowId(itemField.id);
+                                      setSpeciesSearchByRowId((prev) => ({
+                                        ...prev,
+                                        [itemField.id]: event.target.value,
+                                      }));
+                                    }}
+                                  />
+
+                                  {activeSpeciesRowId === itemField.id && (
+                                    <div
+                                      id={`species-options-${itemField.id}`}
+                                      role="listbox"
+                                      className="bg-background absolute z-20 mt-1 max-h-56 w-full overflow-y-auto rounded-md border shadow-md"
+                                    >
+                                      {speciesStatus === "loading" && (
+                                        <div className="px-3 py-2 text-sm">Loading species...</div>
+                                      )}
+
+                                      {speciesStatus === "error" && (
+                                        <div className="px-3 py-2 text-sm">
+                                          Unable to load species options.
+                                        </div>
+                                      )}
+
+                                      {speciesStatus === "idle" &&
+                                        (() => {
+                                          const filtered = getFilteredSpeciesOptions(
+                                            speciesSearchByRowId[itemField.id] ?? "",
+                                          );
+
+                                          if (filtered.length === 0) {
+                                            return (
+                                              <div className="px-3 py-2 text-sm">
+                                                No species matches your filter.
+                                              </div>
+                                            );
+                                          }
+
+                                          return filtered.map((option) => (
+                                            <button
+                                              type="button"
+                                              key={option.id}
+                                              role="option"
+                                              aria-selected={field.value === option.id}
+                                              className="hover:bg-muted block w-full px-3 py-2 text-left"
+                                              onMouseDown={(event) => event.preventDefault()}
+                                              onClick={() => {
+                                                field.onChange(option.id);
+                                                setSpeciesSearchByRowId((prev) => ({
+                                                  ...prev,
+                                                  [itemField.id]: getSpeciesLabel(option),
+                                                }));
+                                                setActiveSpeciesRowId(null);
+                                              }}
+                                            >
+                                              <div className="text-sm font-medium">
+                                                {option.scientificName}
+                                              </div>
+                                              <div className="text-muted-foreground text-xs">
+                                                {option.commonName}
+                                              </div>
+                                            </button>
+                                          ));
+                                        })()}
+                                    </div>
+                                  )}
+                                </div>
+                              </FormControl>
+                              <FormDescription>
+                                Type to filter by scientific or common name.
+                              </FormDescription>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name={`items.${index}.number_received`}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Received</FormLabel>
+                              <FormControl>
+                                <Input
+                                  type="number"
+                                  min={0}
+                                  step={1}
+                                  value={field.value}
+                                  onChange={handleNumberChange(field.onChange)}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name={`items.${index}.emerged_in_transit`}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Emerged</FormLabel>
+                              <FormControl>
+                                <Input
+                                  type="number"
+                                  min={0}
+                                  step={1}
+                                  value={field.value}
+                                  onChange={handleNumberChange(field.onChange)}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name={`items.${index}.damaged_in_transit`}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Damaged</FormLabel>
+                              <FormControl>
+                                <Input
+                                  type="number"
+                                  min={0}
+                                  step={1}
+                                  value={field.value}
+                                  onChange={handleNumberChange(field.onChange)}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name={`items.${index}.diseased_in_transit`}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Diseased</FormLabel>
+                              <FormControl>
+                                <Input
+                                  type="number"
+                                  min={0}
+                                  step={1}
+                                  value={field.value}
+                                  onChange={handleNumberChange(field.onChange)}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name={`items.${index}.parasite`}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Parasite</FormLabel>
+                              <FormControl>
+                                <Input
+                                  type="number"
+                                  min={0}
+                                  step={1}
+                                  value={field.value}
+                                  onChange={handleNumberChange(field.onChange)}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name={`items.${index}.non_emergence`}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Non-emergence</FormLabel>
+                              <FormControl>
+                                <Input
+                                  type="number"
+                                  min={0}
+                                  step={1}
+                                  value={field.value}
+                                  onChange={handleNumberChange(field.onChange)}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name={`items.${index}.poor_emergence`}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Poor emergence</FormLabel>
+                              <FormControl>
+                                <Input
+                                  type="number"
+                                  min={0}
+                                  step={1}
+                                  value={field.value}
+                                  onChange={handleNumberChange(field.onChange)}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      </div>
+
+                      <div className="mt-4 flex justify-end">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={() => {
+                            remove(index);
+                            setSpeciesSearchByRowId((prev) => {
+                              const next = { ...prev };
+                              delete next[itemField.id];
+                              return next;
+                            });
+                            setActiveSpeciesRowId((current) =>
+                              current === itemField.id ? null : current,
+                            );
+                          }}
+                          disabled={fields.length === 1}
+                        >
+                          Remove item
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {(serverError || successMessage) && (
+                <div
+                  className="rounded-md border px-4 py-3 text-sm"
+                  role="status"
+                  aria-live="polite"
+                >
+                  {serverError ? (
+                    <span className="text-destructive">{serverError}</span>
+                  ) : (
+                    <span className="text-emerald-600">{successMessage}</span>
+                  )}
+                </div>
+              )}
+            </CardContent>
+            <CardFooter className="justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  form.reset(defaultValues);
+                  setSpeciesSearchByRowId({});
+                  setActiveSpeciesRowId(null);
+                }}
+              >
+                Reset
+              </Button>
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                {form.formState.isSubmitting ? "Saving..." : "Save shipment"}
+              </Button>
+            </CardFooter>
+          </form>
+        </Form>
+      </Card>
+    </div>
+  );
 }

--- a/src/app/[institution]/(tenant)/shipments/add/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/add/page.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ChangeEvent } from "react";
-import { useParams } from "next/navigation";
-import { useFieldArray, useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import { createShipmentBodySchema } from "@/lib/validation/shipments";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Image from "next/image";
+import { useParams, useRouter } from "next/navigation";
+import { Bug, Minus, Plus, Trash2 } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -16,669 +25,603 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 
-type ShipmentFormValues = z.input<typeof createShipmentBodySchema>;
+import { ROUTES } from "@/lib/routes";
 
-type ApiErrorBody = {
-  error?: {
-    message?: string;
-  };
-  message?: string;
+import { DatePicker } from "@/components/shared/date-picker";
+import { SpeciesPickerDialog } from "@/components/tenant/shipments/species-picker-dialog";
+import { SupplierSelect, type SupplierOption } from "@/components/tenant/shipments/supplier-select";
+import type { SpeciesPickerOption } from "@/components/tenant/shipments/types";
+
+type ShipmentItemForm = {
+  butterfly_species_id: number;
+  scientific_name: string;
+  common_name: string;
+  imgWingsOpen: string | null;
+  number_received: number;
+  emerged_in_transit: number;
+  damaged_in_transit: number;
+  diseased_in_transit: number;
+  parasite: number;
+  non_emergence: number;
+  poor_emergence: number;
 };
 
-type SpeciesOption = {
-  id: number;
-  scientificName: string;
-  commonName: string;
-};
+type LossKey =
+  | "number_received"
+  | "emerged_in_transit"
+  | "damaged_in_transit"
+  | "diseased_in_transit"
+  | "parasite"
+  | "non_emergence"
+  | "poor_emergence";
 
-const getApiErrorMessage = (payload: unknown, fallback: string) => {
-  const body = payload as ApiErrorBody | null;
-  return body?.error?.message ?? body?.message ?? fallback;
-};
+const METRIC_FIELDS: { key: LossKey; label: string }[] = [
+  { key: "number_received", label: "Received" },
+  { key: "emerged_in_transit", label: "Emerged" },
+  { key: "damaged_in_transit", label: "Damaged" },
+  { key: "diseased_in_transit", label: "Diseased" },
+  { key: "parasite", label: "Parasite" },
+  { key: "non_emergence", label: "Non-emerg" },
+  { key: "poor_emergence", label: "Poor-emerg" },
+];
 
-const toLocalInputValue = (value: unknown) => {
+/** Convert YYYY-MM-DD into an ISO midnight UTC timestamp the API will coerce. */
+function dateOnlyToIso(value: string): string {
   if (!value) return "";
-  const date = value instanceof Date ? value : new Date(String(value));
-  if (Number.isNaN(date.valueOf())) return "";
+  const [y, m, d] = value.split("-").map((p) => Number.parseInt(p, 10));
+  if (!y || !m || !d) return "";
+  return new Date(Date.UTC(y, m - 1, d, 0, 0, 0, 0)).toISOString();
+}
 
-  const tzOffset = date.getTimezoneOffset() * 60000;
-  return new Date(date.getTime() - tzOffset).toISOString().slice(0, 16);
+/** Today's date in YYYY-MM-DD using the user's local timezone. */
+function todayYmd(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Per-field invalid markers. A field is considered invalid only after the
+ * user has tried to submit at least once, so first-time visitors don't see a
+ * sea of red on a fresh page.
+ */
+type FieldErrors = {
+  supplier?: boolean;
+  shipmentDate?: boolean;
+  arrivalDate?: boolean;
+  itemsEmpty?: boolean;
+  receivedByItemId: Record<number, boolean>;
 };
 
-const toIsoString = (localValue: string) => {
-  if (!localValue) return "";
-  const date = new Date(localValue);
-  if (Number.isNaN(date.valueOf())) return localValue;
-  return date.toISOString();
-};
+const EMPTY_FIELD_ERRORS: FieldErrors = { receivedByItemId: {} };
 
-const getSpeciesLabel = (option: SpeciesOption) => {
-  return `${option.scientificName} — ${option.commonName}`;
-};
-
-const defaultItem = {
-  butterfly_species_id: 0,
-  number_received: 0,
-  emerged_in_transit: 0,
-  damaged_in_transit: 0,
-  diseased_in_transit: 0,
-  parasite: 0,
-  non_emergence: 0,
-  poor_emergence: 0,
-};
+function blankItem(species: SpeciesPickerOption): ShipmentItemForm {
+  return {
+    butterfly_species_id: species.id,
+    scientific_name: species.scientificName,
+    common_name: species.commonName,
+    imgWingsOpen: species.imgWingsOpen,
+    number_received: 0,
+    emerged_in_transit: 0,
+    damaged_in_transit: 0,
+    diseased_in_transit: 0,
+    parasite: 0,
+    non_emergence: 0,
+    poor_emergence: 0,
+  };
+}
 
 export default function AddShipmentPage() {
   const params = useParams<{ institution: string }>();
-  const rawInstitutionSlug = params?.institution ?? "";
-  const institutionSlug = Array.isArray(rawInstitutionSlug)
-    ? (rawInstitutionSlug[0] ?? "")
-    : rawInstitutionSlug;
+  const router = useRouter();
+  const slug = params?.institution ?? "";
 
-  const [serverError, setServerError] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const [supplierOptions, setSupplierOptions] = useState<
-    { id: number; name: string; code: string; isActive: boolean }[]
-  >([]);
-  const [suppliersStatus, setSuppliersStatus] = useState<"idle" | "loading" | "error">("idle");
-  const [speciesOptions, setSpeciesOptions] = useState<SpeciesOption[]>([]);
-  const [speciesStatus, setSpeciesStatus] = useState<"idle" | "loading" | "error">("idle");
-  const [speciesSearchByRowId, setSpeciesSearchByRowId] = useState<Record<string, string>>({});
-  const [activeSpeciesRowId, setActiveSpeciesRowId] = useState<string | null>(null);
+  const [supplierCode, setSupplierCode] = useState("");
+  const [shipmentDate, setShipmentDate] = useState("");
+  // Arrival defaults to today since most shipments are recorded the day they
+  // arrive on-site. The user can still pick a different date if needed.
+  const [arrivalDate, setArrivalDate] = useState(() => todayYmd());
+  const [items, setItems] = useState<ShipmentItemForm[]>([]);
 
-  const tenantHeaders = useMemo(() => ({ "x-tenant-slug": institutionSlug }), [institutionSlug]);
+  const [suppliers, setSuppliers] = useState<SupplierOption[]>([]);
+  const [species, setSpecies] = useState<SpeciesPickerOption[]>([]);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
-  const defaultValues = useMemo(
-    () => ({
-      supplier_code: "",
-      shipment_date: "",
-      arrival_date: "",
-      items: [{ ...defaultItem }],
-    }),
-    [],
-  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>(EMPTY_FIELD_ERRORS);
+  const [submitting, setSubmitting] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<ShipmentItemForm | null>(null);
 
-  const form = useForm<ShipmentFormValues>({
-    resolver: zodResolver(createShipmentBodySchema),
-    defaultValues,
-  });
+  const tenantHeaders = useMemo(() => ({ "x-tenant-slug": slug }), [slug]);
 
-  const { fields, append, remove } = useFieldArray({
-    control: form.control,
-    name: "items",
-  });
+  // Load suppliers + species in parallel.
+  useEffect(() => {
+    if (!slug) return;
+    const ac = new AbortController();
+    void (async () => {
+      try {
+        const [supRes, spRes] = await Promise.all([
+          fetch("/api/tenant/suppliers", { headers: tenantHeaders, signal: ac.signal }),
+          fetch("/api/tenant/species", { headers: tenantHeaders, signal: ac.signal }),
+        ]);
+        const supJson = await supRes.json().catch(() => null);
+        const spJson = await spRes.json().catch(() => null);
 
-  const handleNumberChange = (onChange: (value: number) => void) => {
-    return (event: ChangeEvent<HTMLInputElement>) => {
-      const next = Number(event.target.value);
-      onChange(Number.isNaN(next) ? 0 : next);
-    };
-  };
+        const supplierRows = Array.isArray(supJson?.suppliers) ? supJson.suppliers : [];
+        setSuppliers(
+          supplierRows
+            .filter((s: { code?: unknown }) => typeof s.code === "string")
+            .map((s: { id: number; code: string; name?: string; isActive?: boolean }) => ({
+              id: s.id,
+              code: s.code,
+              name: s.name ?? s.code,
+              isActive: s.isActive ?? true,
+            })),
+        );
 
-  const getFilteredSpeciesOptions = (searchTerm: string) => {
-    const normalized = searchTerm.trim().toLowerCase();
-    if (!normalized) return speciesOptions;
+        const speciesRows = Array.isArray(spJson?.species) ? spJson.species : [];
+        setSpecies(
+          speciesRows
+            .map(
+              (row: {
+                id?: number;
+                scientificName?: string;
+                commonName?: string;
+                commonNameOverride?: string;
+                family?: string;
+                imgWingsOpen?: string | null;
+              }) => {
+                const id = typeof row.id === "number" ? row.id : Number(row.id);
+                const sci = (row.scientificName ?? "").trim();
+                if (!Number.isFinite(id) || id <= 0 || !sci) return null;
+                const common =
+                  (row.commonNameOverride ?? "").trim() || (row.commonName ?? "").trim() || sci;
+                return {
+                  id,
+                  scientificName: sci,
+                  commonName: common,
+                  family: (row.family ?? "").trim() || "—",
+                  imgWingsOpen: row.imgWingsOpen ?? null,
+                } satisfies SpeciesPickerOption;
+              },
+            )
+            .filter((row: SpeciesPickerOption | null): row is SpeciesPickerOption => row !== null),
+        );
+      } catch (err) {
+        if (ac.signal.aborted) return;
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        // Errors surface as empty dropdowns; the user can retry by reloading.
+      }
+    })();
+    return () => ac.abort();
+  }, [slug, tenantHeaders]);
 
-    return speciesOptions.filter((option) => {
-      return (
-        option.scientificName.toLowerCase().includes(normalized) ||
-        option.commonName.toLowerCase().includes(normalized)
-      );
+  const addedSpeciesIds = useMemo(() => items.map((item) => item.butterfly_species_id), [items]);
+
+  const handlePickerConfirm = useCallback((chosen: SpeciesPickerOption[]) => {
+    setItems((current) => [
+      ...current,
+      ...chosen
+        .filter((c) => !current.some((item) => item.butterfly_species_id === c.id))
+        .map(blankItem),
+    ]);
+    // Adding species clears the "no items" error and any per-item received
+    // errors that happened to belong to species the user has now removed.
+    setFieldErrors((prev) => ({ ...prev, itemsEmpty: false }));
+  }, []);
+
+  const updateItem = useCallback((id: number, key: LossKey, value: number) => {
+    const safe = Math.max(0, Math.floor(Number.isFinite(value) ? value : 0));
+    setItems((current) =>
+      current.map((item) => (item.butterfly_species_id === id ? { ...item, [key]: safe } : item)),
+    );
+    // Clear the per-item received error as soon as the user types something
+    // > 0 into that field.
+    if (key === "number_received" && safe > 0) {
+      setFieldErrors((prev) => {
+        if (!prev.receivedByItemId[id]) return prev;
+        const next = { ...prev.receivedByItemId };
+        delete next[id];
+        return { ...prev, receivedByItemId: next };
+      });
+    }
+  }, []);
+
+  const removeItem = useCallback((id: number) => {
+    setItems((current) => current.filter((item) => item.butterfly_species_id !== id));
+    setFieldErrors((prev) => {
+      const next = { ...prev.receivedByItemId };
+      delete next[id];
+      return { ...prev, receivedByItemId: next };
     });
-  };
+  }, []);
 
-  const onSubmit = async (values: ShipmentFormValues) => {
-    setServerError(null);
-    setSuccessMessage(null);
+  /**
+   * Build the per-field error map for the current form state. Returns
+   * `null` when everything's valid; otherwise returns the errors AND a
+   * one-liner suitable for the top-of-form banner.
+   */
+  const validate = (): { errors: FieldErrors; message: string } | null => {
+    const errors: FieldErrors = { receivedByItemId: {} };
+    const issues: string[] = [];
 
-    if (!institutionSlug) {
-      setServerError("Missing institution slug");
-      return;
+    if (!supplierCode) {
+      errors.supplier = true;
+      issues.push("supplier");
+    }
+    if (!shipmentDate) {
+      errors.shipmentDate = true;
+      issues.push("shipment date");
+    }
+    if (!arrivalDate) {
+      errors.arrivalDate = true;
+      issues.push("arrival date");
+    }
+    if (items.length === 0) {
+      errors.itemsEmpty = true;
+      issues.push("at least one butterfly species");
+    }
+    for (const item of items) {
+      if (item.number_received <= 0) {
+        errors.receivedByItemId[item.butterfly_species_id] = true;
+      }
     }
 
-    const payload = {
-      ...values,
-      items: values.items.map((item) => ({
-        ...item,
-        emerged_in_transit: item.emerged_in_transit ?? 0,
-        damaged_in_transit: item.damaged_in_transit ?? 0,
-        diseased_in_transit: item.diseased_in_transit ?? 0,
-        parasite: item.parasite ?? 0,
-        non_emergence: item.non_emergence ?? 0,
-        poor_emergence: item.poor_emergence ?? 0,
-      })),
-    };
+    const hasReceivedErrors = Object.keys(errors.receivedByItemId).length > 0;
+    if (hasReceivedErrors) {
+      issues.push("a received count above zero on every species");
+    }
 
+    if (issues.length === 0) return null;
+
+    return {
+      errors,
+      message: `Please fill in: ${issues.join(", ")}.`,
+    };
+  };
+
+  // Clear date errors as the user picks values; don't wait for re-submit.
+  const handleShipmentDateChange = useCallback((next: string) => {
+    setShipmentDate(next);
+    if (next) setFieldErrors((prev) => ({ ...prev, shipmentDate: false }));
+  }, []);
+
+  const handleArrivalDateChange = useCallback((next: string) => {
+    setArrivalDate(next);
+    if (next) setFieldErrors((prev) => ({ ...prev, arrivalDate: false }));
+  }, []);
+
+  const handleSupplierChange = useCallback((code: string) => {
+    setSupplierCode(code);
+    if (code) setFieldErrors((prev) => ({ ...prev, supplier: false }));
+  }, []);
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setErrorMessage(null);
+
+    const validation = validate();
+    if (validation) {
+      setFieldErrors(validation.errors);
+      setErrorMessage(validation.message);
+      return;
+    }
+    setFieldErrors(EMPTY_FIELD_ERRORS);
+
+    setSubmitting(true);
     try {
       const response = await fetch("/api/tenant/shipments", {
         method: "POST",
         headers: { "Content-Type": "application/json", ...tenantHeaders },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({
+          supplier_code: supplierCode,
+          shipment_date: dateOnlyToIso(shipmentDate),
+          arrival_date: dateOnlyToIso(arrivalDate),
+          items: items.map(
+            ({
+              butterfly_species_id,
+              number_received,
+              emerged_in_transit,
+              damaged_in_transit,
+              diseased_in_transit,
+              parasite,
+              non_emergence,
+              poor_emergence,
+            }) => ({
+              butterfly_species_id,
+              number_received,
+              emerged_in_transit,
+              damaged_in_transit,
+              diseased_in_transit,
+              parasite,
+              non_emergence,
+              poor_emergence,
+            }),
+          ),
+        }),
       });
-
       const result = await response.json().catch(() => null);
-
       if (!response.ok) {
-        setServerError(getApiErrorMessage(result, "Unable to create shipment"));
+        setErrorMessage(result?.error?.message ?? "Unable to create shipment.");
         return;
       }
-
-      form.reset(defaultValues);
-      setSpeciesSearchByRowId({});
-      setActiveSpeciesRowId(null);
-      setSuccessMessage("Shipment created successfully.");
+      router.push(ROUTES.tenant.shipmentById(slug, result.id));
     } catch {
-      setServerError("Unable to create shipment");
+      setErrorMessage("Unable to create shipment.");
+    } finally {
+      setSubmitting(false);
     }
   };
 
-  useEffect(() => {
-    const loadSuppliers = async () => {
-      if (!institutionSlug) {
-        setSuppliersStatus("error");
-        return;
-      }
-
-      setSuppliersStatus("loading");
-      try {
-        const response = await fetch("/api/tenant/suppliers", {
-          headers: tenantHeaders,
-        });
-        const result = await response.json().catch(() => null);
-
-        if (!response.ok) {
-          setSuppliersStatus("error");
-          return;
-        }
-
-        const rows =
-          result && typeof result === "object" && "suppliers" in result ? result.suppliers : null;
-
-        const options = Array.isArray(rows)
-          ? rows
-              .filter((item) => item && typeof item.code === "string")
-              .map((item) => ({
-                id: item.id,
-                name: item.name ?? item.code,
-                code: item.code,
-                isActive: item.isActive ?? true,
-              }))
-          : [];
-
-        setSupplierOptions(options);
-        setSuppliersStatus("idle");
-      } catch {
-        setSuppliersStatus("error");
-      }
-    };
-
-    void loadSuppliers();
-  }, [institutionSlug, tenantHeaders]);
-
-  useEffect(() => {
-    const loadSpecies = async () => {
-      if (!institutionSlug) {
-        setSpeciesStatus("error");
-        return;
-      }
-
-      setSpeciesStatus("loading");
-
-      try {
-        const response = await fetch("/api/tenant/species", {
-          headers: tenantHeaders,
-        });
-        const result = await response.json().catch(() => null);
-
-        if (!response.ok) {
-          setSpeciesStatus("error");
-          return;
-        }
-
-        const rows =
-          result && typeof result === "object" && "species" in result ? result.species : null;
-
-        const options = Array.isArray(rows)
-          ? rows
-              .map((row) => {
-                if (!row || typeof row !== "object") return null;
-
-                const id = typeof row.id === "number" ? row.id : Number(row.id);
-                const scientificName =
-                  typeof row.scientificName === "string" ? row.scientificName.trim() : "";
-                const commonNameOverride =
-                  typeof row.commonNameOverride === "string" ? row.commonNameOverride.trim() : "";
-                const commonNameBase =
-                  typeof row.commonName === "string" ? row.commonName.trim() : "";
-                const commonName = commonNameOverride || commonNameBase || scientificName;
-
-                if (!Number.isFinite(id) || id <= 0 || !scientificName) return null;
-
-                return {
-                  id,
-                  scientificName,
-                  commonName,
-                } satisfies SpeciesOption;
-              })
-              .filter((option): option is SpeciesOption => option !== null)
-          : [];
-
-        setSpeciesOptions(options);
-        setSpeciesStatus("idle");
-      } catch {
-        setSpeciesStatus("error");
-      }
-    };
-
-    void loadSpecies();
-  }, [institutionSlug, tenantHeaders]);
-
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 py-10">
-      <div className="space-y-2">
+    <div className="flex flex-col gap-6">
+      <div className="space-y-1">
         <h1 className="text-3xl font-semibold">Add shipment</h1>
         <p className="text-muted-foreground">
-          Record shipment details and quality metrics for each species in the delivery.
+          Record a new shipment and the butterflies that arrived.
         </p>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Shipment details</CardTitle>
-          <CardDescription>Provide the shipment header and line items.</CardDescription>
-        </CardHeader>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)}>
-            <CardContent className="space-y-6">
-              <div className="grid gap-4 md:grid-cols-3">
-                <FormField
-                  control={form.control}
-                  name="supplier_code"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Supplier code</FormLabel>
-                      <FormControl>
-                        <NativeSelect
-                          value={field.value}
-                          onChange={field.onChange}
-                          aria-label="Select supplier"
-                        >
-                          <NativeSelectOption value="">
-                            {suppliersStatus === "loading"
-                              ? "Loading suppliers..."
-                              : "Select a supplier"}
-                          </NativeSelectOption>
-                          {supplierOptions.map((supplier) => (
-                            <NativeSelectOption key={supplier.id} value={supplier.code}>
-                              {supplier.code} — {supplier.name}
-                              {supplier.isActive ? "" : " (inactive)"}
-                            </NativeSelectOption>
-                          ))}
-                        </NativeSelect>
-                      </FormControl>
-                      <FormDescription>Use the USDA supplier abbreviation.</FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="shipment_date"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Shipment date</FormLabel>
-                      <FormControl>
-                        <Input
-                          type="datetime-local"
-                          value={toLocalInputValue(field.value)}
-                          onChange={(event) => field.onChange(toIsoString(event.target.value))}
-                        />
-                      </FormControl>
-                      <FormDescription>When the shipment left the supplier.</FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="arrival_date"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Arrival date</FormLabel>
-                      <FormControl>
-                        <Input
-                          type="datetime-local"
-                          value={toLocalInputValue(field.value)}
-                          onChange={(event) => field.onChange(toIsoString(event.target.value))}
-                        />
-                      </FormControl>
-                      <FormDescription>When the shipment arrived on-site.</FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
+      <form onSubmit={onSubmit} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Shipment details</CardTitle>
+            <CardDescription>Supplier and dates for this shipment.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="supplier">Supplier</Label>
+              <SupplierSelect
+                id="supplier"
+                suppliers={suppliers}
+                value={supplierCode}
+                onChange={handleSupplierChange}
+                aria-invalid={fieldErrors.supplier}
+                aria-describedby={fieldErrors.supplier ? "supplier-error" : undefined}
+              />
+              {fieldErrors.supplier && (
+                <p id="supplier-error" className="text-destructive text-xs">
+                  Supplier is required.
+                </p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="shipment-date">Shipment date</Label>
+              <DatePicker
+                id="shipment-date"
+                value={shipmentDate}
+                onChange={handleShipmentDateChange}
+                // The arrival date sets the latest valid shipment date — a
+                // shipment can't have left the supplier after it arrived.
+                maxDate={arrivalDate || undefined}
+                aria-invalid={fieldErrors.shipmentDate}
+                aria-describedby={fieldErrors.shipmentDate ? "shipment-date-error" : undefined}
+              />
+              {fieldErrors.shipmentDate && (
+                <p id="shipment-date-error" className="text-destructive text-xs">
+                  Shipment date is required.
+                </p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="arrival-date">Arrival date</Label>
+              <DatePicker
+                id="arrival-date"
+                value={arrivalDate}
+                onChange={handleArrivalDateChange}
+                // Conversely, arrival can't be earlier than the shipment date.
+                minDate={shipmentDate || undefined}
+                aria-invalid={fieldErrors.arrivalDate}
+                aria-describedby={fieldErrors.arrivalDate ? "arrival-date-error" : undefined}
+              />
+              {fieldErrors.arrivalDate && (
+                <p id="arrival-date-error" className="text-destructive text-xs">
+                  Arrival date is required.
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
 
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <h2 className="text-lg font-semibold">Shipment items</h2>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => append({ ...defaultItem })}
-                  >
-                    Add item
-                  </Button>
-                </div>
-
-                <div className="space-y-4">
-                  {fields.map((itemField, index) => (
-                    <div key={itemField.id} className="rounded-lg border p-4">
-                      <div className="grid gap-4 md:grid-cols-4">
-                        <FormField
-                          control={form.control}
-                          name={`items.${index}.butterfly_species_id`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Species</FormLabel>
-                              <FormControl>
-                                <div className="relative space-y-2">
-                                  <Input
-                                    type="text"
-                                    value={speciesSearchByRowId[itemField.id] ?? ""}
-                                    placeholder="Type scientific or common name"
-                                    role="combobox"
-                                    aria-expanded={activeSpeciesRowId === itemField.id}
-                                    aria-controls={`species-options-${itemField.id}`}
-                                    aria-autocomplete="list"
-                                    onFocus={() => setActiveSpeciesRowId(itemField.id)}
-                                    onBlur={() => {
-                                      window.setTimeout(() => {
-                                        setActiveSpeciesRowId((current) =>
-                                          current === itemField.id ? null : current,
-                                        );
-                                      }, 120);
-                                    }}
-                                    onChange={(event) => {
-                                      field.onChange(0);
-                                      setActiveSpeciesRowId(itemField.id);
-                                      setSpeciesSearchByRowId((prev) => ({
-                                        ...prev,
-                                        [itemField.id]: event.target.value,
-                                      }));
-                                    }}
-                                  />
-
-                                  {activeSpeciesRowId === itemField.id && (
-                                    <div
-                                      id={`species-options-${itemField.id}`}
-                                      role="listbox"
-                                      className="bg-background absolute z-20 mt-1 max-h-56 w-full overflow-y-auto rounded-md border shadow-md"
-                                    >
-                                      {speciesStatus === "loading" && (
-                                        <div className="px-3 py-2 text-sm">Loading species...</div>
-                                      )}
-
-                                      {speciesStatus === "error" && (
-                                        <div className="px-3 py-2 text-sm">
-                                          Unable to load species options.
-                                        </div>
-                                      )}
-
-                                      {speciesStatus === "idle" &&
-                                        (() => {
-                                          const filtered = getFilteredSpeciesOptions(
-                                            speciesSearchByRowId[itemField.id] ?? "",
-                                          );
-
-                                          if (filtered.length === 0) {
-                                            return (
-                                              <div className="px-3 py-2 text-sm">
-                                                No species matches your filter.
-                                              </div>
-                                            );
-                                          }
-
-                                          return filtered.map((option) => (
-                                            <button
-                                              type="button"
-                                              key={option.id}
-                                              role="option"
-                                              aria-selected={field.value === option.id}
-                                              className="hover:bg-muted block w-full px-3 py-2 text-left"
-                                              onMouseDown={(event) => event.preventDefault()}
-                                              onClick={() => {
-                                                field.onChange(option.id);
-                                                setSpeciesSearchByRowId((prev) => ({
-                                                  ...prev,
-                                                  [itemField.id]: getSpeciesLabel(option),
-                                                }));
-                                                setActiveSpeciesRowId(null);
-                                              }}
-                                            >
-                                              <div className="text-sm font-medium">
-                                                {option.scientificName}
-                                              </div>
-                                              <div className="text-muted-foreground text-xs">
-                                                {option.commonName}
-                                              </div>
-                                            </button>
-                                          ));
-                                        })()}
-                                    </div>
-                                  )}
-                                </div>
-                              </FormControl>
-                              <FormDescription>
-                                Type to filter by scientific or common name.
-                              </FormDescription>
-                              <FormMessage />
-                            </FormItem>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0">
+            <div>
+              <CardTitle>Butterflies</CardTitle>
+              <CardDescription>
+                Add species and record received quantities and any losses.
+              </CardDescription>
+            </div>
+            <Button type="button" onClick={() => setPickerOpen(true)}>
+              Add butterflies
+            </Button>
+          </CardHeader>
+          <CardContent>
+            {items.length === 0 ? (
+              <p
+                className={cn(
+                  "rounded-md border p-6 text-center text-sm",
+                  fieldErrors.itemsEmpty
+                    ? "border-destructive text-destructive"
+                    : "text-muted-foreground",
+                )}
+              >
+                No species added yet. Click <strong>Add butterflies</strong> to get started.
+              </p>
+            ) : (
+              <ul className="grid gap-4">
+                {items.map((item) => {
+                  const receivedInvalid = !!fieldErrors.receivedByItemId[item.butterfly_species_id];
+                  return (
+                    <li
+                      key={item.butterfly_species_id}
+                      className={cn(
+                        "bg-card flex flex-col gap-4 rounded-lg border p-4",
+                        receivedInvalid && "border-destructive",
+                      )}
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="bg-muted relative size-16 shrink-0 overflow-hidden rounded">
+                          {item.imgWingsOpen ? (
+                            <Image
+                              src={item.imgWingsOpen}
+                              alt=""
+                              width={128}
+                              height={128}
+                              quality={90}
+                              className="size-full object-cover"
+                            />
+                          ) : (
+                            <Bug className="text-muted-foreground absolute inset-0 m-auto size-7" />
                           )}
-                        />
-                        <FormField
-                          control={form.control}
-                          name={`items.${index}.number_received`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Received</FormLabel>
-                              <FormControl>
-                                <Input
-                                  type="number"
-                                  min={0}
-                                  step={1}
-                                  value={field.value}
-                                  onChange={handleNumberChange(field.onChange)}
-                                />
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                        <FormField
-                          control={form.control}
-                          name={`items.${index}.emerged_in_transit`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Emerged</FormLabel>
-                              <FormControl>
-                                <Input
-                                  type="number"
-                                  min={0}
-                                  step={1}
-                                  value={field.value}
-                                  onChange={handleNumberChange(field.onChange)}
-                                />
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                        <FormField
-                          control={form.control}
-                          name={`items.${index}.damaged_in_transit`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Damaged</FormLabel>
-                              <FormControl>
-                                <Input
-                                  type="number"
-                                  min={0}
-                                  step={1}
-                                  value={field.value}
-                                  onChange={handleNumberChange(field.onChange)}
-                                />
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                        <FormField
-                          control={form.control}
-                          name={`items.${index}.diseased_in_transit`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Diseased</FormLabel>
-                              <FormControl>
-                                <Input
-                                  type="number"
-                                  min={0}
-                                  step={1}
-                                  value={field.value}
-                                  onChange={handleNumberChange(field.onChange)}
-                                />
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                        <FormField
-                          control={form.control}
-                          name={`items.${index}.parasite`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Parasite</FormLabel>
-                              <FormControl>
-                                <Input
-                                  type="number"
-                                  min={0}
-                                  step={1}
-                                  value={field.value}
-                                  onChange={handleNumberChange(field.onChange)}
-                                />
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                        <FormField
-                          control={form.control}
-                          name={`items.${index}.non_emergence`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Non-emergence</FormLabel>
-                              <FormControl>
-                                <Input
-                                  type="number"
-                                  min={0}
-                                  step={1}
-                                  value={field.value}
-                                  onChange={handleNumberChange(field.onChange)}
-                                />
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                        <FormField
-                          control={form.control}
-                          name={`items.${index}.poor_emergence`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Poor emergence</FormLabel>
-                              <FormControl>
-                                <Input
-                                  type="number"
-                                  min={0}
-                                  step={1}
-                                  value={field.value}
-                                  onChange={handleNumberChange(field.onChange)}
-                                />
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      </div>
-
-                      <div className="mt-4 flex justify-end">
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-base font-medium">{item.common_name}</div>
+                          <div className="text-muted-foreground truncate text-sm italic">
+                            {item.scientific_name}
+                          </div>
+                        </div>
                         <Button
                           type="button"
+                          size="icon"
                           variant="ghost"
-                          onClick={() => {
-                            remove(index);
-                            setSpeciesSearchByRowId((prev) => {
-                              const next = { ...prev };
-                              delete next[itemField.id];
-                              return next;
-                            });
-                            setActiveSpeciesRowId((current) =>
-                              current === itemField.id ? null : current,
-                            );
-                          }}
-                          disabled={fields.length === 1}
+                          aria-label={`Remove ${item.common_name}`}
+                          onClick={() => setPendingDelete(item)}
                         >
-                          Remove item
+                          <Trash2 className="size-4" />
                         </Button>
                       </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
 
-              {(serverError || successMessage) && (
-                <div
-                  className="rounded-md border px-4 py-3 text-sm"
-                  role="status"
-                  aria-live="polite"
-                >
-                  {serverError ? (
-                    <span className="text-destructive">{serverError}</span>
-                  ) : (
-                    <span className="text-emerald-600">{successMessage}</span>
-                  )}
-                </div>
-              )}
-            </CardContent>
-            <CardFooter className="justify-end gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => {
-                  form.reset(defaultValues);
-                  setSpeciesSearchByRowId({});
-                  setActiveSpeciesRowId(null);
-                }}
-              >
-                Reset
-              </Button>
-              <Button type="submit" disabled={form.formState.isSubmitting}>
-                {form.formState.isSubmitting ? "Saving..." : "Save shipment"}
-              </Button>
-            </CardFooter>
-          </form>
-        </Form>
-      </Card>
+                      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-7">
+                        {METRIC_FIELDS.map((field) => (
+                          <MetricInput
+                            key={field.key}
+                            label={field.label}
+                            value={item[field.key]}
+                            ariaLabel={`${field.label} for ${item.common_name}`}
+                            // Only the "Received" stepper is required > 0; the rest
+                            // can legitimately stay at 0.
+                            invalid={field.key === "number_received" && receivedInvalid}
+                            onChange={(next) =>
+                              updateItem(item.butterfly_species_id, field.key, next)
+                            }
+                          />
+                        ))}
+                      </div>
+                      {receivedInvalid && (
+                        <p className="text-destructive text-xs">Received must be greater than 0.</p>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </CardContent>
+          <CardFooter className="flex items-center justify-between">
+            {errorMessage ? (
+              <span className="text-destructive text-sm" role="alert">
+                {errorMessage}
+              </span>
+            ) : (
+              <span />
+            )}
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Saving…" : "Save shipment"}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+
+      <SpeciesPickerDialog
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        species={species}
+        excludeIds={addedSpeciesIds}
+        onConfirm={handlePickerConfirm}
+      />
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove this species from the shipment?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingDelete
+                ? `${pendingDelete.common_name} (${pendingDelete.scientific_name}) and any quantities you entered for it will be discarded.`
+                : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (pendingDelete) removeItem(pendingDelete.butterfly_species_id);
+                setPendingDelete(null);
+              }}
+            >
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+interface MetricInputProps {
+  label: string;
+  value: number;
+  ariaLabel: string;
+  onChange: (next: number) => void;
+  invalid?: boolean;
+}
+
+function MetricInput({ label, value, ariaLabel, onChange, invalid }: MetricInputProps) {
+  const clamp = (next: number) => Math.max(0, Math.floor(Number.isFinite(next) ? next : 0));
+  return (
+    <div className="space-y-1">
+      <Label className={cn("text-xs", invalid && "text-destructive")}>{label}</Label>
+      <div className="flex items-center gap-1">
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          className="size-8"
+          aria-label={`Decrease ${ariaLabel}`}
+          onClick={() => onChange(clamp(value - 1))}
+        >
+          <Minus className="size-3" />
+        </Button>
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={0}
+          step={1}
+          value={value}
+          aria-label={ariaLabel}
+          aria-invalid={invalid}
+          className="h-8 w-14 px-1 text-center text-sm"
+          onChange={(event) => onChange(clamp(Number(event.target.value)))}
+        />
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          className="size-8"
+          aria-label={`Increase ${ariaLabel}`}
+          onClick={() => onChange(clamp(value + 1))}
+        >
+          <Plus className="size-3" />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/app/[institution]/(tenant)/shipments/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/page.tsx
@@ -1,3 +1,391 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+type ShipmentListItem = {
+  id: number;
+  supplierCode: string;
+  shipmentDate: string;
+  arrivalDate: string;
+  createdAt: string;
+};
+
+type ShipmentsPagination = {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+};
+
+const SHIPMENTS_PAGE_LIMIT = 50;
+
+const formatDateTime = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return "-";
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+};
+
 export default function ShipmentsPage() {
-  return <h1>Shipments</h1>;
+  const params = useParams<{ institution: string }>();
+  const institution = params?.institution ?? "";
+
+  const [shipments, setShipments] = useState<ShipmentListItem[]>([]);
+  const [page, setPage] = useState(1);
+  const [pagination, setPagination] = useState<ShipmentsPagination>({
+    page: 1,
+    limit: SHIPMENTS_PAGE_LIMIT,
+    total: 0,
+    totalPages: 1,
+  });
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [deleteStatus, setDeleteStatus] = useState<"idle" | "deleting" | "error" | "success">(
+    "idle",
+  );
+  const [deleteMessage, setDeleteMessage] = useState<string | null>(null);
+  const [deletingShipmentId, setDeletingShipmentId] = useState<number | null>(null);
+
+  const addShipmentHref = useMemo(() => {
+    if (!institution) return "/shipments/add";
+    return `/${institution}/shipments/add`;
+  }, [institution]);
+
+  const detailHref = useCallback(
+    (shipmentId: number) => {
+      if (!institution) return `/shipments/${shipmentId}`;
+      return `/${institution}/shipments/${shipmentId}`;
+    },
+    [institution],
+  );
+
+  const fetchShipments = useCallback(
+    async (targetPage: number) => {
+      try {
+        const queryParams = new URLSearchParams({
+          page: String(targetPage),
+          limit: String(SHIPMENTS_PAGE_LIMIT),
+        });
+
+        const url = `/api/tenant/shipments?${queryParams.toString()}`;
+
+        const response = await fetch(url, {
+          headers: {
+            "x-tenant-slug": institution,
+          },
+        });
+
+        const result = await response.json().catch(() => null);
+
+        if (!response.ok) {
+          return { ok: false as const, error: "Failed to load shipments." };
+        }
+
+        const shipmentsData = Array.isArray(result?.shipments) ? result.shipments : [];
+        const parsedPagination = result?.pagination;
+
+        const paginationData: ShipmentsPagination = {
+          page:
+            typeof parsedPagination?.page === "number" && parsedPagination.page > 0
+              ? parsedPagination.page
+              : targetPage,
+          limit:
+            typeof parsedPagination?.limit === "number" && parsedPagination.limit > 0
+              ? parsedPagination.limit
+              : SHIPMENTS_PAGE_LIMIT,
+          total:
+            typeof parsedPagination?.total === "number" && parsedPagination.total >= 0
+              ? parsedPagination.total
+              : shipmentsData.length,
+          totalPages:
+            typeof parsedPagination?.totalPages === "number" && parsedPagination.totalPages > 0
+              ? parsedPagination.totalPages
+              : 1,
+        };
+
+        return {
+          ok: true as const,
+          data: shipmentsData,
+          pagination: paginationData,
+        };
+      } catch {
+        return { ok: false as const, error: "Failed to load shipments." };
+      }
+    },
+    [institution],
+  );
+
+  const loadShipments = useCallback(
+    async (targetPage: number) => {
+      setStatus("loading");
+      setErrorMessage(null);
+      setDeleteStatus("idle");
+      setDeleteMessage(null);
+
+      const result = await fetchShipments(targetPage);
+      if (!result.ok) {
+        setStatus("error");
+        setErrorMessage(result.error);
+        return;
+      }
+
+      setShipments(result.data);
+      setPagination(result.pagination);
+      setStatus("idle");
+    },
+    [fetchShipments],
+  );
+
+  const handleDeleteShipment = useCallback(
+    async (shipmentId: number) => {
+      if (!Number.isInteger(shipmentId) || shipmentId <= 0) return;
+
+      const confirmed = window.confirm(`Delete shipment #${shipmentId}? This cannot be undone.`);
+      if (!confirmed) return;
+
+      setDeletingShipmentId(shipmentId);
+      setDeleteStatus("deleting");
+      setDeleteMessage(null);
+
+      try {
+        const response = await fetch(`/api/tenant/shipments/${shipmentId}`, {
+          method: "DELETE",
+          headers: {
+            "x-tenant-slug": institution,
+          },
+        });
+
+        const result = await response.json().catch(() => null);
+
+        if (!response.ok) {
+          setDeleteStatus("error");
+          setDeleteMessage(result?.error?.message ?? "Unable to delete shipment");
+          return;
+        }
+
+        setShipments((current) => current.filter((s) => s.id !== shipmentId));
+
+        setDeleteStatus("success");
+        setDeleteMessage(`Shipment #${shipmentId} deleted.`);
+      } catch {
+        setDeleteStatus("error");
+        setDeleteMessage("Unable to delete shipment");
+      } finally {
+        setDeletingShipmentId(null);
+      }
+    },
+    [institution],
+  );
+
+  const handleDeleteAllShipments = useCallback(async () => {
+    if (shipments.length === 0) return;
+
+    const confirmed = window.confirm(
+      `Delete all ${shipments.length} shipments? This cannot be undone.`,
+    );
+    if (!confirmed) return;
+
+    setDeleteStatus("deleting");
+    setDeleteMessage(null);
+
+    try {
+      const response = await fetch("/api/tenant/shipments", {
+        method: "DELETE",
+        headers: {
+          "x-tenant-slug": institution,
+        },
+      });
+
+      const result = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        setDeleteStatus("error");
+        setDeleteMessage(result?.error?.message ?? "Unable to delete shipments");
+        return;
+      }
+
+      const deletedCount = result?.deleted ?? 0;
+
+      setShipments([]);
+      setDeleteStatus("success");
+      setDeleteMessage(
+        deletedCount > 0
+          ? `Deleted ${deletedCount} shipment${deletedCount === 1 ? "" : "s"}.`
+          : "No shipments were deleted.",
+      );
+    } catch {
+      setDeleteStatus("error");
+      setDeleteMessage("Unable to delete shipments");
+    }
+  }, [shipments.length, institution]);
+
+  useEffect(() => {
+    void loadShipments(page);
+  }, [page, loadShipments]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 py-10">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold">Shipments</h1>
+          <p className="text-muted-foreground">
+            Review and manage shipment records for your institution.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={() => void loadShipments(page)}>
+            Refresh
+          </Button>
+
+          <Button
+            variant="destructive"
+            onClick={handleDeleteAllShipments}
+            disabled={shipments.length === 0 || deleteStatus === "deleting"}
+          >
+            {deleteStatus === "deleting" ? "Deleting..." : "Delete all shipments"}
+          </Button>
+
+          <Button asChild>
+            <Link href={addShipmentHref}>Add shipment</Link>
+          </Button>
+        </div>
+      </div>
+
+      {deleteMessage ? (
+        <div
+          className={
+            deleteStatus === "error" ? "text-destructive text-sm" : "text-sm text-emerald-700"
+          }
+        >
+          {deleteMessage}
+        </div>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent shipments</CardTitle>
+          <CardDescription>Sorted by shipment date.</CardDescription>
+        </CardHeader>
+
+        <CardContent>
+          {status === "loading" ? (
+            <div className="text-muted-foreground text-sm">Loading shipments...</div>
+          ) : status === "error" ? (
+            <div className="text-destructive text-sm">
+              {errorMessage ?? "Unable to load shipments"}
+            </div>
+          ) : shipments.length === 0 ? (
+            <Empty>
+              <EmptyHeader>
+                <EmptyTitle>No shipments yet</EmptyTitle>
+                <EmptyDescription>
+                  Add your first shipment to start tracking arrivals.
+                </EmptyDescription>
+              </EmptyHeader>
+
+              <EmptyContent>
+                <Button asChild>
+                  <Link href={addShipmentHref}>Add shipment</Link>
+                </Button>
+              </EmptyContent>
+            </Empty>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Supplier Code</TableHead>
+                  <TableHead>Shipment Date</TableHead>
+                  <TableHead>Arrival Date</TableHead>
+                  <TableHead>Created At</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+
+              <TableBody>
+                {shipments.map((shipment) => (
+                  <TableRow key={shipment.id}>
+                    <TableCell className="font-medium">
+                      <Link
+                        href={detailHref(shipment.id)}
+                        className="underline-offset-4 hover:underline"
+                      >
+                        #{shipment.id}
+                      </Link>
+                    </TableCell>
+
+                    <TableCell>{shipment.supplierCode}</TableCell>
+                    <TableCell>{formatDateTime(shipment.shipmentDate)}</TableCell>
+                    <TableCell>{formatDateTime(shipment.arrivalDate)}</TableCell>
+                    <TableCell>{formatDateTime(shipment.createdAt)}</TableCell>
+
+                    <TableCell className="text-right">
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => handleDeleteShipment(shipment.id)}
+                        disabled={deleteStatus === "deleting" || deletingShipmentId === shipment.id}
+                      >
+                        {deletingShipmentId === shipment.id ? "Deleting..." : "Delete"}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+
+          {status !== "error" ? (
+            <div className="mt-4 flex items-center justify-end gap-4">
+              <Button
+                variant="outline"
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+                disabled={status === "loading" || page === 1}
+              >
+                Previous
+              </Button>
+
+              <span className="text-muted-foreground text-sm">
+                Page {pagination.page} of {pagination.totalPages}
+              </span>
+
+              <Button
+                variant="outline"
+                onClick={() => setPage((current) => current + 1)}
+                disabled={status === "loading" || page >= pagination.totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  );
 }

--- a/src/app/[institution]/(tenant)/shipments/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 
 import { Link } from "@/components/ui/link";
 import { MoreHorizontal, Trash2 } from "lucide-react";
@@ -68,6 +68,7 @@ type Pagination = {
 
 export default function ShipmentsListPage() {
   const params = useParams<{ institution: string }>();
+  const router = useRouter();
   const slug = params?.institution ?? "";
 
   const [shipments, setShipments] = useState<ShipmentListRow[]>([]);
@@ -207,7 +208,7 @@ export default function ShipmentsListPage() {
               </EmptyContent>
             </Empty>
           ) : (
-            <div className="overflow-x-auto rounded-md border">
+            <div className="overflow-x-auto">
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -220,17 +221,24 @@ export default function ShipmentsListPage() {
                 </TableHeader>
                 <TableBody>
                   {shipments.map((shipment) => {
-                    // The supplier cell is a real anchor so keyboard and
-                    // screen-reader users get native link semantics. The
-                    // action buttons stay in the rightmost cell and do not
-                    // rely on row-level click propagation.
+                    // The whole row navigates to the shipment detail. The
+                    // supplier cell stays a real anchor so keyboard and
+                    // screen-reader users still get native link semantics, and
+                    // the actions cell stops propagation so its buttons don't
+                    // accidentally trigger row navigation.
+                    const href = detailHref(shipment.id);
                     return (
-                      <TableRow key={shipment.id} className="hover:bg-muted/50">
+                      <TableRow
+                        key={shipment.id}
+                        className="hover:bg-muted/50 cursor-pointer"
+                        onClick={() => router.push(href)}
+                      >
                         <TableCell className="font-medium">
                           <Link
-                            href={detailHref(shipment.id)}
+                            href={href}
                             aria-label={`Open shipment from ${shipment.supplierCode}`}
                             className="focus-visible:ring-ring rounded-sm underline-offset-2 hover:underline focus-visible:ring-2 focus-visible:outline-none"
+                            onClick={(event) => event.stopPropagation()}
                           >
                             {shipment.supplierCode}
                           </Link>
@@ -243,7 +251,10 @@ export default function ShipmentsListPage() {
                             isCompleted={shipment.isCompleted}
                           />
                         </TableCell>
-                        <TableCell className="text-right">
+                        <TableCell
+                          className="text-right"
+                          onClick={(event) => event.stopPropagation()}
+                        >
                           <div className="flex items-center justify-end gap-1">
                             {!shipment.isCompleted && (
                               <Button asChild size="sm">

--- a/src/app/[institution]/(tenant)/shipments/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/page.tsx
@@ -1,10 +1,28 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { useParams } from "next/navigation";
+
+import { Link } from "@/components/ui/link";
+import { MoreHorizontal, Trash2 } from "lucide-react";
+
+import { ROUTES } from "@/lib/routes";
+
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty";
 import {
   Table,
   TableBody,
@@ -14,291 +32,165 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyTitle,
-} from "@/components/ui/empty";
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
-type ShipmentListItem = {
-  id: number;
-  supplierCode: string;
-  shipmentDate: string;
-  arrivalDate: string;
-  createdAt: string;
-};
+import { ShipmentStatusBadge } from "@/components/tenant/shipments/shipment-status-badge";
+import type { ShipmentListRow } from "@/components/tenant/shipments/types";
 
-type ShipmentsPagination = {
+const PAGE_LIMIT = 50;
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "2-digit",
+  year: "numeric",
+});
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return "—";
+  return dateFormatter.format(date);
+}
+
+type Pagination = {
   page: number;
   limit: number;
   total: number;
   totalPages: number;
 };
 
-const SHIPMENTS_PAGE_LIMIT = 50;
-
-const formatDateTime = (value: string) => {
-  const date = new Date(value);
-  if (Number.isNaN(date.valueOf())) return "-";
-
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "2-digit",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
-};
-
-export default function ShipmentsPage() {
+export default function ShipmentsListPage() {
   const params = useParams<{ institution: string }>();
-  const institution = params?.institution ?? "";
+  const slug = params?.institution ?? "";
 
-  const [shipments, setShipments] = useState<ShipmentListItem[]>([]);
-  const [page, setPage] = useState(1);
-  const [pagination, setPagination] = useState<ShipmentsPagination>({
+  const [shipments, setShipments] = useState<ShipmentListRow[]>([]);
+  const [pagination, setPagination] = useState<Pagination>({
     page: 1,
-    limit: SHIPMENTS_PAGE_LIMIT,
+    limit: PAGE_LIMIT,
     total: 0,
     totalPages: 1,
   });
+  const [page, setPage] = useState(1);
   const [status, setStatus] = useState<"idle" | "loading" | "error">("loading");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [deleteStatus, setDeleteStatus] = useState<"idle" | "deleting" | "error" | "success">(
-    "idle",
-  );
-  const [deleteMessage, setDeleteMessage] = useState<string | null>(null);
-  const [deletingShipmentId, setDeletingShipmentId] = useState<number | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+  const [busyId, setBusyId] = useState<number | null>(null);
 
-  const addShipmentHref = useMemo(() => {
-    if (!institution) return "/shipments/add";
-    return `/${institution}/shipments/add`;
-  }, [institution]);
-
-  const detailHref = useCallback(
-    (shipmentId: number) => {
-      if (!institution) return `/shipments/${shipmentId}`;
-      return `/${institution}/shipments/${shipmentId}`;
-    },
-    [institution],
-  );
-
-  const fetchShipments = useCallback(
-    async (targetPage: number) => {
-      try {
-        const queryParams = new URLSearchParams({
-          page: String(targetPage),
-          limit: String(SHIPMENTS_PAGE_LIMIT),
-        });
-
-        const url = `/api/tenant/shipments?${queryParams.toString()}`;
-
-        const response = await fetch(url, {
-          headers: {
-            "x-tenant-slug": institution,
-          },
-        });
-
-        const result = await response.json().catch(() => null);
-
-        if (!response.ok) {
-          return { ok: false as const, error: "Failed to load shipments." };
-        }
-
-        const shipmentsData = Array.isArray(result?.shipments) ? result.shipments : [];
-        const parsedPagination = result?.pagination;
-
-        const paginationData: ShipmentsPagination = {
-          page:
-            typeof parsedPagination?.page === "number" && parsedPagination.page > 0
-              ? parsedPagination.page
-              : targetPage,
-          limit:
-            typeof parsedPagination?.limit === "number" && parsedPagination.limit > 0
-              ? parsedPagination.limit
-              : SHIPMENTS_PAGE_LIMIT,
-          total:
-            typeof parsedPagination?.total === "number" && parsedPagination.total >= 0
-              ? parsedPagination.total
-              : shipmentsData.length,
-          totalPages:
-            typeof parsedPagination?.totalPages === "number" && parsedPagination.totalPages > 0
-              ? parsedPagination.totalPages
-              : 1,
-        };
-
-        return {
-          ok: true as const,
-          data: shipmentsData,
-          pagination: paginationData,
-        };
-      } catch {
-        return { ok: false as const, error: "Failed to load shipments." };
-      }
-    },
-    [institution],
+  const tenantHeaders = useMemo(() => ({ "x-tenant-slug": slug }), [slug]);
+  const addHref = ROUTES.tenant.shipmentAdd(slug);
+  const detailHref = useCallback((id: number) => ROUTES.tenant.shipmentById(slug, id), [slug]);
+  const releaseHref = useCallback(
+    (id: number) => ROUTES.tenant.shipmentReleaseNew(slug, id),
+    [slug],
   );
 
   const loadShipments = useCallback(
-    async (targetPage: number) => {
+    async (targetPage: number, signal?: AbortSignal) => {
       setStatus("loading");
       setErrorMessage(null);
-      setDeleteStatus("idle");
-      setDeleteMessage(null);
-
-      const result = await fetchShipments(targetPage);
-      if (!result.ok) {
-        setStatus("error");
-        setErrorMessage(result.error);
-        return;
-      }
-
-      setShipments(result.data);
-      setPagination(result.pagination);
-      setStatus("idle");
-    },
-    [fetchShipments],
-  );
-
-  const handleDeleteShipment = useCallback(
-    async (shipmentId: number) => {
-      if (!Number.isInteger(shipmentId) || shipmentId <= 0) return;
-
-      const confirmed = window.confirm(`Delete shipment #${shipmentId}? This cannot be undone.`);
-      if (!confirmed) return;
-
-      setDeletingShipmentId(shipmentId);
-      setDeleteStatus("deleting");
-      setDeleteMessage(null);
-
       try {
-        const response = await fetch(`/api/tenant/shipments/${shipmentId}`, {
-          method: "DELETE",
-          headers: {
-            "x-tenant-slug": institution,
-          },
+        const search = new URLSearchParams({
+          page: String(targetPage),
+          limit: String(PAGE_LIMIT),
         });
-
+        const response = await fetch(`/api/tenant/shipments?${search.toString()}`, {
+          headers: tenantHeaders,
+          signal,
+        });
         const result = await response.json().catch(() => null);
-
+        if (signal?.aborted) return;
         if (!response.ok) {
-          setDeleteStatus("error");
-          setDeleteMessage(result?.error?.message ?? "Unable to delete shipment");
+          setStatus("error");
+          setErrorMessage(result?.error?.message ?? "Failed to load shipments.");
           return;
         }
-
-        setShipments((current) => current.filter((s) => s.id !== shipmentId));
-
-        setDeleteStatus("success");
-        setDeleteMessage(`Shipment #${shipmentId} deleted.`);
-      } catch {
-        setDeleteStatus("error");
-        setDeleteMessage("Unable to delete shipment");
-      } finally {
-        setDeletingShipmentId(null);
+        setShipments(Array.isArray(result?.shipments) ? result.shipments : []);
+        setPagination({
+          page: result?.pagination?.page ?? targetPage,
+          limit: result?.pagination?.limit ?? PAGE_LIMIT,
+          total: result?.pagination?.total ?? 0,
+          totalPages: result?.pagination?.totalPages ?? 1,
+        });
+        setStatus("idle");
+      } catch (err) {
+        if (signal?.aborted) return;
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setStatus("error");
+        setErrorMessage("Failed to load shipments.");
       }
     },
-    [institution],
+    [tenantHeaders],
   );
 
-  const handleDeleteAllShipments = useCallback(async () => {
-    if (shipments.length === 0) return;
-
-    const confirmed = window.confirm(
-      `Delete all ${shipments.length} shipments? This cannot be undone.`,
-    );
-    if (!confirmed) return;
-
-    setDeleteStatus("deleting");
-    setDeleteMessage(null);
-
-    try {
-      const response = await fetch("/api/tenant/shipments", {
-        method: "DELETE",
-        headers: {
-          "x-tenant-slug": institution,
-        },
-      });
-
-      const result = await response.json().catch(() => null);
-
-      if (!response.ok) {
-        setDeleteStatus("error");
-        setDeleteMessage(result?.error?.message ?? "Unable to delete shipments");
-        return;
-      }
-
-      const deletedCount = result?.deleted ?? 0;
-
-      setShipments([]);
-      setDeleteStatus("success");
-      setDeleteMessage(
-        deletedCount > 0
-          ? `Deleted ${deletedCount} shipment${deletedCount === 1 ? "" : "s"}.`
-          : "No shipments were deleted.",
-      );
-    } catch {
-      setDeleteStatus("error");
-      setDeleteMessage("Unable to delete shipments");
-    }
-  }, [shipments.length, institution]);
-
   useEffect(() => {
-    void loadShipments(page);
+    const ac = new AbortController();
+    void loadShipments(page, ac.signal);
+    return () => ac.abort();
   }, [page, loadShipments]);
 
+  const confirmDelete = async () => {
+    if (deleteTargetId === null) return;
+    const id = deleteTargetId;
+    setBusyId(id);
+    try {
+      const response = await fetch(`/api/tenant/shipments/${id}`, {
+        method: "DELETE",
+        headers: tenantHeaders,
+      });
+      if (!response.ok) {
+        const result = await response.json().catch(() => null);
+        setErrorMessage(result?.error?.message ?? "Unable to delete shipment.");
+        return;
+      }
+      setShipments((current) => current.filter((s) => s.id !== id));
+    } finally {
+      setBusyId(null);
+      setDeleteTargetId(null);
+    }
+  };
+
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 py-10">
+    <div className="flex flex-col gap-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="space-y-2">
+        <div className="space-y-1">
           <h1 className="text-3xl font-semibold">Shipments</h1>
           <p className="text-muted-foreground">
-            Review and manage shipment records for your institution.
+            Review every shipment for your institution and track which ones still have butterflies
+            to release.
           </p>
         </div>
-
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={() => void loadShipments(page)}>
-            Refresh
-          </Button>
-
-          <Button
-            variant="destructive"
-            onClick={handleDeleteAllShipments}
-            disabled={shipments.length === 0 || deleteStatus === "deleting"}
-          >
-            {deleteStatus === "deleting" ? "Deleting..." : "Delete all shipments"}
-          </Button>
-
-          <Button asChild>
-            <Link href={addShipmentHref}>Add shipment</Link>
-          </Button>
-        </div>
+        <Button asChild>
+          <Link href={addHref}>Add shipment</Link>
+        </Button>
       </div>
 
-      {deleteMessage ? (
-        <div
-          className={
-            deleteStatus === "error" ? "text-destructive text-sm" : "text-sm text-emerald-700"
-          }
-        >
-          {deleteMessage}
+      {errorMessage && (
+        <div className="text-destructive text-sm" role="alert">
+          {errorMessage}
         </div>
-      ) : null}
+      )}
 
       <Card>
         <CardHeader>
           <CardTitle>Recent shipments</CardTitle>
-          <CardDescription>Sorted by shipment date.</CardDescription>
+          <CardDescription>Sorted by shipment date, newest first.</CardDescription>
         </CardHeader>
-
         <CardContent>
           {status === "loading" ? (
-            <div className="text-muted-foreground text-sm">Loading shipments...</div>
-          ) : status === "error" ? (
-            <div className="text-destructive text-sm">
-              {errorMessage ?? "Unable to load shipments"}
+            <div
+              className="text-muted-foreground text-sm"
+              role="status"
+              aria-live="polite"
+              aria-busy="true"
+            >
+              Loading shipments…
             </div>
           ) : shipments.length === 0 ? (
             <Empty>
@@ -308,84 +200,130 @@ export default function ShipmentsPage() {
                   Add your first shipment to start tracking arrivals.
                 </EmptyDescription>
               </EmptyHeader>
-
               <EmptyContent>
                 <Button asChild>
-                  <Link href={addShipmentHref}>Add shipment</Link>
+                  <Link href={addHref}>Add shipment</Link>
                 </Button>
               </EmptyContent>
             </Empty>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>ID</TableHead>
-                  <TableHead>Supplier Code</TableHead>
-                  <TableHead>Shipment Date</TableHead>
-                  <TableHead>Arrival Date</TableHead>
-                  <TableHead>Created At</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-
-              <TableBody>
-                {shipments.map((shipment) => (
-                  <TableRow key={shipment.id}>
-                    <TableCell className="font-medium">
-                      <Link
-                        href={detailHref(shipment.id)}
-                        className="underline-offset-4 hover:underline"
-                      >
-                        #{shipment.id}
-                      </Link>
-                    </TableCell>
-
-                    <TableCell>{shipment.supplierCode}</TableCell>
-                    <TableCell>{formatDateTime(shipment.shipmentDate)}</TableCell>
-                    <TableCell>{formatDateTime(shipment.arrivalDate)}</TableCell>
-                    <TableCell>{formatDateTime(shipment.createdAt)}</TableCell>
-
-                    <TableCell className="text-right">
-                      <Button
-                        size="sm"
-                        variant="destructive"
-                        onClick={() => handleDeleteShipment(shipment.id)}
-                        disabled={deleteStatus === "deleting" || deletingShipmentId === shipment.id}
-                      >
-                        {deletingShipmentId === shipment.id ? "Deleting..." : "Delete"}
-                      </Button>
-                    </TableCell>
+            <div className="overflow-x-auto rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Supplier</TableHead>
+                    <TableHead>Shipment date</TableHead>
+                    <TableHead>Arrival date</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {shipments.map((shipment) => {
+                    // The supplier cell is a real anchor so keyboard and
+                    // screen-reader users get native link semantics. The
+                    // action buttons stay in the rightmost cell and do not
+                    // rely on row-level click propagation.
+                    return (
+                      <TableRow key={shipment.id} className="hover:bg-muted/50">
+                        <TableCell className="font-medium">
+                          <Link
+                            href={detailHref(shipment.id)}
+                            aria-label={`Open shipment from ${shipment.supplierCode}`}
+                            className="focus-visible:ring-ring rounded-sm underline-offset-2 hover:underline focus-visible:ring-2 focus-visible:outline-none"
+                          >
+                            {shipment.supplierCode}
+                          </Link>
+                        </TableCell>
+                        <TableCell>{formatDate(shipment.shipmentDate)}</TableCell>
+                        <TableCell>{formatDate(shipment.arrivalDate)}</TableCell>
+                        <TableCell>
+                          <ShipmentStatusBadge
+                            remaining={shipment.remaining}
+                            isCompleted={shipment.isCompleted}
+                          />
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex items-center justify-end gap-1">
+                            {!shipment.isCompleted && (
+                              <Button asChild size="sm">
+                                <Link href={releaseHref(shipment.id)}>Add release</Link>
+                              </Button>
+                            )}
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  size="icon"
+                                  variant="ghost"
+                                  aria-label={`More actions for ${shipment.supplierCode}`}
+                                  disabled={busyId === shipment.id}
+                                >
+                                  <MoreHorizontal className="size-4" />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end">
+                                <DropdownMenuItem
+                                  className="text-destructive focus:text-destructive"
+                                  onSelect={() => setDeleteTargetId(shipment.id)}
+                                >
+                                  <Trash2 className="size-4" />
+                                  Delete shipment
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
           )}
 
-          {status !== "error" ? (
-            <div className="mt-4 flex items-center justify-end gap-4">
+          {status !== "error" && pagination.totalPages > 1 && (
+            <div className="mt-4 flex items-center justify-end gap-3">
               <Button
                 variant="outline"
-                onClick={() => setPage((current) => Math.max(1, current - 1))}
-                disabled={status === "loading" || page === 1}
+                size="sm"
+                disabled={page === 1 || status === "loading"}
+                onClick={() => setPage((prev) => Math.max(1, prev - 1))}
               >
                 Previous
               </Button>
-
               <span className="text-muted-foreground text-sm">
                 Page {pagination.page} of {pagination.totalPages}
               </span>
-
               <Button
                 variant="outline"
-                onClick={() => setPage((current) => current + 1)}
-                disabled={status === "loading" || page >= pagination.totalPages}
+                size="sm"
+                disabled={page >= pagination.totalPages || status === "loading"}
+                onClick={() => setPage((prev) => prev + 1)}
               >
                 Next
               </Button>
             </div>
-          ) : null}
+          )}
         </CardContent>
       </Card>
+
+      <AlertDialog
+        open={deleteTargetId !== null}
+        onOpenChange={(open) => !open && setDeleteTargetId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this shipment?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Shipments with line items or releases cannot be deleted. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDelete}>Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/app/api/tenant/releases/[releaseId]/route.ts
+++ b/src/app/api/tenant/releases/[releaseId]/route.ts
@@ -3,12 +3,11 @@ import { NextRequest } from "next/server";
 import { logger } from "@/lib/logger";
 import {
   conflict,
-  forbidden,
   internalError,
   invalidRequest,
+  mapAuthError,
   notFound,
   ok,
-  unauthorized,
 } from "@/lib/api-response";
 import { requireValidBody } from "@/lib/validation/request";
 import {
@@ -55,11 +54,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
       items: result.items,
     });
   } catch (error) {
-    if (error instanceof Error) {
-      if (error.message === "UNAUTHORIZED") return unauthorized();
-      if (error.message === "FORBIDDEN") return forbidden();
-      if (error.message === "NOT_FOUND") return notFound("Institution not found");
-    }
+    const authError = mapAuthError(error);
+    if (authError) return authError;
 
     const tenantError = handleTenantError(error);
     if (tenantError) return tenantError;
@@ -111,14 +107,17 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         return notFound(error.message);
       }
 
+      if (error.message === RELEASE_ERRORS.RELEASE_ITEMS_MUST_MATCH) {
+        return invalidRequest(error.message);
+      }
+
       if (error.message === RELEASE_ERRORS.QUANTITY_EXCEEDS_REMAINING) {
         return conflict(error.message);
       }
-
-      if (error.message === "UNAUTHORIZED") return unauthorized();
-      if (error.message === "FORBIDDEN") return forbidden();
-      if (error.message === "NOT_FOUND") return notFound("Institution not found");
     }
+
+    const authError = mapAuthError(error);
+    if (authError) return authError;
 
     const tenantError = handleTenantError(error);
     if (tenantError) return tenantError;
@@ -153,11 +152,10 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
       if (error.message === RELEASE_ERRORS.RELEASE_EVENT_NOT_FOUND) {
         return notFound(error.message);
       }
-
-      if (error.message === "UNAUTHORIZED") return unauthorized();
-      if (error.message === "FORBIDDEN") return forbidden();
-      if (error.message === "NOT_FOUND") return notFound("Institution not found");
     }
+
+    const authError = mapAuthError(error);
+    if (authError) return authError;
 
     const tenantError = handleTenantError(error);
     if (tenantError) return tenantError;

--- a/src/app/api/tenant/releases/route.ts
+++ b/src/app/api/tenant/releases/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest } from "next/server";
+
+import { logger } from "@/lib/logger";
+import { internalError, invalidRequest, mapAuthError, ok } from "@/lib/api-response";
+import { handleTenantError } from "@/lib/tenant";
+
+import { getTenantReleases } from "@/lib/services/tenant-releases";
+import { listReleasesQuerySchema } from "@/lib/validation/releases";
+
+export async function GET(request: NextRequest) {
+  try {
+    const slug = request.headers.get("x-tenant-slug");
+
+    if (!slug) {
+      return invalidRequest("Missing tenant slug");
+    }
+
+    const url = new URL(request.url);
+    const queryResult = listReleasesQuerySchema.safeParse({
+      page: url.searchParams.get("page") ?? undefined,
+      limit: url.searchParams.get("limit") ?? undefined,
+    });
+    if (!queryResult.success) {
+      return invalidRequest("Invalid query parameters", queryResult.error.issues);
+    }
+
+    const result = await getTenantReleases({
+      slug,
+      page: queryResult.data.page,
+      limit: queryResult.data.limit,
+    });
+    return ok(result);
+  } catch (error) {
+    const authError = mapAuthError(error);
+    if (authError) return authError;
+
+    const tenantError = handleTenantError(error);
+    if (tenantError) return tenantError;
+
+    logger.error("Unexpected GET /tenant/releases error:", error);
+    return internalError();
+  }
+}

--- a/src/components/platform/institutions/detail/institution-users-tab.tsx
+++ b/src/components/platform/institutions/detail/institution-users-tab.tsx
@@ -161,7 +161,7 @@ export default function InstitutionUsersTab({
           readOnly={readOnly}
         />
 
-        <div className="hidden rounded-md border md:block">
+        <div className="hidden md:block">
           <Table>
             <TableHeader>
               <TableRow>

--- a/src/components/platform/layout/auth-nav-panel.tsx
+++ b/src/components/platform/layout/auth-nav-panel.tsx
@@ -3,16 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useParams, usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
-import {
-  Shield,
-  X,
-  LayoutDashboard,
-  Building2,
-  Package,
-  Rocket,
-  Leaf,
-  Warehouse,
-} from "lucide-react";
+import { Shield, X, LayoutDashboard, Building2, Package, Leaf, Warehouse } from "lucide-react";
 
 import { Link } from "@/components/ui/link";
 import { Button } from "@/components/ui/button";
@@ -39,7 +30,6 @@ function getTenantLinks(slug: string): PanelLink[] {
     { label: "Dashboard", href: ROUTES.tenant.dashboard(slug), icon: LayoutDashboard },
     { label: "Organization", href: ROUTES.tenant.organization(slug), icon: Building2 },
     { label: "Shipments", href: ROUTES.tenant.shipments(slug), icon: Package },
-    { label: "Releases", href: ROUTES.tenant.releases(slug), icon: Rocket },
   ];
 }
 

--- a/src/components/platform/layout/tenant/tenant-nav-items.ts
+++ b/src/components/platform/layout/tenant/tenant-nav-items.ts
@@ -1,4 +1,4 @@
-import { Building2, LayoutDashboard, LogOut, type LucideIcon, Package, Rocket } from "lucide-react";
+import { Building2, LayoutDashboard, LogOut, type LucideIcon, Package } from "lucide-react";
 
 export interface NavItem {
   id: string;
@@ -27,12 +27,6 @@ export const TENANT_NAV_ITEMS: readonly NavItem[] = [
     label: "Shipments",
     href: "/shipments",
     icon: Package,
-  },
-  {
-    id: "releases",
-    label: "Releases",
-    href: "/releases",
-    icon: Rocket,
   },
 ];
 

--- a/src/components/shared/date-picker.tsx
+++ b/src/components/shared/date-picker.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { CalendarIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+interface DatePickerProps {
+  /** YYYY-MM-DD string. Empty string means "no date selected". */
+  value: string;
+  onChange: (next: string) => void;
+  /** Disable dates after this YYYY-MM-DD (inclusive bound). */
+  maxDate?: string;
+  /** Disable dates before this YYYY-MM-DD (inclusive bound). */
+  minDate?: string;
+  disabled?: boolean;
+  /** Form id for label association. */
+  id?: string;
+  placeholder?: string;
+  /** Forwarded to the trigger button so the parent form can drive its red state. */
+  "aria-invalid"?: boolean;
+  "aria-describedby"?: string;
+}
+
+const displayFormatter = new Intl.DateTimeFormat("en-US", {
+  weekday: "short",
+  month: "short",
+  day: "2-digit",
+  year: "numeric",
+});
+
+/** Parse a YYYY-MM-DD string into a JS Date in the user's local timezone. */
+function parseDateOnly(value: string): Date | undefined {
+  if (!value) return undefined;
+  const [y, m, d] = value.split("-").map((part) => Number.parseInt(part, 10));
+  if (!y || !m || !d) return undefined;
+  // Reject obvious out-of-range values so JS Date doesn't silently overflow
+  // (e.g. month 13 → next January).
+  if (m < 1 || m > 12 || d < 1 || d > 31) return undefined;
+  const date = new Date(y, m - 1, d);
+  if (Number.isNaN(date.valueOf())) return undefined;
+  // Final sanity check: catch month/day combinations that JS rolled over
+  // (e.g. Feb 30 → Mar 2).
+  if (date.getFullYear() !== y || date.getMonth() !== m - 1 || date.getDate() !== d) {
+    return undefined;
+  }
+  return date;
+}
+
+/** Format a JS Date back into a YYYY-MM-DD string in the user's timezone. */
+function formatDateOnly(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Specialized date-only picker — popover + react-day-picker calendar.
+ *
+ * Stores its value as a YYYY-MM-DD string for easy serialization (the same
+ * shape the rest of the app uses for shipment dates). The display button
+ * shows a friendly weekday/month/day/year string when set.
+ */
+export function DatePicker({
+  value,
+  onChange,
+  maxDate,
+  minDate,
+  disabled,
+  id,
+  placeholder = "Pick a date",
+  "aria-invalid": ariaInvalid,
+  "aria-describedby": ariaDescribedBy,
+}: DatePickerProps) {
+  const [open, setOpen] = useState(false);
+
+  const selected = useMemo(() => parseDateOnly(value), [value]);
+  const minDateObj = useMemo(() => parseDateOnly(minDate ?? ""), [minDate]);
+  const maxDateObj = useMemo(() => parseDateOnly(maxDate ?? ""), [maxDate]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          aria-invalid={ariaInvalid}
+          aria-describedby={ariaDescribedBy}
+          disabled={disabled}
+          className={cn(
+            "h-auto w-full justify-between gap-2 px-3 py-2 text-left font-normal",
+            !selected && "text-muted-foreground",
+          )}
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <CalendarIcon className="text-muted-foreground size-4 shrink-0" aria-hidden="true" />
+            <span className="truncate text-sm">
+              {selected ? displayFormatter.format(selected) : placeholder}
+            </span>
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={selected}
+          onSelect={(date) => {
+            if (date) {
+              onChange(formatDateOnly(date));
+              setOpen(false);
+            }
+          }}
+          disabled={(date) => {
+            if (minDateObj && date < minDateObj) return true;
+            if (maxDateObj && date > maxDateObj) return true;
+            return false;
+          }}
+          // Open on the selected date (or today) when the popover opens.
+          defaultMonth={selected ?? new Date()}
+          captionLayout="dropdown"
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/tenant/releases/release-category-composer.tsx
+++ b/src/components/tenant/releases/release-category-composer.tsx
@@ -47,7 +47,7 @@ const CATEGORY_SHORT: Record<ReleaseCategory, string> = {
 
 export type CategoryQuantities = Record<number, Partial<Record<ReleaseCategory, number>>>;
 
-type ComposerMode = "emergence" | "losses";
+type ComposerMode = "emergence" | "other";
 
 interface ReleaseCategoryComposerProps {
   items: ShipmentItemRow[];
@@ -71,7 +71,7 @@ function sumValues(values: Partial<Record<ReleaseCategory, number>> | undefined)
  * shows two or three inline steppers depending on the active mode:
  *
  * - **Emergence** (default): Good Emergence + Poor Emergence
- * - **Losses**: Diseased + Parasite + No Emergence
+ * - **Other**: Diseased + Parasite + No Emergence
  *
  * A single mode toggle at the top swaps the visible steppers without losing
  * the values entered in the other mode. Good Emergence becomes the release
@@ -79,6 +79,8 @@ function sumValues(values: Partial<Record<ReleaseCategory, number>> | undefined)
  */
 export function ReleaseCategoryComposer({ items, values, onChange }: ReleaseCategoryComposerProps) {
   const [mode, setMode] = useState<ComposerMode>("emergence");
+  // Toggle row pins to the top of the scroll area so the user can switch
+  // categories without scrolling back up on long shipments.
 
   const adapted = useMemo<ComposerSpeciesItem[]>(
     () =>
@@ -106,25 +108,25 @@ export function ReleaseCategoryComposer({ items, values, onChange }: ReleaseCate
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="bg-card sticky top-0 z-20 -mx-6 flex flex-wrap items-center justify-between gap-3 border-b px-6 py-3">
         <ToggleGroup
           type="single"
           value={mode}
           onValueChange={(next) => {
             // Radix returns "" when the user clicks the active item; ignore it
             // so the toggle always reflects a real mode.
-            if (next === "emergence" || next === "losses") setMode(next);
+            if (next === "emergence" || next === "other") setMode(next);
           }}
           variant="outline"
           aria-label="Stepper mode"
         >
           <ToggleGroupItem value="emergence">Emergence</ToggleGroupItem>
-          <ToggleGroupItem value="losses">Losses</ToggleGroupItem>
+          <ToggleGroupItem value="other">Other</ToggleGroupItem>
         </ToggleGroup>
         <p className="text-muted-foreground text-xs">
           {mode === "emergence"
             ? "Set Good and Poor emergence counts. Good releases the butterflies."
-            : "Set Diseased, Parasite, and No-emergence loss counts."}
+            : "Set Diseased, Parasite, and No-emergence counts."}
         </p>
       </div>
 

--- a/src/components/tenant/releases/release-category-composer.tsx
+++ b/src/components/tenant/releases/release-category-composer.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Image from "next/image";
+import { Bug, Minus, Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+  SpeciesSearchToolbar,
+  type SpeciesFilters,
+} from "@/components/shared/species-search-toolbar";
+import { useSpeciesSearch, type SpeciesItem } from "@/hooks/use-species-search";
+import { cn } from "@/lib/utils";
+
+import { computeItemRemaining, type ShipmentItemRow } from "@/components/tenant/shipments/types";
+
+export const RELEASE_CATEGORIES = [
+  "goodEmergence",
+  "poorEmergence",
+  "diseased",
+  "parasite",
+  "nonEmergence",
+] as const;
+
+export type ReleaseCategory = (typeof RELEASE_CATEGORIES)[number];
+
+export const EMERGENCE_CATEGORIES: ReleaseCategory[] = ["goodEmergence", "poorEmergence"];
+export const LOSS_CATEGORIES: ReleaseCategory[] = ["diseased", "parasite", "nonEmergence"];
+
+export const CATEGORY_LABELS: Record<ReleaseCategory, string> = {
+  goodEmergence: "Good emergence",
+  poorEmergence: "Poor emergence",
+  diseased: "Diseased",
+  parasite: "Parasite",
+  nonEmergence: "No emergence",
+};
+
+const CATEGORY_SHORT: Record<ReleaseCategory, string> = {
+  goodEmergence: "Good",
+  poorEmergence: "Poor",
+  diseased: "Diseased",
+  parasite: "Parasite",
+  nonEmergence: "No emerg.",
+};
+
+export type CategoryQuantities = Record<number, Partial<Record<ReleaseCategory, number>>>;
+
+type ComposerMode = "emergence" | "losses";
+
+interface ReleaseCategoryComposerProps {
+  items: ShipmentItemRow[];
+  values: CategoryQuantities;
+  onChange: (itemId: number, category: ReleaseCategory, value: number) => void;
+}
+
+type ComposerSpeciesItem = SpeciesItem & ShipmentItemRow & { baseRemaining: number };
+
+function sumValues(values: Partial<Record<ReleaseCategory, number>> | undefined): number {
+  if (!values) return 0;
+  let total = 0;
+  for (const value of Object.values(values)) {
+    if (typeof value === "number") total += value;
+  }
+  return total;
+}
+
+/**
+ * Multi-category composer used by the Create Release page. Each species row
+ * shows two or three inline steppers depending on the active mode:
+ *
+ * - **Emergence** (default): Good Emergence + Poor Emergence
+ * - **Losses**: Diseased + Parasite + No Emergence
+ *
+ * A single mode toggle at the top swaps the visible steppers without losing
+ * the values entered in the other mode. Good Emergence becomes the release
+ * quantity; the other four buckets are recorded as losses on the shipment.
+ */
+export function ReleaseCategoryComposer({ items, values, onChange }: ReleaseCategoryComposerProps) {
+  const [mode, setMode] = useState<ComposerMode>("emergence");
+
+  const adapted = useMemo<ComposerSpeciesItem[]>(
+    () =>
+      items.map((item) => ({
+        ...item,
+        scientific_name: item.scientificName,
+        common_name: item.commonName,
+        family: "",
+        baseRemaining: computeItemRemaining(item),
+      })),
+    [items],
+  );
+
+  // Only species that still have releasable butterflies are surfaced.
+  const releasable = useMemo(() => adapted.filter((item) => item.baseRemaining > 0), [adapted]);
+
+  // Paginated to keep large shipments (hundreds of species) performant. A
+  // "Load more" button below the list reveals the next batch.
+  const search = useSpeciesSearch<ComposerSpeciesItem>({
+    items: releasable,
+    pageSize: 24,
+  });
+
+  const visibleCategories = mode === "emergence" ? EMERGENCE_CATEGORIES : LOSS_CATEGORIES;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <ToggleGroup
+          type="single"
+          value={mode}
+          onValueChange={(next) => {
+            // Radix returns "" when the user clicks the active item; ignore it
+            // so the toggle always reflects a real mode.
+            if (next === "emergence" || next === "losses") setMode(next);
+          }}
+          variant="outline"
+          aria-label="Stepper mode"
+        >
+          <ToggleGroupItem value="emergence">Emergence</ToggleGroupItem>
+          <ToggleGroupItem value="losses">Losses</ToggleGroupItem>
+        </ToggleGroup>
+        <p className="text-muted-foreground text-xs">
+          {mode === "emergence"
+            ? "Set Good and Poor emergence counts. Good releases the butterflies."
+            : "Set Diseased, Parasite, and No-emergence loss counts."}
+        </p>
+      </div>
+
+      <SpeciesSearchToolbar
+        query={search.query}
+        sortField={search.sortField}
+        sortDirection={search.sortDirection}
+        filters={{ families: search.activeFamilies }}
+        families={search.families}
+        onQueryChange={search.setQuery}
+        onSortChange={search.setSort}
+        onFiltersChange={(filters: SpeciesFilters) => search.setActiveFamilies(filters.families)}
+        onReset={search.resetAll}
+      />
+
+      {search.visibleResults.length === 0 ? (
+        <div className="text-muted-foreground rounded-md border p-6 text-center text-sm">
+          No butterflies are available to release in this shipment.
+        </div>
+      ) : (
+        <ul className="grid gap-3">
+          {search.visibleResults.map((item) => {
+            const itemValues = values[item.id];
+            const allocatedAcrossCategories = sumValues(itemValues);
+            const remainingHeadroom = Math.max(0, item.baseRemaining - allocatedAcrossCategories);
+            const headroomDescribedBy = `release-headroom-${item.id}`;
+
+            return (
+              <li
+                key={item.id}
+                className="bg-card flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center"
+              >
+                <div className="flex min-w-0 flex-1 items-center gap-3">
+                  <div className="bg-muted relative size-20 shrink-0 overflow-hidden rounded">
+                    {item.imageOpen ? (
+                      <Image
+                        src={item.imageOpen}
+                        alt=""
+                        width={160}
+                        height={160}
+                        quality={90}
+                        className="size-full object-cover"
+                      />
+                    ) : (
+                      <Bug className="text-muted-foreground absolute inset-0 m-auto size-7" />
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    <div className="truncate text-base font-medium">{item.commonName}</div>
+                    <div className="text-muted-foreground truncate text-sm italic">
+                      {item.scientificName}
+                    </div>
+                    <CategorySummary
+                      values={itemValues}
+                      remaining={item.baseRemaining}
+                      allocated={allocatedAcrossCategories}
+                    />
+                  </div>
+                </div>
+
+                <div
+                  className={cn(
+                    "grid w-full gap-3 sm:w-auto",
+                    visibleCategories.length === 2 ? "grid-cols-2" : "grid-cols-1 sm:grid-cols-3",
+                  )}
+                >
+                  {visibleCategories.map((category) => {
+                    const ownValue = itemValues?.[category] ?? 0;
+                    // Cap = baseRemaining minus everything allocated elsewhere.
+                    // Adding back ownValue lets the user adjust their own field
+                    // without bumping into a self-imposed ceiling.
+                    const cap = Math.max(
+                      0,
+                      item.baseRemaining - allocatedAcrossCategories + ownValue,
+                    );
+                    return (
+                      <CategoryStepper
+                        key={category}
+                        label={CATEGORY_LABELS[category]}
+                        value={ownValue}
+                        cap={cap}
+                        onChange={(next) => onChange(item.id, category, next)}
+                        ariaLabel={`${CATEGORY_LABELS[category]} for ${item.commonName}`}
+                        ariaDescribedBy={headroomDescribedBy}
+                        disabled={cap === 0 && ownValue === 0}
+                      />
+                    );
+                  })}
+                </div>
+
+                <span id={headroomDescribedBy} className="sr-only">
+                  {remainingHeadroom} remaining for this species
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {search.hasMore && (
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={search.loadMore}
+            aria-label="Load more butterfly species"
+          >
+            Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface CategoryStepperProps {
+  label: string;
+  value: number;
+  cap: number;
+  ariaLabel: string;
+  ariaDescribedBy?: string;
+  onChange: (next: number) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Compact label + −/input/+ control. No Clear / All — the user explicitly
+ * asked to remove those buttons from the release composer.
+ */
+function CategoryStepper({
+  label,
+  value,
+  cap,
+  ariaLabel,
+  ariaDescribedBy,
+  onChange,
+  disabled,
+}: CategoryStepperProps) {
+  const clamp = (next: number) => {
+    if (!Number.isFinite(next)) return 0;
+    return Math.max(0, Math.min(cap, Math.floor(next)));
+  };
+
+  return (
+    <div className="flex flex-col items-stretch gap-1">
+      <span className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+        {label}
+      </span>
+      <div className="inline-flex items-center gap-1">
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          className="size-10 shrink-0"
+          onClick={() => onChange(clamp(value - 1))}
+          disabled={disabled || value === 0}
+          aria-label={`Decrease ${ariaLabel}`}
+        >
+          <Minus className="size-4" />
+        </Button>
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={0}
+          max={cap}
+          step={1}
+          value={value}
+          aria-label={ariaLabel}
+          aria-describedby={ariaDescribedBy}
+          disabled={disabled}
+          className={cn(
+            "h-10 w-16 text-center text-base font-semibold",
+            value > 0 && "border-primary",
+          )}
+          onChange={(event) => onChange(clamp(Number(event.target.value)))}
+        />
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          className="size-10 shrink-0"
+          onClick={() => onChange(clamp(value + 1))}
+          disabled={disabled || value >= cap}
+          aria-label={`Increase ${ariaLabel}`}
+        >
+          <Plus className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+interface CategorySummaryProps {
+  values: Partial<Record<ReleaseCategory, number>> | undefined;
+  remaining: number;
+  allocated: number;
+}
+
+/** Shows the per-species cap and any non-zero allocations from either mode. */
+function CategorySummary({ values, remaining, allocated }: CategorySummaryProps) {
+  const populated = RELEASE_CATEGORIES.filter((category) => (values?.[category] ?? 0) > 0);
+
+  return (
+    <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs">
+      <span>
+        Allocated {allocated} / {remaining}
+      </span>
+      {populated.length > 0 && <span aria-hidden="true">·</span>}
+      {populated.map((category, index) => (
+        <span key={category}>
+          {CATEGORY_SHORT[category]}: {values?.[category] ?? 0}
+          {index < populated.length - 1 && ","}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/tenant/releases/release-composer.tsx
+++ b/src/components/tenant/releases/release-composer.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useMemo } from "react";
+import Image from "next/image";
+import { Bug } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  SpeciesSearchToolbar,
+  type SpeciesFilters,
+} from "@/components/shared/species-search-toolbar";
+import { useSpeciesSearch, type SpeciesItem } from "@/hooks/use-species-search";
+
+import { ReleaseQuantityControls } from "./release-quantity-controls";
+import { computeItemRemaining, type ShipmentItemRow } from "@/components/tenant/shipments/types";
+
+export type ReleaseQuantities = Record<number, number>;
+
+interface ReleaseComposerProps {
+  /** Shipment items as returned by GET /api/tenant/shipments/[id]. */
+  items: ShipmentItemRow[];
+  /** Current release quantity per shipment_item_id. */
+  values: ReleaseQuantities;
+  /** Replace the value for a single item id. */
+  onChange: (itemId: number, quantity: number) => void;
+  /**
+   * In edit mode, an item's `inFlightQuantity` already includes the row being
+   * edited, so the composer must add the current value back to it to compute
+   * a true cap. Pass the current release's quantities here when editing.
+   */
+  alreadyAllocated?: ReleaseQuantities;
+}
+
+type ComposerSpeciesItem = SpeciesItem & ShipmentItemRow & { capForThisRelease: number };
+
+/**
+ * Per-species composer UI used by both Create Release and Edit Release.
+ *
+ * Each row shows common+scientific name, image, the per-species cap, and the
+ * input controls (− / +, All, Clear, numeric input). Wrapped in the shared
+ * search toolbar so a user can find a species fast on long shipments. The
+ * design favors taps over typing per the one-handed release requirement.
+ */
+export function ReleaseComposer({
+  items,
+  values,
+  onChange,
+  alreadyAllocated,
+}: ReleaseComposerProps) {
+  const adapted = useMemo<ComposerSpeciesItem[]>(
+    () =>
+      items.map((item) => {
+        // The DB-returned `inFlightQuantity` already accounts for any current
+        // edit row(s). Add back the current row's allocation so the user can
+        // freely move that value around without bumping into its own cap.
+        const ownAllocation = alreadyAllocated?.[item.id] ?? 0;
+        const capForThisRelease = computeItemRemaining(item) + ownAllocation;
+        return {
+          ...item,
+          scientific_name: item.scientificName,
+          common_name: item.commonName,
+          family: "",
+          capForThisRelease,
+        };
+      }),
+    [items, alreadyAllocated],
+  );
+
+  // Only species that still have releasable butterflies are surfaced.
+  const releasable = useMemo(() => adapted.filter((item) => item.capForThisRelease > 0), [adapted]);
+
+  // Paginated to keep large shipments (hundreds of species) performant. A
+  // "Load more" button below the list reveals the next batch.
+  const search = useSpeciesSearch<ComposerSpeciesItem>({
+    items: releasable,
+    pageSize: 24,
+  });
+
+  return (
+    <div className="space-y-4">
+      <SpeciesSearchToolbar
+        query={search.query}
+        sortField={search.sortField}
+        sortDirection={search.sortDirection}
+        filters={{ families: search.activeFamilies }}
+        families={search.families}
+        onQueryChange={search.setQuery}
+        onSortChange={search.setSort}
+        onFiltersChange={(filters: SpeciesFilters) => search.setActiveFamilies(filters.families)}
+        onReset={search.resetAll}
+      />
+
+      {search.visibleResults.length === 0 ? (
+        <div className="text-muted-foreground rounded-md border p-6 text-center text-sm">
+          No butterflies are available to release in this shipment.
+        </div>
+      ) : (
+        <ul className="grid gap-3">
+          {search.visibleResults.map((item) => {
+            const value = values[item.id] ?? 0;
+            const cap = item.capForThisRelease;
+            return (
+              <li
+                key={item.id}
+                className="bg-card flex flex-wrap items-center gap-4 rounded-lg border p-4"
+              >
+                <div className="flex min-w-0 flex-1 items-center gap-3">
+                  <div className="bg-muted relative size-20 shrink-0 overflow-hidden rounded">
+                    {item.imageOpen ? (
+                      <Image
+                        src={item.imageOpen}
+                        alt=""
+                        width={160}
+                        height={160}
+                        quality={90}
+                        className="size-full object-cover"
+                      />
+                    ) : (
+                      <Bug className="text-muted-foreground absolute inset-0 m-auto size-7" />
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    <div className="truncate text-base font-medium">{item.commonName}</div>
+                    <div className="text-muted-foreground truncate text-sm italic">
+                      {item.scientificName}
+                    </div>
+                    <div className="text-muted-foreground text-xs">Cap: {cap}</div>
+                  </div>
+                </div>
+
+                <ReleaseQuantityControls
+                  value={value}
+                  cap={cap}
+                  ariaLabel={`Release quantity for ${item.commonName}`}
+                  onChange={(next) => onChange(item.id, next)}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {search.hasMore && (
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={search.loadMore}
+            aria-label="Load more butterfly species"
+          >
+            Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/tenant/releases/release-quantity-controls.tsx
+++ b/src/components/tenant/releases/release-quantity-controls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useId } from "react";
 import { Minus, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -13,8 +13,6 @@ interface ReleaseQuantityControlsProps {
   ariaLabel: string;
   onChange: (next: number) => void;
 }
-
-let releaseHintIdCounter = 0;
 
 /**
  * Mouse/tap-friendly quantity controls used by the release composers.
@@ -30,7 +28,8 @@ export function ReleaseQuantityControls({
 }: ReleaseQuantityControlsProps) {
   // Stable id for the visually-hidden cap hint so screen readers can announce
   // the per-row maximum alongside the input via aria-describedby.
-  const [hintId] = useState(() => `release-qty-hint-${++releaseHintIdCounter}`);
+  // useId() yields stable, hydration-safe ids across server and client.
+  const hintId = useId();
   const clamp = (next: number) => {
     if (!Number.isFinite(next)) return 0;
     return Math.max(0, Math.min(cap, Math.floor(next)));

--- a/src/components/tenant/releases/release-quantity-controls.tsx
+++ b/src/components/tenant/releases/release-quantity-controls.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { Minus, Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface ReleaseQuantityControlsProps {
+  value: number;
+  cap: number;
+  ariaLabel: string;
+  onChange: (next: number) => void;
+}
+
+let releaseHintIdCounter = 0;
+
+/**
+ * Mouse/tap-friendly quantity controls used by the release composers.
+ * Includes a Clear button, − / + steppers, a numeric input, and an
+ * "All (N)" button that snaps to the per-row cap. Designed for one-handed
+ * operation per the outline.
+ */
+export function ReleaseQuantityControls({
+  value,
+  cap,
+  ariaLabel,
+  onChange,
+}: ReleaseQuantityControlsProps) {
+  // Stable id for the visually-hidden cap hint so screen readers can announce
+  // the per-row maximum alongside the input via aria-describedby.
+  const [hintId] = useState(() => `release-qty-hint-${++releaseHintIdCounter}`);
+  const clamp = (next: number) => {
+    if (!Number.isFinite(next)) return 0;
+    return Math.max(0, Math.min(cap, Math.floor(next)));
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        onClick={() => onChange(0)}
+        aria-label={`Clear ${ariaLabel}`}
+      >
+        Clear
+      </Button>
+      <div className="inline-flex items-center gap-1">
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          className="size-10"
+          onClick={() => onChange(clamp(value - 1))}
+          aria-label={`Decrease ${ariaLabel}`}
+        >
+          <Minus className="size-4" />
+        </Button>
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={0}
+          max={cap}
+          step={1}
+          value={value}
+          aria-label={ariaLabel}
+          aria-describedby={hintId}
+          className={cn(
+            "h-10 w-20 text-center text-base font-semibold",
+            value > 0 && "border-primary",
+          )}
+          onChange={(event) => onChange(clamp(Number(event.target.value)))}
+        />
+        <span id={hintId} className="sr-only">
+          Maximum {cap}.
+        </span>
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          className="size-10"
+          onClick={() => onChange(clamp(value + 1))}
+          aria-label={`Increase ${ariaLabel}`}
+        >
+          <Plus className="size-4" />
+        </Button>
+      </div>
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        onClick={() => onChange(cap)}
+        aria-label={`Set ${ariaLabel} to maximum`}
+      >
+        All ({cap})
+      </Button>
+    </div>
+  );
+}

--- a/src/components/tenant/shipments/shipment-items-table.tsx
+++ b/src/components/tenant/shipments/shipment-items-table.tsx
@@ -151,7 +151,7 @@ export function ShipmentItemsTable({
         onReset={search.resetAll}
       />
 
-      <div className="overflow-x-auto rounded-md border">
+      <div className="overflow-x-auto">
         <Table>
           <TableHeader>
             <TableRow>

--- a/src/components/tenant/shipments/shipment-items-table.tsx
+++ b/src/components/tenant/shipments/shipment-items-table.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Image from "next/image";
+import { Bug, CheckCircle2, Minus, Plus, Trash2 } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  SpeciesSearchToolbar,
+  type SpeciesFilters,
+} from "@/components/shared/species-search-toolbar";
+import { useSpeciesSearch, type SpeciesItem } from "@/hooks/use-species-search";
+import { cn } from "@/lib/utils";
+
+import { computeItemRemaining, type ShipmentItemRow } from "./types";
+
+type LossField =
+  | "emergedInTransit"
+  | "damagedInTransit"
+  | "diseasedInTransit"
+  | "parasite"
+  | "nonEmergence"
+  | "poorEmergence";
+
+type MetricKey = "numberReceived" | LossField;
+
+interface MetricColumn {
+  key: MetricKey;
+  label: string;
+  short: string;
+}
+
+const METRIC_COLUMNS: MetricColumn[] = [
+  { key: "numberReceived", label: "Number received", short: "Received" },
+  { key: "emergedInTransit", label: "Emerged in transit", short: "Emerged" },
+  { key: "damagedInTransit", label: "Damaged in transit", short: "Damaged" },
+  { key: "diseasedInTransit", label: "Diseased in transit", short: "Diseased" },
+  { key: "parasite", label: "Parasite", short: "Parasite" },
+  { key: "nonEmergence", label: "Non-emergence", short: "Non-emerg" },
+  { key: "poorEmergence", label: "Poor emergence", short: "Poor-emerg" },
+];
+
+/**
+ * Loss columns that must satisfy
+ * `sum(losses) + inFlightQuantity ≤ numberReceived` server-side. Mirroring
+ * that constraint client-side gives better feedback (we clamp at the cap)
+ * and matches the composer's per-species behavior.
+ */
+const LOSS_FIELDS: LossField[] = [
+  "damagedInTransit",
+  "diseasedInTransit",
+  "parasite",
+  "nonEmergence",
+  "poorEmergence",
+];
+
+interface ShipmentItemsTableProps {
+  items: ShipmentItemRow[];
+  /** When true, every metric is editable inline with steppers + a numeric input. */
+  editing: boolean;
+  /** Called when editing mode is on and the user changes a metric. */
+  onMetricChange?: (itemId: number, field: MetricKey, value: number) => void;
+  /** Called when editing mode is on and the user wants to remove an item. */
+  onRemoveItem?: (itemId: number) => void;
+}
+
+/**
+ * Per-column maximum in edit mode.
+ *
+ * - `numberReceived` cannot drop below `inFlightQuantity + sum(losses)` or the
+ *   PATCH API rejects it as an `INVALID_INVENTORY_REDUCTION`.
+ * - Individual loss columns cannot push the total losses past
+ *   `numberReceived - inFlightQuantity`. Clamping at this cap gives the user
+ *   immediate feedback instead of a server error after Save.
+ */
+function metricMaxFor(item: ShipmentItemRow, field: MetricKey): number | undefined {
+  if (field === "numberReceived") return undefined;
+  if (field === "emergedInTransit") return undefined;
+
+  const otherLosses = LOSS_FIELDS.filter((k) => k !== field).reduce((acc, k) => acc + item[k], 0);
+  return Math.max(0, item.numberReceived - item.inFlightQuantity - otherLosses);
+}
+
+function metricMinFor(item: ShipmentItemRow, field: MetricKey): number {
+  if (field !== "numberReceived") return 0;
+  const totalLosses = LOSS_FIELDS.reduce((acc, k) => acc + item[k], 0);
+  return item.inFlightQuantity + totalLosses;
+}
+
+type ItemSpeciesItem = SpeciesItem & ShipmentItemRow;
+
+/**
+ * The items table for the Individual Shipment page. Always wrapped in
+ * `SpeciesSearchToolbar` per the outline. Each row shows both common and
+ * scientific names plus an image. In view mode metrics are read-only; in
+ * editing mode every column gets +/− steppers and a numeric input.
+ */
+export function ShipmentItemsTable({
+  items,
+  editing,
+  onMetricChange,
+  onRemoveItem,
+}: ShipmentItemsTableProps) {
+  const adapted = useMemo<ItemSpeciesItem[]>(
+    () =>
+      items.map((item) => ({
+        ...item,
+        scientific_name: item.scientificName,
+        common_name: item.commonName,
+        // The shipment items query doesn't expose `family`, so default to "—"
+        // which renders harmlessly in the toolbar's family filter.
+        family: "",
+      })),
+    [items],
+  );
+
+  const search = useSpeciesSearch<ItemSpeciesItem>({ items: adapted, pageSize: items.length || 1 });
+
+  const [pendingDelete, setPendingDelete] = useState<ShipmentItemRow | null>(null);
+
+  return (
+    <div className="space-y-4">
+      <SpeciesSearchToolbar
+        query={search.query}
+        sortField={search.sortField}
+        sortDirection={search.sortDirection}
+        filters={{ families: search.activeFamilies }}
+        families={search.families}
+        onQueryChange={search.setQuery}
+        onSortChange={search.setSort}
+        onFiltersChange={(filters: SpeciesFilters) => search.setActiveFamilies(filters.families)}
+        onReset={search.resetAll}
+      />
+
+      <div className="overflow-x-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[280px]">Species</TableHead>
+              {METRIC_COLUMNS.map((col) => (
+                <TableHead key={col.key} className="text-center">
+                  {col.short}
+                </TableHead>
+              ))}
+              <TableHead className="text-center">Released</TableHead>
+              <TableHead className="text-center">Remaining</TableHead>
+              {editing && <TableHead className="w-[60px]" />}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {search.results.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={METRIC_COLUMNS.length + (editing ? 4 : 3)}
+                  className="text-muted-foreground py-6 text-center text-sm"
+                >
+                  No species in this shipment.
+                </TableCell>
+              </TableRow>
+            ) : (
+              search.results.map((item) => (
+                <TableRow key={item.id}>
+                  <TableCell>
+                    <div className="flex items-center gap-3">
+                      <div className="bg-muted relative size-16 shrink-0 overflow-hidden rounded">
+                        {item.imageOpen ? (
+                          <Image
+                            src={item.imageOpen}
+                            alt=""
+                            width={128}
+                            height={128}
+                            quality={90}
+                            className="size-full object-cover"
+                          />
+                        ) : (
+                          <Bug className="text-muted-foreground absolute inset-0 m-auto size-6" />
+                        )}
+                      </div>
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium">{item.commonName}</div>
+                        <div className="text-muted-foreground truncate text-xs italic">
+                          {item.scientificName}
+                        </div>
+                      </div>
+                    </div>
+                  </TableCell>
+                  {METRIC_COLUMNS.map((col) => (
+                    <TableCell key={col.key} className="text-center">
+                      {editing ? (
+                        <MetricStepper
+                          value={item[col.key]}
+                          min={metricMinFor(item, col.key)}
+                          max={metricMaxFor(item, col.key)}
+                          ariaLabel={`${col.label} for ${item.commonName}`}
+                          onChange={(next) => onMetricChange?.(item.id, col.key, next)}
+                        />
+                      ) : (
+                        <span className="text-sm">{item[col.key]}</span>
+                      )}
+                    </TableCell>
+                  ))}
+                  <TableCell className="text-center text-sm">{item.inFlightQuantity}</TableCell>
+                  <TableCell
+                    className={cn(
+                      "text-center text-sm font-medium",
+                      computeItemRemaining(item) === 0 && "text-emerald-600",
+                    )}
+                  >
+                    {computeItemRemaining(item) === 0 ? (
+                      <span className="inline-flex items-center justify-center gap-1">
+                        <CheckCircle2 className="size-4" aria-hidden="true" />
+                        <span>0</span>
+                        <span className="sr-only"> (released)</span>
+                      </span>
+                    ) : (
+                      computeItemRemaining(item)
+                    )}
+                  </TableCell>
+                  {editing && (
+                    <TableCell className="text-right">
+                      {/*
+                        Items that already have released butterflies cannot be
+                        removed — the release would lose its source row.
+                        Disabling here matches the server-side
+                        `CANNOT_DELETE_ITEM_IN_FLIGHT` rejection.
+                      */}
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        aria-label={
+                          item.inFlightQuantity > 0
+                            ? `Cannot remove ${item.commonName}: already released`
+                            : `Remove ${item.commonName}`
+                        }
+                        disabled={item.inFlightQuantity > 0}
+                        title={
+                          item.inFlightQuantity > 0 ? "Cannot remove: already released" : undefined
+                        }
+                        onClick={() => setPendingDelete(item)}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </TableCell>
+                  )}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove this species from the shipment?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingDelete
+                ? `${pendingDelete.commonName} (${pendingDelete.scientificName}) will be removed when you save changes. Items that already have released butterflies cannot be removed.`
+                : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (pendingDelete) onRemoveItem?.(pendingDelete.id);
+                setPendingDelete(null);
+              }}
+            >
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+interface MetricStepperProps {
+  value: number;
+  ariaLabel: string;
+  onChange: (next: number) => void;
+  min?: number;
+  max?: number;
+}
+
+let metricStepperHintId = 0;
+
+function MetricStepper({ value, ariaLabel, onChange, min = 0, max }: MetricStepperProps) {
+  // Stable id for the visually-hidden constraint hint so screen readers can
+  // announce the allowed range alongside the input via aria-describedby.
+  const [hintId] = useState(() => `metric-stepper-hint-${++metricStepperHintId}`);
+
+  const clamp = (next: number) => {
+    const floored = Math.floor(Number.isFinite(next) ? next : min);
+    const lower = Math.max(min, floored);
+    return typeof max === "number" ? Math.min(max, lower) : lower;
+  };
+
+  const hint = typeof max === "number" ? `Allowed range ${min} to ${max}.` : `Minimum ${min}.`;
+
+  return (
+    <div className="inline-flex items-center gap-1">
+      <Button
+        type="button"
+        size="icon"
+        variant="outline"
+        className="size-7"
+        aria-label={`Decrease ${ariaLabel}`}
+        disabled={value <= min}
+        onClick={() => onChange(clamp(value - 1))}
+      >
+        <Minus className="size-3" />
+      </Button>
+      <Input
+        type="number"
+        inputMode="numeric"
+        min={min}
+        max={max}
+        step={1}
+        value={value}
+        aria-label={ariaLabel}
+        aria-describedby={hintId}
+        className="h-7 w-14 px-1 text-center text-sm"
+        onChange={(event) => onChange(clamp(Number(event.target.value)))}
+      />
+      <span id={hintId} className="sr-only">
+        {hint}
+      </span>
+      <Button
+        type="button"
+        size="icon"
+        variant="outline"
+        className="size-7"
+        aria-label={`Increase ${ariaLabel}`}
+        disabled={typeof max === "number" && value >= max}
+        onClick={() => onChange(clamp(value + 1))}
+      >
+        <Plus className="size-3" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/tenant/shipments/shipment-items-table.tsx
+++ b/src/components/tenant/shipments/shipment-items-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import Image from "next/image";
 import { Bug, CheckCircle2, Minus, Plus, Trash2 } from "lucide-react";
 
@@ -128,7 +128,7 @@ export function ShipmentItemsTable({
         common_name: item.commonName,
         // The shipment items query doesn't expose `family`, so default to "—"
         // which renders harmlessly in the toolbar's family filter.
-        family: "",
+        family: "—",
       })),
     [items],
   );
@@ -309,12 +309,11 @@ interface MetricStepperProps {
   max?: number;
 }
 
-let metricStepperHintId = 0;
-
 function MetricStepper({ value, ariaLabel, onChange, min = 0, max }: MetricStepperProps) {
   // Stable id for the visually-hidden constraint hint so screen readers can
   // announce the allowed range alongside the input via aria-describedby.
-  const [hintId] = useState(() => `metric-stepper-hint-${++metricStepperHintId}`);
+  // useId() yields stable, hydration-safe ids across server and client.
+  const hintId = useId();
 
   const clamp = (next: number) => {
     const floored = Math.floor(Number.isFinite(next) ? next : min);

--- a/src/components/tenant/shipments/shipment-status-badge.tsx
+++ b/src/components/tenant/shipments/shipment-status-badge.tsx
@@ -1,0 +1,34 @@
+import { CheckCircle2, Clock } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+
+interface ShipmentStatusBadgeProps {
+  remaining: number;
+  isCompleted: boolean;
+}
+
+/**
+ * Compact status badge used in shipment lists. Shows "Completed" when no
+ * butterflies remain to release, otherwise "In progress" with the remaining
+ * count.
+ */
+export function ShipmentStatusBadge({ remaining, isCompleted }: ShipmentStatusBadgeProps) {
+  if (isCompleted) {
+    return (
+      <Badge
+        variant="secondary"
+        className="bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200"
+      >
+        <CheckCircle2 aria-hidden="true" />
+        Completed
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="outline">
+      <Clock aria-hidden="true" />
+      {remaining} remaining
+    </Badge>
+  );
+}

--- a/src/components/tenant/shipments/shipment-status-badge.tsx
+++ b/src/components/tenant/shipments/shipment-status-badge.tsx
@@ -9,7 +9,7 @@ interface ShipmentStatusBadgeProps {
 
 /**
  * Compact status badge used in shipment lists. Shows "Completed" when no
- * butterflies remain to release, otherwise "In progress" with the remaining
+ * butterflies remain to release, otherwise the remaining
  * count.
  */
 export function ShipmentStatusBadge({ remaining, isCompleted }: ShipmentStatusBadgeProps) {

--- a/src/components/tenant/shipments/species-picker-dialog.tsx
+++ b/src/components/tenant/shipments/species-picker-dialog.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import Image from "next/image";
+import { Bug, Check } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  SpeciesSearchToolbar,
+  type SpeciesFilters,
+} from "@/components/shared/species-search-toolbar";
+import { useSpeciesSearch, type SpeciesItem } from "@/hooks/use-species-search";
+import { cn } from "@/lib/utils";
+
+import type { SpeciesPickerOption } from "./types";
+
+type DialogSpeciesItem = SpeciesItem & SpeciesPickerOption;
+
+interface SpeciesPickerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  species: SpeciesPickerOption[];
+  /** IDs already added to the parent — they remain visible but un-pickable. */
+  excludeIds?: number[];
+  /** Called with the newly chosen species when the user confirms. */
+  onConfirm: (chosen: SpeciesPickerOption[]) => void;
+  title?: string;
+  description?: string;
+  confirmLabel?: string;
+}
+
+/**
+ * Multi-select species picker. Wraps the existing `useSpeciesSearch` +
+ * `SpeciesSearchToolbar` infrastructure inside a dialog with checkbox rows
+ * showing both common and scientific names plus a thumbnail image.
+ */
+export function SpeciesPickerDialog({
+  open,
+  onOpenChange,
+  species,
+  excludeIds,
+  onConfirm,
+  title = "Add butterflies",
+  description = "Search the catalog and select one or more species to add.",
+  confirmLabel = "Add selected",
+}: SpeciesPickerDialogProps) {
+  const excludeSet = useMemo(() => new Set(excludeIds ?? []), [excludeIds]);
+
+  // Adapt picker options to the SpeciesItem shape required by useSpeciesSearch.
+  const items = useMemo<DialogSpeciesItem[]>(
+    () =>
+      species.map((s) => ({
+        ...s,
+        scientific_name: s.scientificName,
+        common_name: s.commonName,
+        family: s.family,
+      })),
+    [species],
+  );
+
+  const search = useSpeciesSearch<DialogSpeciesItem>({ items, pageSize: 24 });
+
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+  // Reset selection + search state whenever the dialog opens fresh. Doing this
+  // in the open-change handler (rather than an effect) avoids set-state-in-
+  // effect cascades and keeps the reset coupled to the actual user action.
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (next) {
+        setSelectedIds(new Set());
+        search.resetAll();
+      }
+      onOpenChange(next);
+    },
+    [onOpenChange, search],
+  );
+
+  const toggle = (id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleConfirm = () => {
+    const chosen = species.filter((s) => selectedIds.has(s.id));
+    onConfirm(chosen);
+    onOpenChange(false);
+  };
+
+  // Roving focus across the option buttons. WCAG listbox pattern requires
+  // Arrow Up/Down (and Home/End) to move focus between options without
+  // tabbing past the list. Refs are keyed by option id (not index) so removed
+  // rows clean themselves up via the callback ref, and the keyboard handler
+  // re-derives the current order from `visibleResults` at event time.
+  const optionRefs = useRef(new Map<number, HTMLButtonElement>());
+
+  const handleListboxKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const order = search.visibleResults
+      .map((opt) => optionRefs.current.get(opt.id))
+      .filter((node): node is HTMLButtonElement => node !== undefined);
+    if (order.length === 0) return;
+    const current = order.findIndex((node) => node === document.activeElement);
+    const focusAt = (index: number) => {
+      const clamped = Math.max(0, Math.min(index, order.length - 1));
+      order[clamped]?.focus();
+    };
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        focusAt(current < 0 ? 0 : current + 1);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        focusAt(current < 0 ? order.length - 1 : current - 1);
+        break;
+      case "Home":
+        event.preventDefault();
+        focusAt(0);
+        break;
+      case "End":
+        event.preventDefault();
+        focusAt(order.length - 1);
+        break;
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="flex max-h-[90vh] flex-col gap-4 sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <SpeciesSearchToolbar
+          query={search.query}
+          sortField={search.sortField}
+          sortDirection={search.sortDirection}
+          filters={{ families: search.activeFamilies }}
+          families={search.families}
+          onQueryChange={search.setQuery}
+          onSortChange={search.setSort}
+          onFiltersChange={(filters: SpeciesFilters) => search.setActiveFamilies(filters.families)}
+          onReset={search.resetAll}
+        />
+
+        <div
+          role="listbox"
+          aria-multiselectable="true"
+          aria-label="Butterfly species"
+          className="min-h-0 flex-1 overflow-y-auto rounded-md border"
+          onKeyDown={handleListboxKeyDown}
+        >
+          {search.visibleResults.length === 0 ? (
+            <p className="text-muted-foreground p-6 text-center text-sm">No species match.</p>
+          ) : (
+            <ul className="divide-y">
+              {search.visibleResults.map((option) => {
+                const isExcluded = excludeSet.has(option.id);
+                const isSelected = selectedIds.has(option.id);
+                return (
+                  <li key={option.id}>
+                    <button
+                      ref={(node) => {
+                        if (node) optionRefs.current.set(option.id, node);
+                        else optionRefs.current.delete(option.id);
+                      }}
+                      type="button"
+                      role="option"
+                      aria-selected={isSelected}
+                      aria-disabled={isExcluded}
+                      disabled={isExcluded}
+                      onClick={() => toggle(option.id)}
+                      className={cn(
+                        "flex w-full items-center gap-3 px-3 py-2 text-left transition-colors",
+                        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset",
+                        isExcluded
+                          ? "text-muted-foreground cursor-not-allowed opacity-60"
+                          : isSelected
+                            ? "bg-primary/10 hover:bg-primary/15"
+                            : "hover:bg-accent",
+                      )}
+                    >
+                      {/*
+                        Visual checkbox stand-in. Cannot use the real Radix
+                        <Checkbox> here because it renders as a <button> and
+                        HTML disallows nested buttons (the row itself is the
+                        button). The row's `aria-selected` already conveys
+                        state to assistive tech, so this div is hidden.
+                      */}
+                      <div
+                        aria-hidden="true"
+                        className={cn(
+                          "border-input flex size-4 shrink-0 items-center justify-center rounded-[4px] border shadow-xs transition-colors",
+                          (isSelected || isExcluded) &&
+                            "bg-primary border-primary text-primary-foreground",
+                        )}
+                      >
+                        {(isSelected || isExcluded) && <Check className="size-3" />}
+                      </div>
+                      <div className="bg-muted relative size-16 shrink-0 overflow-hidden rounded">
+                        {option.imgWingsOpen ? (
+                          <Image
+                            src={option.imgWingsOpen}
+                            alt=""
+                            width={128}
+                            height={128}
+                            quality={90}
+                            className="size-full object-cover"
+                          />
+                        ) : (
+                          <Bug className="text-muted-foreground absolute inset-0 m-auto size-6" />
+                        )}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div
+                          className={cn(
+                            "truncate text-sm font-medium",
+                            isSelected && "text-primary",
+                          )}
+                        >
+                          {option.commonName}
+                        </div>
+                        <div className="text-muted-foreground truncate text-xs italic">
+                          {option.scientificName}
+                        </div>
+                      </div>
+                      {isExcluded && (
+                        <span className="text-muted-foreground text-xs">Already added</span>
+                      )}
+                    </button>
+                  </li>
+                );
+              })}
+
+              {search.hasMore && (
+                <li className="bg-muted/30 flex justify-center p-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={search.loadMore}
+                    aria-label="Load more butterfly species"
+                    className="text-muted-foreground text-xs"
+                  >
+                    Load more
+                  </Button>
+                </li>
+              )}
+            </ul>
+          )}
+        </div>
+
+        <DialogFooter className="items-center sm:justify-between">
+          {/*
+            Visual hierarchy: a small status line on the left, a tertiary
+            ghost Cancel that doesn't compete with the primary action, and
+            the primary Add selected on the right.
+          */}
+          <span className="text-muted-foreground text-xs">
+            {selectedIds.size === 0
+              ? "Select at least one species"
+              : `${selectedIds.size} selected`}
+          </span>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="button" disabled={selectedIds.size === 0} onClick={handleConfirm}>
+              {confirmLabel}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/tenant/shipments/supplier-select.tsx
+++ b/src/components/tenant/shipments/supplier-select.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, ChevronsUpDown, Warehouse } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+export type SupplierOption = {
+  id: number;
+  code: string;
+  name: string;
+  isActive: boolean;
+};
+
+interface SupplierSelectProps {
+  /** Supplier list, typically loaded from /api/tenant/suppliers. */
+  suppliers: SupplierOption[];
+  /** Currently selected supplier code (matches `SupplierOption.code`). */
+  value: string;
+  onChange: (code: string) => void;
+  disabled?: boolean;
+  /** Field id for label association. */
+  id?: string;
+  placeholder?: string;
+  /** Forwarded to the trigger button so the parent form can drive its red state. */
+  "aria-invalid"?: boolean;
+  "aria-describedby"?: string;
+}
+
+/**
+ * Specialized supplier picker — popover + Command palette with search across
+ * code and name. Shows active suppliers first, then inactive ones grouped
+ * separately with a muted style. The trigger button doubles as the form
+ * control and renders the picked supplier's code + name.
+ */
+export function SupplierSelect({
+  suppliers,
+  value,
+  onChange,
+  disabled,
+  id,
+  placeholder = "Select a supplier",
+  "aria-invalid": ariaInvalid,
+  "aria-describedby": ariaDescribedBy,
+}: SupplierSelectProps) {
+  const [open, setOpen] = useState(false);
+
+  const { active, inactive } = useMemo(() => {
+    const a: SupplierOption[] = [];
+    const i: SupplierOption[] = [];
+    for (const supplier of suppliers) {
+      (supplier.isActive ? a : i).push(supplier);
+    }
+    a.sort((x, y) => x.code.localeCompare(y.code));
+    i.sort((x, y) => x.code.localeCompare(y.code));
+    return { active: a, inactive: i };
+  }, [suppliers]);
+
+  const selected = useMemo(
+    () => suppliers.find((supplier) => supplier.code === value) ?? null,
+    [suppliers, value],
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-invalid={ariaInvalid}
+          aria-describedby={ariaDescribedBy}
+          disabled={disabled}
+          className={cn(
+            "h-auto w-full justify-between gap-2 px-3 py-2 text-left font-normal",
+            !selected && "text-muted-foreground",
+          )}
+        >
+          {selected ? (
+            <span className="flex min-w-0 items-center gap-2">
+              <Warehouse className="text-muted-foreground size-4 shrink-0" aria-hidden="true" />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium">{selected.code}</span>
+                <span className="text-muted-foreground block truncate text-xs">
+                  {selected.name}
+                  {!selected.isActive && " · inactive"}
+                </span>
+              </span>
+            </span>
+          ) : (
+            <span className="flex items-center gap-2">
+              <Warehouse className="size-4 shrink-0" aria-hidden="true" />
+              {placeholder}
+            </span>
+          )}
+          <ChevronsUpDown className="text-muted-foreground size-4 shrink-0" aria-hidden="true" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-(--radix-popover-trigger-width) min-w-72 p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search by code or name…" />
+          <CommandList>
+            <CommandEmpty>No suppliers match.</CommandEmpty>
+            {active.length > 0 && (
+              <CommandGroup heading="Active">
+                {active.map((supplier) => (
+                  <SupplierCommandItem
+                    key={supplier.id}
+                    supplier={supplier}
+                    selected={selected?.code === supplier.code}
+                    onSelect={() => {
+                      onChange(supplier.code);
+                      setOpen(false);
+                    }}
+                  />
+                ))}
+              </CommandGroup>
+            )}
+            {inactive.length > 0 && (
+              <CommandGroup heading="Inactive">
+                {inactive.map((supplier) => (
+                  <SupplierCommandItem
+                    key={supplier.id}
+                    supplier={supplier}
+                    selected={selected?.code === supplier.code}
+                    muted
+                    onSelect={() => {
+                      onChange(supplier.code);
+                      setOpen(false);
+                    }}
+                  />
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+interface SupplierCommandItemProps {
+  supplier: SupplierOption;
+  selected: boolean;
+  muted?: boolean;
+  onSelect: () => void;
+}
+
+function SupplierCommandItem({ supplier, selected, muted, onSelect }: SupplierCommandItemProps) {
+  return (
+    <CommandItem
+      // Command's filter matches against the `value` prop, so combine the
+      // searchable fields here.
+      value={`${supplier.code} ${supplier.name}`}
+      onSelect={onSelect}
+      className={cn("gap-2", muted && "opacity-70")}
+    >
+      <Check
+        className={cn("size-4 shrink-0", selected ? "opacity-100" : "opacity-0")}
+        aria-hidden="true"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium">{supplier.code}</div>
+        <div className="text-muted-foreground truncate text-xs">{supplier.name}</div>
+      </div>
+    </CommandItem>
+  );
+}

--- a/src/components/tenant/shipments/types.ts
+++ b/src/components/tenant/shipments/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared shapes for the tenant shipment + release UIs.
+ *
+ * Field names match what the tenant API actually returns (camelCase) so
+ * components don't have to translate at the boundary.
+ */
+
+export type SpeciesPickerOption = {
+  id: number;
+  scientificName: string;
+  commonName: string;
+  family: string;
+  imgWingsOpen: string | null;
+};
+
+export type ShipmentListRow = {
+  id: number;
+  supplierCode: string;
+  shipmentDate: string;
+  arrivalDate: string;
+  createdAt: string;
+  remaining: number;
+  isCompleted: boolean;
+};
+
+export type ShipmentItemRow = {
+  id: number;
+  butterflySpeciesId: number;
+  scientificName: string;
+  commonName: string;
+  imageOpen: string | null;
+  imageClosed: string | null;
+  numberReceived: number;
+  emergedInTransit: number;
+  damagedInTransit: number;
+  diseasedInTransit: number;
+  parasite: number;
+  nonEmergence: number;
+  poorEmergence: number;
+  inFlightQuantity: number;
+};
+
+export type ShipmentDetailHeader = {
+  id: number;
+  supplierCode: string;
+  shipmentDate: string;
+  arrivalDate: string;
+  createdAt: string;
+};
+
+export type ShipmentDetailResponse = {
+  shipment: ShipmentDetailHeader;
+  items: ShipmentItemRow[];
+};
+
+export type ReleaseHistoryRow = {
+  id: number;
+  shipmentId: number;
+  supplierCode: string;
+  shipmentDate: string;
+  releaseDate: string;
+  releasedBy: string;
+  totalReleased: number;
+};
+
+export type ReleaseEventDetail = {
+  event: {
+    id: number;
+    shipmentId: number;
+    releaseDate: string;
+    releasedBy: string;
+  };
+  items: { id: number; shipmentItemId: number; quantity: number }[];
+};
+
+/**
+ * Compute the remaining (releasable) butterflies for a single shipment item:
+ * received minus all loss columns minus any quantity already in_flight.
+ * Mirrors `calculateRemaining()` in `src/lib/queries/releases.ts`.
+ */
+export function computeItemRemaining(item: ShipmentItemRow): number {
+  const grossAvailable =
+    item.numberReceived -
+    item.damagedInTransit -
+    item.diseasedInTransit -
+    item.parasite -
+    item.nonEmergence -
+    item.poorEmergence;
+
+  return Math.max(0, grossAvailable - item.inFlightQuantity);
+}

--- a/src/lib/__test__/build-shipment-completion-map.test.ts
+++ b/src/lib/__test__/build-shipment-completion-map.test.ts
@@ -1,0 +1,111 @@
+import { buildShipmentCompletionMap } from "@/lib/queries/shipments";
+
+describe("buildShipmentCompletionMap", () => {
+  it("returns remaining = grossAvailable when nothing is released", () => {
+    const map = buildShipmentCompletionMap(
+      [{ shipmentId: 1, itemCount: 2, grossAvailable: 30 }],
+      [],
+    );
+
+    expect(map.get(1)).toEqual({ remaining: 30, isCompleted: false });
+  });
+
+  it("subtracts released totals from grossAvailable", () => {
+    const map = buildShipmentCompletionMap(
+      [{ shipmentId: 1, itemCount: 2, grossAvailable: 30 }],
+      [{ shipmentId: 1, released: 12 }],
+    );
+
+    expect(map.get(1)).toEqual({ remaining: 18, isCompleted: false });
+  });
+
+  it("flags isCompleted when remaining hits zero AND items exist", () => {
+    const map = buildShipmentCompletionMap(
+      [{ shipmentId: 1, itemCount: 2, grossAvailable: 20 }],
+      [{ shipmentId: 1, released: 20 }],
+    );
+
+    expect(map.get(1)).toEqual({ remaining: 0, isCompleted: true });
+  });
+
+  it("clamps remaining at zero when released exceeds grossAvailable", () => {
+    // Shouldn't happen in practice, but the helper must never report a
+    // negative remaining count.
+    const map = buildShipmentCompletionMap(
+      [{ shipmentId: 1, itemCount: 2, grossAvailable: 10 }],
+      [{ shipmentId: 1, released: 25 }],
+    );
+
+    expect(map.get(1)).toEqual({ remaining: 0, isCompleted: true });
+  });
+
+  it("treats string numerics from PG as numbers", () => {
+    // node-postgres can serialize bigint sums as strings if the ::int cast is
+    // ever forgotten. The helper must coerce defensively.
+    const map = buildShipmentCompletionMap(
+      [{ shipmentId: 1, itemCount: 1, grossAvailable: "15" }],
+      [{ shipmentId: 1, released: "5" }],
+    );
+
+    expect(map.get(1)).toEqual({ remaining: 10, isCompleted: false });
+  });
+
+  it("defaults shipments with no items to in-progress when shipmentIds is provided", () => {
+    // Empty shipments are surfaced as "still has work to do" so users can fill
+    // them in instead of seeing them as completed shells.
+    const map = buildShipmentCompletionMap([], [], [1, 2, 3]);
+
+    expect(map.get(1)).toEqual({ remaining: 0, isCompleted: false });
+    expect(map.get(2)).toEqual({ remaining: 0, isCompleted: false });
+    expect(map.get(3)).toEqual({ remaining: 0, isCompleted: false });
+  });
+
+  it("does not synthesize entries for missing shipments when shipmentIds is omitted", () => {
+    const map = buildShipmentCompletionMap(
+      [{ shipmentId: 1, itemCount: 1, grossAvailable: 10 }],
+      [],
+    );
+
+    expect(map.has(1)).toBe(true);
+    expect(map.has(2)).toBe(false);
+  });
+
+  it("handles multiple shipments independently", () => {
+    const map = buildShipmentCompletionMap(
+      [
+        { shipmentId: 1, itemCount: 2, grossAvailable: 30 },
+        { shipmentId: 2, itemCount: 1, grossAvailable: 15 },
+      ],
+      [
+        { shipmentId: 1, released: 30 },
+        { shipmentId: 2, released: 5 },
+      ],
+    );
+
+    expect(map.get(1)).toEqual({ remaining: 0, isCompleted: true });
+    expect(map.get(2)).toEqual({ remaining: 10, isCompleted: false });
+  });
+
+  it("does NOT mark itemCount=0 shipments as completed even when remaining=0", () => {
+    // Guards against the bug where empty shipments could otherwise look "done"
+    // because their gross available is also zero.
+    const map = buildShipmentCompletionMap(
+      [{ shipmentId: 1, itemCount: 0, grossAvailable: 0 }],
+      [],
+    );
+
+    expect(map.get(1)).toEqual({ remaining: 0, isCompleted: false });
+  });
+
+  it("ignores released_rows for shipments not present in itemRows when shipmentIds is omitted", () => {
+    // A released row without a matching item row would be a data integrity
+    // bug, but the helper should not crash or create a bogus entry for it.
+    const map = buildShipmentCompletionMap(
+      [{ shipmentId: 1, itemCount: 1, grossAvailable: 10 }],
+      [{ shipmentId: 99, released: 5 }],
+    );
+
+    expect(map.get(1)).toEqual({ remaining: 10, isCompleted: false });
+    expect(map.has(99)).toBe(false);
+  });
+});

--- a/src/lib/__test__/validation-releases.test.ts
+++ b/src/lib/__test__/validation-releases.test.ts
@@ -1,0 +1,282 @@
+import {
+  createInFlightBodySchema,
+  createReleaseFromShipmentSchema,
+  listReleasesQuerySchema,
+  updateInFlightQuantitySchema,
+  updateReleaseEventItemsSchema,
+} from "@/lib/validation/releases";
+
+describe("createReleaseFromShipmentSchema", () => {
+  const validBase = () => ({
+    released_at: "2026-03-13T12:00:00.000Z",
+    items: [
+      { shipment_item_id: 1, quantity: 5 },
+      { shipment_item_id: 2, quantity: 3 },
+    ],
+  });
+
+  it("accepts a minimal valid payload (no loss_updates)", () => {
+    const result = createReleaseFromShipmentSchema.safeParse(validBase());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // loss_updates defaults to an empty array so downstream code never has
+      // to null-check it.
+      expect(result.data.loss_updates).toEqual([]);
+    }
+  });
+
+  it("accepts a payload with loss_updates", () => {
+    const result = createReleaseFromShipmentSchema.safeParse({
+      ...validBase(),
+      loss_updates: [
+        { shipment_item_id: 1, damaged_in_transit: 2, parasite: 1 },
+        { shipment_item_id: 2, non_emergence: 4 },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty items array", () => {
+    const result = createReleaseFromShipmentSchema.safeParse({ items: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicate shipment_item_id values in items", () => {
+    const result = createReleaseFromShipmentSchema.safeParse({
+      items: [
+        { shipment_item_id: 1, quantity: 5 },
+        { shipment_item_id: 1, quantity: 2 },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.path[0] === "items")).toBe(true);
+    }
+  });
+
+  it("rejects duplicate shipment_item_id values in loss_updates", () => {
+    const result = createReleaseFromShipmentSchema.safeParse({
+      ...validBase(),
+      loss_updates: [
+        { shipment_item_id: 1, damaged_in_transit: 1 },
+        { shipment_item_id: 1, parasite: 2 },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.path[0] === "loss_updates")).toBe(true);
+    }
+  });
+
+  it("rejects non-positive quantities", () => {
+    expect(
+      createReleaseFromShipmentSchema.safeParse({
+        items: [{ shipment_item_id: 1, quantity: 0 }],
+      }).success,
+    ).toBe(false);
+    expect(
+      createReleaseFromShipmentSchema.safeParse({
+        items: [{ shipment_item_id: 1, quantity: -3 }],
+      }).success,
+    ).toBe(false);
+    expect(
+      createReleaseFromShipmentSchema.safeParse({
+        items: [{ shipment_item_id: 1, quantity: 1.5 }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects non-positive shipment_item_id", () => {
+    expect(
+      createReleaseFromShipmentSchema.safeParse({
+        items: [{ shipment_item_id: 0, quantity: 1 }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects negative loss_updates values", () => {
+    const result = createReleaseFromShipmentSchema.safeParse({
+      ...validBase(),
+      loss_updates: [{ shipment_item_id: 1, damaged_in_transit: -1 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("allows a loss_updates row with only the shipment_item_id (no-op row)", () => {
+    // The schema permits this; the service applies no UPDATE for empty rows.
+    // Keeping this permissive avoids forcing the client to filter empty rows
+    // before sending.
+    const result = createReleaseFromShipmentSchema.safeParse({
+      ...validBase(),
+      loss_updates: [{ shipment_item_id: 1 }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown top-level keys (strict mode)", () => {
+    const result = createReleaseFromShipmentSchema.safeParse({
+      ...validBase(),
+      sneaky: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown keys inside loss_updates rows (strict mode)", () => {
+    const result = createReleaseFromShipmentSchema.safeParse({
+      ...validBase(),
+      loss_updates: [{ shipment_item_id: 1, mystery_column: 2 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("coerces stringified numbers in items and loss_updates", () => {
+    const result = createReleaseFromShipmentSchema.safeParse({
+      items: [{ shipment_item_id: "1", quantity: "5" }],
+      loss_updates: [{ shipment_item_id: "1", parasite: "2" }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.items[0].quantity).toBe(5);
+      expect(result.data.loss_updates?.[0]?.parasite).toBe(2);
+    }
+  });
+
+  it("coerces released_at to a Date when provided", () => {
+    const result = createReleaseFromShipmentSchema.safeParse(validBase());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.released_at).toBeInstanceOf(Date);
+    }
+  });
+
+  it("rejects unparseable released_at strings", () => {
+    const result = createReleaseFromShipmentSchema.safeParse({
+      ...validBase(),
+      released_at: "not-a-date",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-numeric strings inside coerced quantity fields", () => {
+    const result = createReleaseFromShipmentSchema.safeParse({
+      released_at: "2026-03-13T12:00:00.000Z",
+      items: [{ shipment_item_id: "abc", quantity: 1 }],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateReleaseEventItemsSchema", () => {
+  it("accepts a valid payload", () => {
+    const result = updateReleaseEventItemsSchema.safeParse({
+      items: [
+        { shipment_item_id: 1, quantity: 9 },
+        { shipment_item_id: 2, quantity: 4 },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty items array", () => {
+    expect(updateReleaseEventItemsSchema.safeParse({ items: [] }).success).toBe(false);
+  });
+
+  it("rejects duplicate shipment_item_id values", () => {
+    const result = updateReleaseEventItemsSchema.safeParse({
+      items: [
+        { shipment_item_id: 1, quantity: 1 },
+        { shipment_item_id: 1, quantity: 2 },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown top-level keys (strict mode)", () => {
+    const result = updateReleaseEventItemsSchema.safeParse({
+      items: [{ shipment_item_id: 1, quantity: 1 }],
+      extra: true,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("createInFlightBodySchema", () => {
+  it("accepts a valid payload", () => {
+    expect(createInFlightBodySchema.safeParse({ shipment_item_id: 1, quantity: 3 }).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects zero or negative quantities", () => {
+    expect(createInFlightBodySchema.safeParse({ shipment_item_id: 1, quantity: 0 }).success).toBe(
+      false,
+    );
+    expect(createInFlightBodySchema.safeParse({ shipment_item_id: 1, quantity: -1 }).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects unknown keys", () => {
+    expect(
+      createInFlightBodySchema.safeParse({ shipment_item_id: 1, quantity: 1, extra: 1 }).success,
+    ).toBe(false);
+  });
+});
+
+describe("updateInFlightQuantitySchema", () => {
+  it("accepts positive integer quantities", () => {
+    expect(updateInFlightQuantitySchema.safeParse({ quantity: 1 }).success).toBe(true);
+    expect(updateInFlightQuantitySchema.safeParse({ quantity: 100 }).success).toBe(true);
+  });
+
+  it("rejects zero, negative, and fractional quantities", () => {
+    expect(updateInFlightQuantitySchema.safeParse({ quantity: 0 }).success).toBe(false);
+    expect(updateInFlightQuantitySchema.safeParse({ quantity: -2 }).success).toBe(false);
+    expect(updateInFlightQuantitySchema.safeParse({ quantity: 1.5 }).success).toBe(false);
+  });
+});
+
+describe("listReleasesQuerySchema", () => {
+  it("defaults page=1 and limit=50 when no params provided", () => {
+    const result = listReleasesQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ page: 1, limit: 50 });
+    }
+  });
+
+  it("coerces stringified numbers", () => {
+    const result = listReleasesQuerySchema.safeParse({ page: "3", limit: "25" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ page: 3, limit: 25 });
+    }
+  });
+
+  it("rejects non-numeric strings", () => {
+    expect(listReleasesQuerySchema.safeParse({ page: "abc" }).success).toBe(false);
+    expect(listReleasesQuerySchema.safeParse({ limit: "xx" }).success).toBe(false);
+  });
+
+  it("rejects zero or negative page/limit", () => {
+    expect(listReleasesQuerySchema.safeParse({ page: 0 }).success).toBe(false);
+    expect(listReleasesQuerySchema.safeParse({ page: -1 }).success).toBe(false);
+    expect(listReleasesQuerySchema.safeParse({ limit: 0 }).success).toBe(false);
+    expect(listReleasesQuerySchema.safeParse({ limit: -10 }).success).toBe(false);
+  });
+
+  it("rejects fractional page/limit", () => {
+    expect(listReleasesQuerySchema.safeParse({ page: 1.5 }).success).toBe(false);
+    expect(listReleasesQuerySchema.safeParse({ limit: 50.5 }).success).toBe(false);
+  });
+
+  it("caps limit at 200", () => {
+    expect(listReleasesQuerySchema.safeParse({ limit: 200 }).success).toBe(true);
+    expect(listReleasesQuerySchema.safeParse({ limit: 201 }).success).toBe(false);
+    expect(listReleasesQuerySchema.safeParse({ limit: 9999 }).success).toBe(false);
+  });
+
+  it("rejects unknown keys (strict mode)", () => {
+    expect(listReleasesQuerySchema.safeParse({ page: 1, sort: "asc" }).success).toBe(false);
+  });
+});

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -85,3 +85,19 @@ export function internalError(message = "Internal server error") {
 export function ok<T>(data: T, status = 200) {
   return NextResponse.json(data, { status });
 }
+
+/**
+ * Map the sentinel "UNAUTHORIZED" / "FORBIDDEN" / "NOT_FOUND" error messages
+ * thrown by service-layer helpers to standard HTTP error responses. Returns
+ * `null` when the error is not one of the known sentinels so callers can fall
+ * through to other handlers (e.g. `handleTenantError`).
+ */
+export function mapAuthError(error: unknown) {
+  if (!(error instanceof Error)) return null;
+
+  if (error.message === "UNAUTHORIZED") return unauthorized();
+  if (error.message === "FORBIDDEN") return forbidden();
+  if (error.message === "NOT_FOUND") return notFound("Institution not found");
+
+  return null;
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -11,7 +11,6 @@ export type Role = "SUPERUSER" | "ADMIN" | "EMPLOYEE" | string;
 export type Permission =
   | "VIEW_DASHBOARD"
   | "VIEW_SHIPMENTS"
-  | "VIEW_RELEASES"
   | "CREATE_RELEASE"
   | "CREATE_SHIPMENT"
   | "VIEW_INVENTORY"
@@ -32,7 +31,6 @@ export const PERMISSION_MATRIX: Record<Role, Permission[]> = {
   SUPERUSER: [
     "VIEW_DASHBOARD",
     "VIEW_SHIPMENTS",
-    "VIEW_RELEASES",
     "CREATE_RELEASE",
     "CREATE_SHIPMENT",
     "VIEW_INVENTORY",
@@ -52,7 +50,6 @@ export const PERMISSION_MATRIX: Record<Role, Permission[]> = {
   ADMIN: [
     "VIEW_DASHBOARD",
     "VIEW_SHIPMENTS",
-    "VIEW_RELEASES",
     "CREATE_RELEASE",
     "CREATE_SHIPMENT",
     "VIEW_INVENTORY",
@@ -68,7 +65,6 @@ export const PERMISSION_MATRIX: Record<Role, Permission[]> = {
   EMPLOYEE: [
     "VIEW_DASHBOARD",
     "VIEW_SHIPMENTS",
-    "VIEW_RELEASES",
     "VIEW_ORGANIZATION",
     "CREATE_RELEASE",
     "CREATE_SHIPMENT",

--- a/src/lib/queries/releases.ts
+++ b/src/lib/queries/releases.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
+import { and, count, desc, eq, inArray, ne, sql } from "drizzle-orm";
 
 import { db } from "@/lib/db";
 import { in_flight, release_events, shipment_items, shipments } from "@/lib/schema";
@@ -20,6 +20,8 @@ export const RELEASE_ERRORS = {
   INVALID_QUANTITY: "Quantity must be a positive integer",
   SHIPMENT_ITEM_RELEASE_MISMATCH: "Shipment item does not belong to the release shipment",
   QUANTITY_EXCEEDS_REMAINING: "Quantity exceeds remaining available butterflies",
+  RELEASE_ITEMS_MUST_MATCH:
+    "Release update must include every existing in-flight row for the release event",
 } as const;
 
 type LockedShipmentItem = {
@@ -32,6 +34,14 @@ type LockedShipmentItem = {
   non_emergence: number;
   poor_emergence: number;
 };
+
+const LOSS_COLUMNS = [
+  "damaged_in_transit",
+  "diseased_in_transit",
+  "parasite",
+  "non_emergence",
+  "poor_emergence",
+] as const;
 
 type ReleaseItemInput = {
   shipment_item_id: number;
@@ -77,7 +87,77 @@ function calculateRemaining(item: LockedShipmentItem, alreadyReleased: number) {
 }
 
 /**
- * List release events for a shipment (newest first).
+ * List release events for an institution (newest first, paginated), enriched
+ * with the supplier code of the parent shipment and the total butterflies
+ * released in each event.
+ */
+export async function listInstitutionReleases(institutionId: number, page: number, limit: number) {
+  const offset = (page - 1) * limit;
+
+  const [rows, totalResult] = await Promise.all([
+    db
+      .select({
+        id: release_events.id,
+        shipmentId: release_events.shipment_id,
+        releaseDate: release_events.release_date,
+        releasedBy: release_events.released_by,
+        supplierCode: shipments.supplier_code,
+        shipmentDate: shipments.shipment_date,
+        totalReleased: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as(
+          "total_released",
+        ),
+      })
+      .from(release_events)
+      .innerJoin(
+        shipments,
+        and(
+          eq(shipments.id, release_events.shipment_id),
+          eq(shipments.institution_id, release_events.institution_id),
+        ),
+      )
+      .leftJoin(
+        in_flight,
+        and(
+          eq(in_flight.release_event_id, release_events.id),
+          eq(in_flight.institution_id, release_events.institution_id),
+        ),
+      )
+      .where(eq(release_events.institution_id, institutionId))
+      .groupBy(
+        release_events.id,
+        release_events.shipment_id,
+        release_events.release_date,
+        release_events.released_by,
+        shipments.supplier_code,
+        shipments.shipment_date,
+      )
+      .orderBy(desc(release_events.release_date))
+      .limit(limit)
+      .offset(offset),
+
+    db
+      .select({ total: count() })
+      .from(release_events)
+      .where(eq(release_events.institution_id, institutionId)),
+  ]);
+
+  const total = totalResult[0]?.total ?? 0;
+
+  return {
+    releases: rows,
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.max(1, Math.ceil(total / limit)),
+    },
+  };
+}
+
+/**
+ * List release events for a shipment (newest first), enriched with the total
+ * butterflies released per event so the shipment-detail history table can
+ * render a meaningful "Released" column without an extra round-trip.
  */
 export async function listReleaseEventsForShipment(institutionId: number, shipmentId: number) {
   return db
@@ -85,14 +165,23 @@ export async function listReleaseEventsForShipment(institutionId: number, shipme
       id: release_events.id,
       releaseDate: release_events.release_date,
       releasedBy: release_events.released_by,
+      totalReleased: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as("total_released"),
     })
     .from(release_events)
+    .leftJoin(
+      in_flight,
+      and(
+        eq(in_flight.release_event_id, release_events.id),
+        eq(in_flight.institution_id, release_events.institution_id),
+      ),
+    )
     .where(
       and(
         eq(release_events.institution_id, institutionId),
         eq(release_events.shipment_id, shipmentId),
       ),
     )
+    .groupBy(release_events.id, release_events.release_date, release_events.released_by)
     .orderBy(desc(release_events.release_date));
 }
 
@@ -166,6 +255,10 @@ export async function updateReleaseEventItems(
 
     const shipmentItemIds = payload.items.map((item) => item.shipment_item_id);
 
+    // Read every in-flight row for the release event so we can enforce that
+    // the caller supplied an update for each one. Partial updates (omitting
+    // an existing row) would silently leave that row untouched, which is
+    // almost never what the UI intends.
     const existingRows = await tx
       .select({
         id: in_flight.id,
@@ -176,13 +269,16 @@ export async function updateReleaseEventItems(
         and(
           eq(in_flight.institution_id, institutionId),
           eq(in_flight.release_event_id, releaseEventId),
-          inArray(in_flight.shipment_item_id, shipmentItemIds),
         ),
       )
       .for("update");
 
-    if (existingRows.length !== shipmentItemIds.length) {
-      throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
+    const payloadSet = new Set(shipmentItemIds);
+    if (
+      existingRows.length !== payloadSet.size ||
+      existingRows.some((row) => !payloadSet.has(row.shipmentItemId))
+    ) {
+      throw new Error(RELEASE_ERRORS.RELEASE_ITEMS_MUST_MATCH);
     }
 
     const existingByShipmentItemId = new Map(existingRows.map((row) => [row.shipmentItemId, row]));
@@ -253,6 +349,10 @@ export async function updateReleaseEventItems(
 
 /**
  * Create a release event and corresponding in-flight rows from a shipment.
+ *
+ * `payload.loss_updates` are applied inside the same transaction as the
+ * release event so callers can correct loss-column values atomically with
+ * the release they're creating from the remaining inventory.
  */
 export async function createReleaseFromShipment(
   institutionId: number,
@@ -273,7 +373,15 @@ export async function createReleaseFromShipment(
       throw new Error(RELEASE_ERRORS.SHIPMENT_NOT_FOUND);
     }
 
+    // Lock the union of items touched by the release + the loss updates so
+    // every row used in the subsequent validation is locked in one shot.
+    const lossUpdates = payload.loss_updates ?? [];
+    const lockedIdSet = new Set<number>([
+      ...payload.items.map((item) => item.shipment_item_id),
+      ...lossUpdates.map((row) => row.shipment_item_id),
+    ]);
     const shipmentItemIds = payload.items.map((item) => item.shipment_item_id);
+    const allLockedIds = Array.from(lockedIdSet);
 
     const lockedItems = await tx
       .select({
@@ -291,15 +399,59 @@ export async function createReleaseFromShipment(
         and(
           eq(shipment_items.institution_id, institutionId),
           eq(shipment_items.shipment_id, shipmentId),
-          inArray(shipment_items.id, shipmentItemIds),
+          inArray(shipment_items.id, allLockedIds),
         ),
       )
       .for("update");
 
-    if (lockedItems.length !== shipmentItemIds.length) {
+    if (lockedItems.length !== allLockedIds.length) {
       throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
     }
 
+    // Apply loss updates in memory + via UPDATE statements so downstream
+    // remaining checks see the corrected inventory.
+    const lockedMutableItems = new Map(lockedItems.map((row) => [row.id, { ...row }]));
+    for (const update of lossUpdates) {
+      const row = lockedMutableItems.get(update.shipment_item_id);
+      if (!row) {
+        throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
+      }
+
+      const patch: Partial<Record<(typeof LOSS_COLUMNS)[number], number>> = {};
+      for (const column of LOSS_COLUMNS) {
+        const next = update[column];
+        if (typeof next === "number") {
+          row[column] = next;
+          patch[column] = next;
+        }
+      }
+
+      if (Object.keys(patch).length === 0) continue;
+
+      await tx
+        .update(shipment_items)
+        .set({ ...patch, updated_at: new Date() })
+        .where(
+          and(
+            eq(shipment_items.id, update.shipment_item_id),
+            eq(shipment_items.institution_id, institutionId),
+          ),
+        );
+    }
+
+    // Replace the original lockedItems list with the mutated copies so the
+    // rest of the function reads post-correction values.
+    const lockedItemsAfterUpdates = Array.from(lockedMutableItems.values()).filter((row) =>
+      shipmentItemIds.includes(row.id),
+    );
+
+    if (lockedItemsAfterUpdates.length !== shipmentItemIds.length) {
+      throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
+    }
+
+    // Query in-flight for every locked id, not just the items being released,
+    // so we can also validate that loss-only updates don't push remaining
+    // below the already-released quantity for untouched items.
     const releasedRows = await tx
       .select({
         shipment_item_id: in_flight.shipment_item_id,
@@ -309,12 +461,25 @@ export async function createReleaseFromShipment(
       .where(
         and(
           eq(in_flight.institution_id, institutionId),
-          inArray(in_flight.shipment_item_id, shipmentItemIds),
+          inArray(in_flight.shipment_item_id, allLockedIds),
         ),
       )
       .groupBy(in_flight.shipment_item_id);
 
-    const lockedItemById = new Map(lockedItems.map((row) => [row.id, row]));
+    // Guard against loss corrections that would push a non-released item's
+    // remaining below zero (i.e. losses + in_flight > number_received).
+    for (const update of lossUpdates) {
+      const row = lockedMutableItems.get(update.shipment_item_id);
+      if (!row) continue;
+      const alreadyReleased = Number(
+        releasedRows.find((r) => r.shipment_item_id === update.shipment_item_id)?.quantity ?? 0,
+      );
+      if (calculateRemaining(row, alreadyReleased) < 0) {
+        throw new Error(RELEASE_ERRORS.QUANTITY_EXCEEDS_REMAINING);
+      }
+    }
+
+    const lockedItemById = new Map(lockedItemsAfterUpdates.map((row) => [row.id, row]));
     const alreadyReleasedByShipmentItemId = new Map(
       releasedRows.map((row) => [row.shipment_item_id, Number(row.quantity)]),
     );

--- a/src/lib/queries/shipments.ts
+++ b/src/lib/queries/shipments.ts
@@ -37,7 +37,8 @@ export function parseDateOnlyToUtcExclusiveEnd(value: string): Date {
 }
 
 /**
- * List shipments for a tenant (paginated)
+ * List shipments for a tenant (paginated). Each row carries a `remaining`
+ * count and an `isCompleted` flag derived from shipment items + in_flight.
  */
 export async function listShipments(institutionId: number, page: number, limit: number) {
   const offset = (page - 1) * limit;
@@ -64,9 +65,22 @@ export async function listShipments(institutionId: number, page: number, limit: 
   ]);
 
   const total = totalResult[0]?.total ?? 0;
+  const completionByShipmentId = await getShipmentCompletionMap(
+    institutionId,
+    rows.map((row) => row.id),
+  );
+
+  const enriched = rows.map((row) => {
+    const status = completionByShipmentId.get(row.id) ?? { remaining: 0, isCompleted: true };
+    return {
+      ...row,
+      remaining: status.remaining,
+      isCompleted: status.isCompleted,
+    };
+  });
 
   return {
-    shipments: rows,
+    shipments: enriched,
     pagination: {
       page,
       limit,
@@ -74,6 +88,113 @@ export async function listShipments(institutionId: number, page: number, limit: 
       totalPages: Math.ceil(total / limit),
     },
   };
+}
+
+/**
+ * Pure helper that turns the raw aggregation rows from the DB into the
+ * shipment-id → {remaining, isCompleted} map. Extracted so the completion
+ * logic (clamping, empty-shipment defaulting, in_flight subtraction) can be
+ * unit-tested without going through drizzle.
+ */
+export function buildShipmentCompletionMap(
+  itemRows: { shipmentId: number; itemCount: number; grossAvailable: number | string }[],
+  releasedRows: { shipmentId: number; released: number | string }[],
+  shipmentIds?: number[],
+): Map<number, { remaining: number; isCompleted: boolean }> {
+  const releasedByShipmentId = new Map(
+    releasedRows.map((row) => [row.shipmentId, Number(row.released)]),
+  );
+
+  const map = new Map<number, { remaining: number; isCompleted: boolean }>();
+
+  for (const row of itemRows) {
+    const released = releasedByShipmentId.get(row.shipmentId) ?? 0;
+    const remaining = Math.max(0, Number(row.grossAvailable) - released);
+    map.set(row.shipmentId, {
+      remaining,
+      isCompleted: row.itemCount > 0 && remaining === 0,
+    });
+  }
+
+  // Shipments with zero items aren't returned by the grouping above. Default
+  // them to "in progress" so empty shells aren't surfaced as completed.
+  if (shipmentIds) {
+    for (const id of shipmentIds) {
+      if (!map.has(id)) {
+        map.set(id, { remaining: 0, isCompleted: false });
+      }
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Compute remaining butterflies + completion flag per shipment for a tenant.
+ *
+ * Per shipment item, "remaining" = number_received − (damaged + diseased
+ * + parasite + non_emergence + poor_emergence) − sum(in_flight.quantity).
+ * A shipment is "completed" when remaining sums to zero across all of its
+ * items AND it has at least one item (an empty shipment is treated as
+ * in-progress so users see something to fill in).
+ *
+ * If `shipmentIds` is provided the result is restricted to those ids;
+ * otherwise every shipment for the institution is included.
+ */
+export async function getShipmentCompletionMap(
+  institutionId: number,
+  shipmentIds?: number[],
+): Promise<Map<number, { remaining: number; isCompleted: boolean }>> {
+  if (shipmentIds && shipmentIds.length === 0) {
+    return new Map();
+  }
+
+  const itemConditions = [eq(shipment_items.institution_id, institutionId)];
+  if (shipmentIds) {
+    itemConditions.push(inArray(shipment_items.shipment_id, shipmentIds));
+  }
+
+  // Per-shipment item totals (received minus losses), grouped in SQL.
+  const itemRows = await db
+    .select({
+      shipmentId: shipment_items.shipment_id,
+      itemCount: count(shipment_items.id),
+      grossAvailable: sql<number>`coalesce(sum(
+        ${shipment_items.number_received}
+        - ${shipment_items.damaged_in_transit}
+        - ${shipment_items.diseased_in_transit}
+        - ${shipment_items.parasite}
+        - ${shipment_items.non_emergence}
+        - ${shipment_items.poor_emergence}
+      ), 0)::int`.as("gross_available"),
+    })
+    .from(shipment_items)
+    .where(and(...itemConditions))
+    .groupBy(shipment_items.shipment_id);
+
+  // Per-shipment in_flight totals via shipment_items join.
+  const releasedConditions = [eq(in_flight.institution_id, institutionId)];
+  if (shipmentIds) {
+    releasedConditions.push(inArray(shipment_items.shipment_id, shipmentIds));
+  }
+
+  const releasedRows = await db
+    .select({
+      shipmentId: shipment_items.shipment_id,
+      released: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as("released_total"),
+    })
+    .from(in_flight)
+    .innerJoin(
+      shipment_items,
+      and(
+        eq(shipment_items.id, in_flight.shipment_item_id),
+        eq(shipment_items.institution_id, in_flight.institution_id),
+      ),
+    )
+    .where(and(...releasedConditions))
+    .groupBy(shipment_items.shipment_id);
+
+  return buildShipmentCompletionMap(itemRows, releasedRows, shipmentIds);
 }
 
 /**
@@ -114,7 +235,11 @@ export async function getShipmentWithItems(institutionId: number, shipmentId: nu
       nonEmergence: shipment_items.non_emergence,
       poorEmergence: shipment_items.poor_emergence,
 
-      inFlightQuantity: sql<number>`coalesce(sum(${in_flight.quantity}), 0)`.as(
+      // ::int cast is required: PG sum() over integer returns bigint, which
+      // node-postgres serializes as a string. Without the cast, JS code that
+      // does `acc + item.inFlightQuantity` ends up string-concatenating
+      // ("0" + "5" + "10" → "0510") and surfaces as a giant number.
+      inFlightQuantity: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as(
         "in_flight_quantity",
       ),
     })

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -30,7 +30,11 @@ export const ROUTES = {
     organization: (slug: string) => `/${slug}/organization`,
     shipments: (slug: string) => `/${slug}/shipments`,
     shipmentAdd: (slug: string) => `/${slug}/shipments/add`,
-    releases: (slug: string) => `/${slug}/releases`,
+    shipmentById: (slug: string, id: string | number) => `/${slug}/shipments/${id}`,
+    shipmentReleaseNew: (slug: string, id: string | number) =>
+      `/${slug}/shipments/${id}/release/new`,
+    shipmentReleaseEdit: (slug: string, id: string | number, releaseId: string | number) =>
+      `/${slug}/shipments/${id}/release/${releaseId}/edit`,
     shipmentsApi: "/api/tenant/shipments",
     shipmentSummaryApi: "/api/tenant/shipments/summary",
     shipmentImportPreviewApi: "/api/tenant/shipments/import/preview",

--- a/src/lib/services/tenant-releases.ts
+++ b/src/lib/services/tenant-releases.ts
@@ -1,10 +1,11 @@
 import { auth } from "@/auth";
-import { canCreateRelease, requireUser } from "@/lib/authz";
+import { canCreateRelease, canReadShipment, requireUser } from "@/lib/authz";
 import {
   createInFlightForRelease,
   deleteInFlightRow,
   deleteReleaseEvent,
   getReleaseEventWithItems,
+  listInstitutionReleases,
   RELEASE_ERRORS,
   updateInFlightQuantity,
   updateReleaseEventItems,
@@ -23,6 +24,11 @@ type TenantReleaseContext = {
   slug: string;
 };
 
+type ListTenantReleasesInput = TenantReleaseContext & {
+  page?: number;
+  limit?: number;
+};
+
 type TenantReleaseByIdInput = TenantReleaseContext & {
   releaseId: number;
 };
@@ -37,10 +43,21 @@ type UpdateTenantReleaseInput = TenantReleaseByIdInput & UpdateReleaseEventItems
 
 type UpdateTenantInFlightInput = TenantInFlightByIdInput & UpdateInFlightQuantityBody;
 
+export async function getTenantReleases({ slug, page = 1, limit = 50 }: ListTenantReleasesInput) {
+  const user = requireUser(await auth());
+
+  if (!canReadShipment(user)) {
+    throw new Error("FORBIDDEN");
+  }
+
+  const tenantId = await resolveTenantBySlug(user, slug);
+  return listInstitutionReleases(tenantId, page, limit);
+}
+
 export async function getTenantReleaseById({ slug, releaseId }: TenantReleaseByIdInput) {
   const user = requireUser(await auth());
 
-  if (!canCreateRelease(user)) {
+  if (!canReadShipment(user)) {
     throw new Error("FORBIDDEN");
   }
 

--- a/src/lib/validation/releases.ts
+++ b/src/lib/validation/releases.ts
@@ -7,10 +7,29 @@ const releaseItemSchema = z
   })
   .strict();
 
+/**
+ * Loss-column corrections that can be applied atomically alongside a release
+ * POST. Each row carries absolute new values for any loss columns the client
+ * wants to adjust; omitted columns are left unchanged. The same transaction
+ * that creates the release event also writes these updates, so the
+ * "remaining" check is computed against the post-correction inventory.
+ */
+const releaseLossUpdateSchema = z
+  .object({
+    shipment_item_id: z.coerce.number().int().positive(),
+    damaged_in_transit: z.coerce.number().int().nonnegative().optional(),
+    diseased_in_transit: z.coerce.number().int().nonnegative().optional(),
+    parasite: z.coerce.number().int().nonnegative().optional(),
+    non_emergence: z.coerce.number().int().nonnegative().optional(),
+    poor_emergence: z.coerce.number().int().nonnegative().optional(),
+  })
+  .strict();
+
 export const createReleaseFromShipmentSchema = z
   .object({
     released_at: z.coerce.date().optional(),
     items: z.array(releaseItemSchema).min(1, "At least one release item is required"),
+    loss_updates: z.array(releaseLossUpdateSchema).optional().default([]),
   })
   .strict()
   .superRefine((data, ctx) => {
@@ -28,7 +47,22 @@ export const createReleaseFromShipmentSchema = z
 
       seen.add(item.shipment_item_id);
     }
+
+    const lossSeen = new Set<number>();
+    for (const row of data.loss_updates ?? []) {
+      if (lossSeen.has(row.shipment_item_id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Shipment items must be unique in loss_updates",
+          path: ["loss_updates"],
+        });
+        break;
+      }
+      lossSeen.add(row.shipment_item_id);
+    }
   });
+
+export type ReleaseLossUpdate = z.infer<typeof releaseLossUpdateSchema>;
 
 export type CreateReleaseFromShipmentBody = z.infer<typeof createReleaseFromShipmentSchema>;
 
@@ -81,3 +115,16 @@ export const updateReleaseEventItemsSchema = z
   });
 
 export type UpdateReleaseEventItemsBody = z.infer<typeof updateReleaseEventItemsSchema>;
+
+/**
+ * Query schema for `GET /api/tenant/releases`. Mirrors the shipments list
+ * pagination contract so the UI can rely on a consistent shape.
+ */
+export const listReleasesQuerySchema = z
+  .object({
+    page: z.coerce.number().int().positive().default(1),
+    limit: z.coerce.number().int().positive().max(200).default(50),
+  })
+  .strict();
+
+export type ListReleasesQuery = z.infer<typeof listReleasesQuerySchema>;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,7 @@ import { hasPermission } from "@/lib/permissions";
 // /:institution/dashboard, /:institution/shipments, etc.
 // Public routes (login, unauthorized, api, _next) bypass middleware entirely.
 export const config = {
-  matcher: ["/:institution/(dashboard|organization|shipments|releases)/:path*"],
+  matcher: ["/:institution/(dashboard|organization|shipments)/:path*"],
 };
 
 // Required permission to enter each top-level admin section.
@@ -17,7 +17,6 @@ const SECTION_PERMISSION_MAP: Record<string, Permission> = {
   dashboard: "VIEW_DASHBOARD",
   organization: "VIEW_ORGANIZATION",
   shipments: "VIEW_SHIPMENTS",
-  releases: "VIEW_RELEASES",
 };
 
 // Required permission for specific sub-paths within a section.


### PR DESCRIPTION
## Summary

- Adds a shipment-scoped release flow: create release (`shipments/[id]/release/new`) and edit release (`shipments/[id]/release/[releaseId]/edit`) pages, backed by a new `ReleaseCategoryComposer` (Good/Poor emergence + Diseased/Parasite/No-emergence loss buckets) and a per-species `ReleaseComposer` for edits.
- Tracks in-flight butterflies per shipment item; the shipment list and detail pages now show a `ShipmentStatusBadge` ("In progress {N} remaining" / "Completed") computed via a new `getShipmentCompletionMap` query.
- Adds inline edit mode to the shipment detail page with a `ShipmentItemsTable` (per-metric steppers, species picker for additions, force-edit confirmation), plus delete with dependency checks.
- Replaces the standalone `/releases` page with release management nested under each shipment. Removes the now-dead `VIEW_RELEASES` permission, middleware matcher entry, and nav items.
- New `GET /api/tenant/releases` (paginated, `page`/`limit`, max 200) and supporting service/query/validation. Existing `[releaseId]` routes refactored to use the shared `mapAuthError()` helper.
- New shared building blocks: `DatePicker`, `SupplierSelect`, `SpeciesPickerDialog`, `ShipmentItemsTable`, `ShipmentStatusBadge`, `ReleaseComposer`, `ReleaseCategoryComposer`, `ReleaseQuantityControls`, plus `computeItemRemaining` mirroring the server formula.

## Code-review fixes folded in

**Concurrency & data integrity**
- Atomic loss corrections inside `createReleaseFromShipment`: items in `loss_updates` and `items` are locked together (`for("update")`) before any UPDATE runs, so the post-correction `remaining` check sees a consistent snapshot.

**Memory leaks / state-on-unmounted-component**
- `AbortController` wired through `loadShipment`, `loadSpecies`, and `loadShipments` (the new release pages already had it) so in-flight fetches cancel on unmount/page-change.

**Routing & cleanup**
- `shipments/page.tsx` now uses `ROUTES.tenant.*` constants instead of hardcoded `/${slug}/...` strings.
- Removed `releases` from the middleware matcher and `SECTION_PERMISSION_MAP`, deleted `VIEW_RELEASES` from `permissions.ts`, and dropped two stale middleware tests.
- Invalid URL ids on `shipments/[id]`, `release/new`, and `release/[releaseId]/edit` now trip `notFound()` instead of rendering bespoke "Invalid id" UI.

**API surface**
- `GET /api/tenant/releases` is now paginated (`listReleasesQuerySchema`: `page≥1`, `1≤limit≤200`, defaults `1`/`50`, strict mode); 400 on invalid input.
- `[releaseId]/route.ts` GET/PATCH/DELETE deduplicated via `mapAuthError()`.

**Accessibility (WCAG 2.1 AA)**
- `MetricStepper` and `ReleaseQuantityControls` inputs now carry `aria-describedby` linking to a sr-only constraint hint (allowed range / max).
- `shipment-items-table.tsx` "remaining = 0" cell adds a `CheckCircle2` icon + sr-only "(released)" text — no longer color-only.
- Loading states across the four new pages get `role="status"`, `aria-live="polite"`, `aria-busy="true"`.
- "Load more" buttons in `release-composer`, `release-category-composer`, and `species-picker-dialog` now carry `aria-label="Load more butterfly species"`.
- `DatePicker.parseDateOnly` rejects month > 12, day > 31, and round-trip mismatches (e.g., Feb 30 → Mar 2 overflow).

**Documentation**
- `docs/api/README.md` documents the new `GET /api/tenant/releases` endpoint with query params, response shape, error conditions, and adds it to the route matrix.

**Test coverage**
- Extracted pure `buildShipmentCompletionMap(itemRows, releasedRows, shipmentIds?)` from `getShipmentCompletionMap` so the completion logic is unit-testable without mocking drizzle.
- New `build-shipment-completion-map.test.ts` (10 cases): clamping, isCompleted flag, PG string→number coercion, empty-shipment defaulting, multi-shipment isolation, itemCount=0 not marked done, orphan released_rows.
- Expanded `validation-releases.test.ts`: invalid `released_at` strings, non-numeric coerced quantities, full coverage of `listReleasesQuerySchema` (defaults, coercion, rejections, fractional, max cap, strict mode).
- New `releases.route.test.ts` cases: forwards `page`/`limit` to service, rejects non-numeric pagination, rejects `limit > 200`.

**Total: 604/604 tests passing (was 582, added 22).**

## Test plan

- [ ] `pnpm lint` — 0 errors
- [ ] `pnpm test` — all 604 pass
- [ ] Visit http://localhost:3000/reiman-gardens/shipments and confirm each row shows the correct "In progress {N} remaining" or "Completed" badge
- [ ] From http://localhost:3000/reiman-gardens/shipments/1, click **Add release** → http://localhost:3000/reiman-gardens/shipments/1/release/new — confirm Good Emergence becomes the release quantity and loss buckets are applied atomically (status badge flips toward "Completed" once everything is released)
- [ ] From the same shipment detail page, edit an existing release via http://localhost:3000/reiman-gardens/shipments/1/release/1/edit and confirm cap accounting includes the row's own current allocation (you can move quantities up to the row's own value + remaining headroom)
- [ ] As ADMIN, click **Edit items** on http://localhost:3000/reiman-gardens/shipments/1, confirm the force-edit dialog appears and that reductions below already-released quantities are rejected by the server
- [ ] Try deleting a shipment with releases from http://localhost:3000/reiman-gardens/shipments — should 409 with the dependency message
- [ ] Visit http://localhost:3000/reiman-gardens/shipments/abc and http://localhost:3000/reiman-gardens/shipments/0 — both should hit the not-found boundary
- [ ] `curl -H "x-tenant-slug: reiman-gardens" "http://localhost:3000/api/tenant/releases?page=1&limit=200"` — 200; same with `limit=201` — 400 INVALID_REQUEST; same with `page=abc` — 400
- [ ] Tab through the release composer at http://localhost:3000/reiman-gardens/shipments/1/release/new with a screen reader and confirm the per-row constraint hints ("Maximum N", "{N} remaining for this species") are announced
- [ ] Confirm http://localhost:3000/reiman-gardens/releases now 404s (route was removed; middleware no longer protects it)
