### PR TITLE
fix(auth): fixed error with login and fixed unauthorized page

### DIFF
--- a/src/app/(home)/login/page.tsx
+++ b/src/app/(home)/login/page.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod/v4";
 import { toast } from "sonner";
+import { X } from "lucide-react";
 import { logger } from "@/lib/logger";
 import { ROUTES } from "@/lib/routes";
 
@@ -40,6 +41,7 @@ type PublicInstitutionsResponse = {
 export default function LoginPage() {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
+  const [authError, setAuthError] = useState<string | null>(null);
   const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -82,6 +84,7 @@ export default function LoginPage() {
 
   async function onSubmit(data: LoginFormData) {
     setIsLoading(true);
+    setAuthError(null);
 
     try {
       await signIn("credentials", {
@@ -97,7 +100,7 @@ export default function LoginPage() {
       const role = session?.user?.role;
 
       if (!role) {
-        toast.error("Invalid email or password");
+        setAuthError("Incorrect email or password.");
         return;
       }
 
@@ -114,7 +117,7 @@ export default function LoginPage() {
         router.push("/");
       }
     } catch (error) {
-      toast.error("An error occurred. Please try again.");
+      setAuthError("An error occurred. Please try again.");
       logger.error("Login error:", error);
     } finally {
       setIsLoading(false);
@@ -144,6 +147,22 @@ export default function LoginPage() {
           <CardContent>
             <Form {...form}>
               <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                {authError && (
+                  <div
+                    role="alert"
+                    className="flex items-center justify-between gap-2 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/50 dark:text-red-400"
+                  >
+                    <span>{authError}</span>
+                    <button
+                      type="button"
+                      aria-label="Dismiss error"
+                      onClick={() => setAuthError(null)}
+                      className="shrink-0 rounded focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+                )}
                 <FormField
                   control={form.control}
                   name="email"

--- a/src/app/(home)/login/page.tsx
+++ b/src/app/(home)/login/page.tsx
@@ -84,23 +84,24 @@ export default function LoginPage() {
     setIsLoading(true);
 
     try {
-      const result = await signIn("credentials", {
+      await signIn("credentials", {
         email: data.email,
         password: data.password,
         redirect: false,
       });
 
-      if (!result?.ok) {
-        toast.error(result?.error || "Invalid email or password");
+      // NextAuth v5 beta does not reliably reflect auth failure in the signIn return
+      // value. Verify by checking whether a session was actually created.
+      const sessionResponse = await fetch("/api/auth/session");
+      const session = await sessionResponse.json();
+      const role = session?.user?.role;
+
+      if (!role) {
+        toast.error("Invalid email or password");
         return;
       }
 
       toast.success("Logged in successfully");
-
-      // Get the session to retrieve institution information
-      const sessionResponse = await fetch("/api/auth/session");
-      const session = await sessionResponse.json();
-      const role = session?.user?.role;
 
       if (role === "SUPERUSER") {
         // Redirect superusers to the platform dashboard
@@ -109,7 +110,7 @@ export default function LoginPage() {
         // Redirect to institution dashboard using slug (public tenant segment)
         router.push(ROUTES.tenant.dashboard(session.user.institutionSlug));
       } else {
-        // Fallback if institution slug is missing (e.g. SUPERUSER with no institution)
+        // Fallback if institution slug is missing
         router.push("/");
       }
     } catch (error) {

--- a/src/app/unauthorized/page.tsx
+++ b/src/app/unauthorized/page.tsx
@@ -1,13 +1,46 @@
+import { Button } from "@/components/ui/button";
 import { Link } from "@/components/ui/link";
+import { BackButton } from "@/components/shared/back-button";
 
 export default function UnauthorizedPage() {
   return (
-    <main style={{ padding: "40px", fontFamily: "system-ui, sans-serif" }}>
-      <h1>Access Denied</h1>
-      <p>You do not have permission to view this page.</p>
-      <p>
-        <Link href="/">Return home</Link> | <Link href="/login">Sign in</Link>
+    <main
+      id="main-content"
+      className="flex flex-1 flex-col items-center justify-center px-4 py-24 text-center"
+    >
+      <div className="relative mb-8 select-none" aria-hidden="true">
+        <span className="text-muted-foreground/15 text-[8rem] leading-none font-bold tracking-tighter">
+          403
+        </span>
+        <svg
+          viewBox="0 0 100 80"
+          className="text-primary/20 absolute -top-2 -right-6 w-16 rotate-12"
+          fill="currentColor"
+        >
+          <path d="M50 40 C30 10, 5 10, 5 35 C5 55, 30 65, 50 40Z" />
+          <path d="M50 40 C70 10, 95 10, 95 35 C95 55, 70 65, 50 40Z" />
+          <path d="M50 40 C35 50, 15 70, 25 75 C35 80, 45 60, 50 40Z" />
+          <path d="M50 40 C65 50, 85 70, 75 75 C65 80, 55 60, 50 40Z" />
+        </svg>
+      </div>
+
+      <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+        <span className="sr-only">Error 403: </span>
+        Access denied
+      </h1>
+      <p className="text-muted-foreground mt-3 max-w-sm text-balance">
+        You don&apos;t have permission to view this page.
       </p>
+
+      <nav
+        aria-label="Error page navigation"
+        className="mt-8 flex flex-wrap items-center justify-center gap-3"
+      >
+        <BackButton />
+        <Button asChild>
+          <Link href="/login">Sign in</Link>
+        </Button>
+      </nav>
     </main>
   );
 }


### PR DESCRIPTION
Fixes a bug where the login page redirected to / on failed credentials because of bad
return values from `signIn` in NextAuth. Replaces the unauthorized
page placeholder with a proper error page


- `login/page.tsx`: Drop `signIn` return value, fetching
  the session immediately after sign in and check for `session.user.role` instead. If its not there, the
  login fails and we show an "Invalid email or password" toast without redirect
- `unauthorized/page.tsx`: Replace placeholder with a 403 page


- [ ] Navigate to `/login`, enter wrong credentials  toast error shown, no redirect occurs
- [ ] Navigate to `/login`, enter correct credentials  redirects to the correct dashboard
- [ ] Navigate to `/unauthorized`  403 page renders with back button and sign in link
