### PR TITLE
Feat: global suppliers schema migration

### DIFF
--- a/docs/api/API_ARCHITECTURE_V3.md
+++ b/docs/api/API_ARCHITECTURE_V3.md
@@ -92,7 +92,10 @@ SUPERUSER can resolve any valid slug. Non-SUPERUSER can only resolve their own i
 
 ### Query responsibility
 
-Queries receive the already-resolved `institutionId` (a number). They must never receive `slug` or perform slug lookups.
+Queries for tenant-owned data receive the already-resolved `institutionId` (a number). They must
+never receive `slug` or perform slug lookups. Global reference data can be exposed through tenant
+routes after the service layer resolves the slug for authorization; suppliers currently follow that
+pattern.
 
 ```typescript
 export async function listFooForTenant(institutionId: number, user: AuthenticatedUser) {

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -111,7 +111,7 @@ All tenant routes use `x-tenant-slug` for tenant context:
 - `POST /api/tenant/releases/[releaseId]/in-flight` — add one in-flight row to an existing release event
 - `PATCH/DELETE /api/tenant/in-flight/[id]` — update or remove an in-flight row
 - `GET/PATCH/DELETE /api/tenant/releases/[releaseId]` — release detail, quantity updates, and delete
-- `GET /api/tenant/suppliers` — list suppliers for tenant
+- `GET /api/tenant/suppliers` — list global suppliers available to tenant shipment forms
 - `GET/POST /api/tenant/users` — list and create users for a tenant
 - `GET/PATCH/DELETE /api/tenant/users/[id]` — user detail, update, delete
 - `GET/PATCH /api/tenant/institution` — tenant institution profile
@@ -125,8 +125,8 @@ All tenant routes use `x-tenant-slug` for tenant context:
 - `GET/PATCH/DELETE /api/platform/institutions/[id]` — institution detail, update, delete
 - `GET/POST /api/platform/species` — list and create global species
 - `GET/PATCH/DELETE /api/platform/species/[id]` — species detail, update, delete
-- `GET/POST /api/platform/suppliers` — list & create suppliers (cross-tenant)
-- `GET/PATCH/DELETE /api/platform/suppliers/[id]` — supplier detail, update, delete
+- `GET/POST /api/platform/suppliers` — list & create global suppliers
+- `GET/PATCH/DELETE /api/platform/suppliers/[id]` — global supplier detail, update, delete
 
 ### Platform species create/update contract
 
@@ -426,6 +426,10 @@ All tenant routes use the `x-tenant-slug` header for tenant context. Missing hea
 | `/tenant/in-flight/[id]`                 | PATCH, DELETE      | `x-tenant-slug` header |
 
 ### Tenant suppliers contract
+
+Tenant supplier reads return the global supplier list. The `x-tenant-slug` header is still required
+for authentication, authorization, and tenant-route consistency, but suppliers are not owned by that
+institution.
 
 Response shape:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -69,7 +69,7 @@ PostgreSQL 17 managed via Drizzle ORM:
 - **User** — An account scoped to an institution with a role
 - **Butterfly Species** — Global scientific reference data
 - **Butterfly Species Institution** — Institution-specific species details (common name, description, image)
-- **Supplier** — Butterfly vendor/supplier
+- **Supplier** — Global butterfly vendor/supplier code used by shipments and imports
 - **Shipment** — A butterfly shipment record with quality/damage tracking metrics
 
 ### Key Relationships
@@ -78,7 +78,7 @@ PostgreSQL 17 managed via Drizzle ORM:
 Institution ─┬─ Users
               ├─ Butterfly Species Institution ── Butterfly Species (global)
               └─ Shipments ─┬─ Butterfly Species (global)
-                            └─ Supplier
+                            └─ Supplier (global by code)
 ```
 
 ## API Routes

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -22,18 +22,21 @@
 - Always filter by `institution_id` for tenant-scoped data
 - Foreign keys use a mix of `CASCADE` and `RESTRICT`; verify behavior per relationship
 - The `butterfly_species` table is global; `butterfly_species_institution` is per-tenant
+- The `suppliers` table is global; shipments preserve historical supplier codes in `supplier_code`
 
 ## Tenant Composite-Key Enforcement
 
 Tenant isolation is enforced at the database level using composite foreign keys that include `institution_id`.
 
-- `shipments (institution_id, supplier_code) -> suppliers (institution_id, code)` — `RESTRICT`
+- `shipments (supplier_code) -> suppliers (code)` — `RESTRICT`
 - `shipment_items (institution_id, shipment_id) -> shipments (institution_id, id)` — `CASCADE`
 - `release_events (institution_id, shipment_id) -> shipments (institution_id, id)` — `CASCADE`
 - `in_flight (institution_id, release_event_id) -> release_events (institution_id, id)` — `CASCADE`
 - `in_flight (institution_id, shipment_item_id) -> shipment_items (institution_id, id)` — `RESTRICT`
 
-This prevents cross-tenant references even if a raw numeric ID exists in another institution.
+Composite tenant keys prevent cross-tenant references even if a raw numeric ID exists in another
+institution. The supplier relationship is intentionally global by code so historical imports can
+reuse shared supplier codes across institutions.
 
 ## Docker
 

--- a/drizzle/0002_young_chameleon.sql
+++ b/drizzle/0002_young_chameleon.sql
@@ -1,0 +1,49 @@
+ALTER TABLE "suppliers" DROP CONSTRAINT "unique_supplier_per_institution";--> statement-breakpoint
+ALTER TABLE "suppliers" DROP CONSTRAINT "unique_supplier_id_per_institution";--> statement-breakpoint
+ALTER TABLE "shipments" DROP CONSTRAINT "fk_shipments_supplier_code";--> statement-breakpoint
+ALTER TABLE "suppliers" DROP CONSTRAINT "suppliers_institution_id_institutions_id_fk";--> statement-breakpoint
+WITH "missing_supplier_codes" AS (
+	SELECT
+		"shipments"."supplier_code" AS "code",
+		min("shipments"."institution_id") AS "institution_id"
+	FROM "shipments"
+	LEFT JOIN "suppliers" ON "suppliers"."code" = "shipments"."supplier_code"
+	WHERE "suppliers"."id" IS NULL
+	GROUP BY "shipments"."supplier_code"
+)
+INSERT INTO "suppliers" (
+	"institution_id",
+	"name",
+	"code",
+	"country",
+	"website_url",
+	"is_active",
+	"created_at",
+	"updated_at"
+)
+SELECT
+	"missing_supplier_codes"."institution_id",
+	"missing_supplier_codes"."code",
+	"missing_supplier_codes"."code",
+	'Unknown',
+	NULL,
+	false,
+	now(),
+	now()
+FROM "missing_supplier_codes";--> statement-breakpoint
+WITH "ranked_suppliers" AS (
+	SELECT
+		"id",
+		row_number() OVER (
+			PARTITION BY "code"
+			ORDER BY "is_active" DESC, "updated_at" DESC, "created_at" DESC, "id" DESC
+		) AS "dedupe_rank"
+	FROM "suppliers"
+)
+DELETE FROM "suppliers"
+USING "ranked_suppliers"
+WHERE "suppliers"."id" = "ranked_suppliers"."id"
+	AND "ranked_suppliers"."dedupe_rank" > 1;--> statement-breakpoint
+ALTER TABLE "suppliers" ADD CONSTRAINT "unique_supplier_code" UNIQUE("code");--> statement-breakpoint
+ALTER TABLE "suppliers" DROP COLUMN "institution_id";--> statement-breakpoint
+ALTER TABLE "shipments" ADD CONSTRAINT "fk_shipments_supplier_code" FOREIGN KEY ("supplier_code") REFERENCES "public"."suppliers"("code") ON DELETE restrict ON UPDATE no action;

--- a/drizzle/0002_young_chameleon.sql
+++ b/drizzle/0002_young_chameleon.sql
@@ -1,6 +1,6 @@
+ALTER TABLE "shipments" DROP CONSTRAINT "fk_shipments_supplier_code";--> statement-breakpoint
 ALTER TABLE "suppliers" DROP CONSTRAINT "unique_supplier_per_institution";--> statement-breakpoint
 ALTER TABLE "suppliers" DROP CONSTRAINT "unique_supplier_id_per_institution";--> statement-breakpoint
-ALTER TABLE "shipments" DROP CONSTRAINT "fk_shipments_supplier_code";--> statement-breakpoint
 ALTER TABLE "suppliers" DROP CONSTRAINT "suppliers_institution_id_institutions_id_fk";--> statement-breakpoint
 WITH "missing_supplier_codes" AS (
 	SELECT

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1222 @@
+{
+  "id": "3d702efe-57b1-4751-9f9d-cf785558a9ae",
+  "prevId": "fa73bbc4-9aa1-45c3-bc11-40af855cbceb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.butterfly_species": {
+      "name": "butterfly_species",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scientific_name": {
+          "name": "scientific_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name": {
+          "name": "common_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_family": {
+          "name": "sub_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifespan_days": {
+          "name": "lifespan_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range": {
+          "name": "range",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_plant": {
+          "name": "host_plant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "habitat": {
+          "name": "habitat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fun_facts": {
+          "name": "fun_facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "img_wings_open": {
+          "name": "img_wings_open",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "img_wings_closed": {
+          "name": "img_wings_closed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_img_1": {
+          "name": "extra_img_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_img_2": {
+          "name": "extra_img_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "butterfly_species_scientific_name_unique": {
+          "name": "butterfly_species_scientific_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scientific_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.butterfly_species_institution": {
+      "name": "butterfly_species_institution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "butterfly_species_id": {
+          "name": "butterfly_species_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name_override": {
+          "name": "common_name_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifespan_override": {
+          "name": "lifespan_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_institution_species": {
+          "name": "unique_institution_species",
+          "columns": [
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bsi_institution_id": {
+          "name": "idx_bsi_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "butterfly_species_institution_butterfly_species_id_butterfly_species_id_fk": {
+          "name": "butterfly_species_institution_butterfly_species_id_butterfly_species_id_fk",
+          "tableFrom": "butterfly_species_institution",
+          "tableTo": "butterfly_species",
+          "columnsFrom": [
+            "butterfly_species_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "butterfly_species_institution_institution_id_institutions_id_fk": {
+          "name": "butterfly_species_institution_institution_id_institutions_id_fk",
+          "tableFrom": "butterfly_species_institution",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_flight": {
+      "name": "in_flight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_event_id": {
+          "name": "release_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_item_id": {
+          "name": "shipment_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_in_flight_shipment_item": {
+          "name": "unique_in_flight_shipment_item",
+          "columns": [
+            {
+              "expression": "release_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_flight_institution_shipment_item": {
+          "name": "idx_in_flight_institution_shipment_item",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_flight_institution_id_institutions_id_fk": {
+          "name": "in_flight_institution_id_institutions_id_fk",
+          "tableFrom": "in_flight",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_in_flight_event_institution": {
+          "name": "fk_in_flight_event_institution",
+          "tableFrom": "in_flight",
+          "tableTo": "release_events",
+          "columnsFrom": [
+            "institution_id",
+            "release_event_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_in_flight_shipment_item_institution": {
+          "name": "fk_in_flight_shipment_item_institution",
+          "tableFrom": "in_flight",
+          "tableTo": "shipment_items",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_item_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institution_news": {
+      "name": "institution_news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_institution_news_institution_id": {
+          "name": "idx_institution_news_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "institution_news_institution_id_institutions_id_fk": {
+          "name": "institution_news_institution_id_institutions_id_fk",
+          "tableFrom": "institution_news",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street_address": {
+          "name": "street_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extended_address": {
+          "name": "extended_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_province": {
+          "name": "state_province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iabes_member": {
+          "name": "iabes_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_colors": {
+          "name": "theme_colors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_image_url": {
+          "name": "facility_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_active": {
+          "name": "stats_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_slug_unique": {
+          "name": "institutions_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "institutions_email_address_unique": {
+          "name": "institutions_email_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.release_events": {
+      "name": "release_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_by": {
+          "name": "released_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "release_events_institution_id_institutions_id_fk": {
+          "name": "release_events_institution_id_institutions_id_fk",
+          "tableFrom": "release_events",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_release_events_shipment_institution": {
+          "name": "fk_release_events_shipment_institution",
+          "tableFrom": "release_events",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_release_event_id_per_institution": {
+          "name": "unique_release_event_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipment_items": {
+      "name": "shipment_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "butterfly_species_id": {
+          "name": "butterfly_species_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_received": {
+          "name": "number_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emerged_in_transit": {
+          "name": "emerged_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "damaged_in_transit": {
+          "name": "damaged_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "diseased_in_transit": {
+          "name": "diseased_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parasite": {
+          "name": "parasite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "non_emergence": {
+          "name": "non_emergence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "poor_emergence": {
+          "name": "poor_emergence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_shipment_species": {
+          "name": "unique_shipment_species",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipment_items_institution_species": {
+          "name": "idx_shipment_items_institution_species",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_items_institution_id_institutions_id_fk": {
+          "name": "shipment_items_institution_id_institutions_id_fk",
+          "tableFrom": "shipment_items",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shipment_items_butterfly_species_id_butterfly_species_id_fk": {
+          "name": "shipment_items_butterfly_species_id_butterfly_species_id_fk",
+          "tableFrom": "shipment_items",
+          "tableTo": "butterfly_species",
+          "columnsFrom": [
+            "butterfly_species_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fk_shipment_items_shipment_institution": {
+          "name": "fk_shipment_items_shipment_institution",
+          "tableFrom": "shipment_items",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_shipment_item_id_per_institution": {
+          "name": "unique_shipment_item_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipments": {
+      "name": "shipments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_date": {
+          "name": "shipment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrival_date": {
+          "name": "arrival_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shipments_institution_id_institutions_id_fk": {
+          "name": "shipments_institution_id_institutions_id_fk",
+          "tableFrom": "shipments",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_shipments_supplier_code": {
+          "name": "fk_shipments_supplier_code",
+          "tableFrom": "shipments",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_shipment_id_per_institution": {
+          "name": "unique_shipment_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_supplier_code": {
+          "name": "unique_supplier_code",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_institution_id": {
+          "name": "idx_users_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_institution_id_institutions_id_fk": {
+          "name": "users_institution_id_institutions_id_fk",
+          "tableFrom": "users",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775749264952,
       "tag": "0001_icy_hedge_knight",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776553805058,
+      "tag": "0002_young_chameleon",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__test__/api/platform/suppliers.route.test.ts
+++ b/src/__test__/api/platform/suppliers.route.test.ts
@@ -73,13 +73,11 @@ function validCreatePayload() {
     name: "Costa Rica Butterflies",
     code: "CRB",
     country: "CR",
-    institutionId: 1,
   };
 }
 
 const sampleSupplier = {
   id: 1,
-  institutionId: 1,
   name: "Costa Rica Butterflies",
   code: "CRB",
   country: "CR",
@@ -123,19 +121,12 @@ describe("Platform Suppliers API", () => {
       const body = await response.json();
       expect(body.suppliers).toHaveLength(1);
       expect(body.suppliers[0].code).toBe("CRB");
-      expect(mockGetPlatformSuppliers).toHaveBeenCalledWith(undefined);
+      expect(mockGetPlatformSuppliers).toHaveBeenCalledTimes(1);
+      expect(mockGetPlatformSuppliers).toHaveBeenCalledWith();
     });
 
-    it("filters by institutionId when provided", async () => {
-      mockGetPlatformSuppliers.mockResolvedValueOnce([]);
-
+    it("returns 400 when institutionId query is provided", async () => {
       const response = (await getSuppliers(makeGetRequest({ institutionId: "2" })))!;
-      expect(response.status).toBe(200);
-      expect(mockGetPlatformSuppliers).toHaveBeenCalledWith(2);
-    });
-
-    it("returns 400 for invalid institutionId query", async () => {
-      const response = (await getSuppliers(makeGetRequest({ institutionId: "abc" })))!;
       expect(response.status).toBe(400);
       expect((await response.json()).error.code).toBe("INVALID_REQUEST");
     });
@@ -181,27 +172,18 @@ describe("Platform Suppliers API", () => {
       expect((await response.json()).error.code).toBe("CONFLICT");
     });
 
-    it("returns 404 when institutionId does not exist", async () => {
-      mockCreatePlatformSupplier.mockRejectedValueOnce(new Error("Institution not found"));
-
-      const response = (await postSupplier(makePostRequest(validCreatePayload())))!;
-      expect(response.status).toBe(404);
-      expect((await response.json()).error.code).toBe("NOT_FOUND");
-    });
-
     it("returns 400 for missing required fields", async () => {
       const response = (await postSupplier(makePostRequest({ name: "Only name" })))!;
       expect(response.status).toBe(400);
       expect((await response.json()).error.code).toBe("INVALID_REQUEST");
     });
 
-    it("returns 403 when SUPERUSER omits institutionId", async () => {
-      mockCreatePlatformSupplier.mockRejectedValueOnce(new Error("FORBIDDEN"));
-
-      const payload = { name: "Test", code: "TST", country: "US" };
-      const response = (await postSupplier(makePostRequest(payload)))!;
-      expect(response.status).toBe(403);
-      expect((await response.json()).error.code).toBe("FORBIDDEN");
+    it("returns 400 when institutionId is provided in create body", async () => {
+      const response = (await postSupplier(
+        makePostRequest({ ...validCreatePayload(), institutionId: 1 }),
+      ))!;
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.code).toBe("INVALID_REQUEST");
     });
   });
 

--- a/src/__test__/api/tenant/suppliers.route.test.ts
+++ b/src/__test__/api/tenant/suppliers.route.test.ts
@@ -53,7 +53,7 @@ describe("Tenant Suppliers API", () => {
       expect((await response.json()).error.code).toBe("NOT_FOUND");
     });
 
-    it("returns 200 with suppliers list and calls service with slug", async () => {
+    it("returns 200 with global suppliers list and calls service with slug", async () => {
       mockGetTenantSuppliers.mockResolvedValueOnce([
         { id: 1, name: "Supplier One", code: "SUP-1", country: "CR", isActive: true },
       ]);

--- a/src/app/[institution]/(tenant)/shipments/add/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/add/page.tsx
@@ -32,7 +32,11 @@ import { ROUTES } from "@/lib/routes";
 
 import { DatePicker } from "@/components/shared/date-picker";
 import { SpeciesPickerDialog } from "@/components/tenant/shipments/species-picker-dialog";
-import { SupplierSelect, type SupplierOption } from "@/components/tenant/shipments/supplier-select";
+import {
+  SupplierSelect,
+  mapSupplierRowsToOptions,
+  type SupplierOption,
+} from "@/components/tenant/shipments/supplier-select";
 import type { SpeciesPickerOption } from "@/components/tenant/shipments/types";
 
 type ShipmentItemForm = {
@@ -149,20 +153,23 @@ export default function AddShipmentPage() {
           fetch("/api/tenant/suppliers", { headers: tenantHeaders, signal: ac.signal }),
           fetch("/api/tenant/species", { headers: tenantHeaders, signal: ac.signal }),
         ]);
+
+        if (!supRes.ok) {
+          throw new Error("Unable to load suppliers.");
+        }
+        if (!spRes.ok) {
+          throw new Error("Unable to load species.");
+        }
+
         const supJson = await supRes.json().catch(() => null);
         const spJson = await spRes.json().catch(() => null);
 
-        const supplierRows = Array.isArray(supJson?.suppliers) ? supJson.suppliers : [];
-        setSuppliers(
-          supplierRows
-            .filter((s: { code?: unknown }) => typeof s.code === "string")
-            .map((s: { id: number; code: string; name?: string; isActive?: boolean }) => ({
-              id: s.id,
-              code: s.code,
-              name: s.name ?? s.code,
-              isActive: s.isActive ?? true,
-            })),
-        );
+        const supplierRows = Array.isArray(supJson?.suppliers)
+          ? supJson.suppliers
+          : Array.isArray(supJson?.data?.suppliers)
+            ? supJson.data.suppliers
+            : [];
+        setSuppliers(mapSupplierRowsToOptions(supplierRows));
 
         const speciesRows = Array.isArray(spJson?.species) ? spJson.species : [];
         setSpecies(
@@ -195,7 +202,7 @@ export default function AddShipmentPage() {
       } catch (err) {
         if (ac.signal.aborted) return;
         if (err instanceof DOMException && err.name === "AbortError") return;
-        // Errors surface as empty dropdowns; the user can retry by reloading.
+        setErrorMessage(err instanceof Error ? err.message : "Unable to load shipment form data.");
       }
     })();
     return () => ac.abort();

--- a/src/app/api/platform/suppliers/[id]/route.ts
+++ b/src/app/api/platform/suppliers/[id]/route.ts
@@ -68,8 +68,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       if (error.message === "UNAUTHORIZED") return unauthorized();
       if (error.message === "FORBIDDEN") return forbidden();
       if (error.message === "NOT_FOUND") return notFound("Supplier not found");
-      if (error.message === "CONFLICT")
-        return conflict("Supplier code already exists for this institution");
+      if (error.message === "CONFLICT") return conflict("Supplier code already exists");
       if (error.message === SUPPLIER_ERRORS.REFERENCED_BY_SHIPMENTS) return conflict(error.message);
     }
 

--- a/src/app/api/platform/suppliers/route.ts
+++ b/src/app/api/platform/suppliers/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest } from "next/server";
 
 import { logger } from "@/lib/logger";
-import { conflict, forbidden, internalError, notFound, ok, unauthorized } from "@/lib/api-response";
-import { TENANT_ERRORS } from "@/lib/tenant";
+import { conflict, forbidden, internalError, ok, unauthorized } from "@/lib/api-response";
 import { requireValidBody } from "@/lib/validation/request";
 import { requireValidQuery } from "@/lib/validation/query";
 import { createSupplierBodySchema, listSuppliersQuerySchema } from "@/lib/validation/suppliers";
@@ -17,7 +16,7 @@ export async function GET(request: NextRequest) {
     );
     if ("error" in queryResult) return queryResult.error;
 
-    const suppliers = await getPlatformSuppliers(queryResult.data.institutionId);
+    const suppliers = await getPlatformSuppliers();
 
     return ok({ suppliers });
   } catch (error) {
@@ -43,10 +42,7 @@ export async function POST(request: NextRequest) {
     if (error instanceof Error) {
       if (error.message === "UNAUTHORIZED") return unauthorized();
       if (error.message === "FORBIDDEN") return forbidden();
-      if (error.message === TENANT_ERRORS.INSTITUTION_NOT_FOUND)
-        return notFound("Institution not found");
-      if (error.message === "CONFLICT")
-        return conflict("Supplier code already exists for this institution");
+      if (error.message === "CONFLICT") return conflict("Supplier code already exists");
     }
 
     logger.error("Unexpected POST /platform/suppliers error:", error);

--- a/src/components/tenant/shipments/__test__/supplier-options.test.ts
+++ b/src/components/tenant/shipments/__test__/supplier-options.test.ts
@@ -1,0 +1,27 @@
+import { mapSupplierRowsToOptions } from "@/components/tenant/shipments/supplier-options";
+
+describe("mapSupplierRowsToOptions", () => {
+  it("maps camelCase supplier API rows for the shipment supplier dropdown", () => {
+    expect(
+      mapSupplierRowsToOptions([{ id: 1, code: "EBN", name: "El Bosque Nuevo", isActive: true }]),
+    ).toEqual([{ id: 1, code: "EBN", name: "El Bosque Nuevo", isActive: true }]);
+  });
+
+  it("accepts snake_case active flags and keeps inactive suppliers visible", () => {
+    expect(
+      mapSupplierRowsToOptions([
+        { id: "2", code: " LPSS ", name: " Legacy Supplier ", is_active: false },
+      ]),
+    ).toEqual([{ id: 2, code: "LPSS", name: "Legacy Supplier", isActive: false }]);
+  });
+
+  it("drops malformed rows instead of poisoning the dropdown", () => {
+    expect(
+      mapSupplierRowsToOptions([
+        { id: 0, code: "BAD", name: "Bad" },
+        { id: 3, code: "", name: "Missing Code" },
+        { id: 4, code: "LPS" },
+      ]),
+    ).toEqual([{ id: 4, code: "LPS", name: "LPS", isActive: true }]);
+  });
+});

--- a/src/components/tenant/shipments/supplier-options.ts
+++ b/src/components/tenant/shipments/supplier-options.ts
@@ -1,0 +1,44 @@
+export type SupplierOption = {
+  id: number;
+  code: string;
+  name: string;
+  isActive: boolean;
+};
+
+type SupplierApiRow = {
+  id?: unknown;
+  code?: unknown;
+  name?: unknown;
+  isActive?: unknown;
+  is_active?: unknown;
+};
+
+export function mapSupplierRowsToOptions(rows: unknown): SupplierOption[] {
+  if (!Array.isArray(rows)) return [];
+
+  return rows
+    .map((row): SupplierOption | null => {
+      const supplier = row as SupplierApiRow;
+      const id = typeof supplier.id === "number" ? supplier.id : Number(supplier.id);
+      const code = typeof supplier.code === "string" ? supplier.code.trim() : "";
+
+      if (!Number.isFinite(id) || id <= 0 || !code) return null;
+
+      const name =
+        typeof supplier.name === "string" && supplier.name.trim() ? supplier.name.trim() : code;
+      const isActive =
+        typeof supplier.isActive === "boolean"
+          ? supplier.isActive
+          : typeof supplier.is_active === "boolean"
+            ? supplier.is_active
+            : true;
+
+      return {
+        id,
+        code,
+        name,
+        isActive,
+      };
+    })
+    .filter((supplier): supplier is SupplierOption => supplier !== null);
+}

--- a/src/components/tenant/shipments/supplier-select.tsx
+++ b/src/components/tenant/shipments/supplier-select.tsx
@@ -13,14 +13,13 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { type SupplierOption } from "@/components/tenant/shipments/supplier-options";
 import { cn } from "@/lib/utils";
 
-export type SupplierOption = {
-  id: number;
-  code: string;
-  name: string;
-  isActive: boolean;
-};
+export {
+  mapSupplierRowsToOptions,
+  type SupplierOption,
+} from "@/components/tenant/shipments/supplier-options";
 
 interface SupplierSelectProps {
   /** Supplier list, typically loaded from /api/tenant/suppliers. */

--- a/src/lib/__test__/schema.test.ts
+++ b/src/lib/__test__/schema.test.ts
@@ -123,7 +123,6 @@ describe("schema", () => {
     it("has required columns", () => {
       const columns = Object.keys(suppliers);
       expect(columns).toContain("id");
-      expect(columns).toContain("institution_id");
       expect(columns).toContain("name");
       expect(columns).toContain("code");
       expect(columns).toContain("country");

--- a/src/lib/__test__/shipment-import-parser.test.ts
+++ b/src/lib/__test__/shipment-import-parser.test.ts
@@ -69,6 +69,18 @@ describe("shipment-import-parser", () => {
       ).toBe(true);
     });
 
+    it("preserves imported supplier value case while trimming outer whitespace", () => {
+      const input = [
+        "Species,No. rec,Supplier,Ship date,Arrival date",
+        "Caligo atreus,10, lps historical ,12/11/25,12/11/25",
+      ].join("\n");
+
+      const result = parseShipmentImportRows(input);
+
+      expect(result.rowErrors).toHaveLength(0);
+      expect(result.rows[0]?.supplierCode).toBe("lps historical");
+    });
+
     it("treats blank No. rec as 0 for legacy compatibility", () => {
       const input = [
         "Species,No. rec,Supplier,Ship date,Arrival date,Emerg. in tr,Damag in tr,No. disea,No. parasit,No emerg,Poor emerg",

--- a/src/lib/__test__/shipment-import-service.test.ts
+++ b/src/lib/__test__/shipment-import-service.test.ts
@@ -1,0 +1,170 @@
+import { createHash } from "node:crypto";
+
+jest.mock("@/auth", () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock("@/lib/queries/shipments", () => ({
+  createShipment: jest.fn(),
+  listShipmentExportRows: jest.fn(),
+  shipmentHeaderExists: jest.fn(),
+}));
+
+jest.mock("@/lib/queries/species", () => ({
+  createSpecies: jest.fn(),
+  ensureSpeciesLinksForInstitution: jest.fn(),
+  listSpeciesGlobal: jest.fn(),
+}));
+
+jest.mock("@/lib/queries/suppliers", () => ({
+  ensureSupplierExistsForGlobalImport: jest.fn(),
+  ensureSupplierExistsForTenant: jest.fn(),
+  listSuppliersForPlatform: jest.fn(),
+  listSuppliersGlobal: jest.fn(),
+}));
+
+import {
+  buildShipmentImportPreviewForInstitution,
+  commitShipmentImportForInstitution,
+} from "@/lib/services/shipment-import";
+import { createShipment, shipmentHeaderExists } from "@/lib/queries/shipments";
+import { ensureSpeciesLinksForInstitution, listSpeciesGlobal } from "@/lib/queries/species";
+import {
+  ensureSupplierExistsForGlobalImport,
+  listSuppliersForPlatform,
+  listSuppliersGlobal,
+} from "@/lib/queries/suppliers";
+import type { ShipmentImportDraft } from "@/lib/validation/shipment-import";
+
+const mockCreateShipment = createShipment as jest.Mock;
+const mockShipmentHeaderExists = shipmentHeaderExists as jest.Mock;
+const mockEnsureSpeciesLinksForInstitution = ensureSpeciesLinksForInstitution as jest.Mock;
+const mockListSpeciesGlobal = listSpeciesGlobal as jest.Mock;
+const mockEnsureSupplierExistsForGlobalImport = ensureSupplierExistsForGlobalImport as jest.Mock;
+const mockListSuppliersForPlatform = listSuppliersForPlatform as jest.Mock;
+const mockListSuppliersGlobal = listSuppliersGlobal as jest.Mock;
+
+function buildPreviewHash(institutionId: number, shipments: ShipmentImportDraft[]) {
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify({ institution_id: institutionId, shipments }))
+    .digest("hex")}`;
+}
+
+function shipmentDraft(supplierCode = "EBN"): ShipmentImportDraft {
+  return {
+    supplier_code: supplierCode,
+    shipment_date: "2025-12-09T12:00:00.000Z",
+    arrival_date: "2025-12-11T12:00:00.000Z",
+    items: [
+      {
+        scientific_name: "caligo atreus",
+        number_received: 10,
+        emerged_in_transit: 0,
+        damaged_in_transit: 0,
+        diseased_in_transit: 0,
+        parasite: 0,
+        non_emergence: 0,
+        poor_emergence: 0,
+      },
+    ],
+  };
+}
+
+describe("shipment import service", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("buildShipmentImportPreviewForInstitution", () => {
+    it("checks supplier existence against the global supplier list", async () => {
+      mockListSpeciesGlobal.mockResolvedValueOnce([{ id: 1, scientificName: "Caligo atreus" }]);
+      mockListSuppliersGlobal.mockResolvedValueOnce([{ id: 10, code: "EBN" }]);
+
+      const preview = await buildShipmentImportPreviewForInstitution({
+        institutionId: 1,
+        raw_text: [
+          "Species,No. rec,Supplier,Ship date,Arrival date",
+          "Caligo atreus,10,EBN,12/9/25,12/11/25",
+        ].join("\n"),
+        source: { kind: "paste" },
+      });
+
+      expect(mockListSuppliersGlobal).toHaveBeenCalledTimes(1);
+      expect(mockListSuppliersForPlatform).not.toHaveBeenCalled();
+      expect(preview.summary.unknown_suppliers).toBe(0);
+      expect(preview.unknown_suppliers).toEqual([]);
+    });
+  });
+
+  describe("commitShipmentImportForInstitution", () => {
+    it("ensures supplier codes through the global import helper before creating shipments", async () => {
+      const shipments = [shipmentDraft("EBN")];
+      mockListSpeciesGlobal.mockResolvedValueOnce([{ id: 1, scientificName: "Caligo atreus" }]);
+      mockListSuppliersGlobal.mockResolvedValueOnce([{ id: 10, code: "EBN" }]);
+      mockEnsureSupplierExistsForGlobalImport.mockResolvedValueOnce({
+        id: 10,
+        code: "EBN",
+        wasGloballyMissing: false,
+        wasCompatibilityCreated: true,
+      });
+      mockEnsureSpeciesLinksForInstitution.mockResolvedValueOnce(undefined);
+      mockShipmentHeaderExists.mockResolvedValueOnce(false);
+      mockCreateShipment.mockResolvedValueOnce(123);
+
+      const summary = await commitShipmentImportForInstitution({
+        institutionId: 1,
+        preview_hash: buildPreviewHash(1, shipments),
+        shipments,
+      });
+
+      expect(mockListSuppliersGlobal).toHaveBeenCalledTimes(1);
+      expect(mockListSuppliersForPlatform).not.toHaveBeenCalled();
+      expect(mockEnsureSupplierExistsForGlobalImport).toHaveBeenCalledWith(1, "EBN", {
+        name: "EBN",
+        country: "Unknown",
+        websiteUrl: null,
+      });
+      expect(mockCreateShipment).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ supplier_code: "EBN" }),
+      );
+      expect(summary).toEqual({ created: 1, failed: 0, skipped: 0, failures: [], warnings: [] });
+    });
+
+    it("warns when commit auto-creates a globally missing supplier as inactive", async () => {
+      const shipments = [shipmentDraft("NEW")];
+      mockListSpeciesGlobal.mockResolvedValueOnce([{ id: 1, scientificName: "Caligo atreus" }]);
+      mockListSuppliersGlobal.mockResolvedValueOnce([]);
+      mockEnsureSupplierExistsForGlobalImport.mockResolvedValueOnce({
+        id: 25,
+        code: "NEW",
+        wasGloballyMissing: true,
+        wasCompatibilityCreated: true,
+      });
+      mockEnsureSpeciesLinksForInstitution.mockResolvedValueOnce(undefined);
+      mockShipmentHeaderExists.mockResolvedValueOnce(false);
+      mockCreateShipment.mockResolvedValueOnce(123);
+
+      const summary = await commitShipmentImportForInstitution({
+        institutionId: 1,
+        preview_hash: buildPreviewHash(1, shipments),
+        shipments,
+      });
+
+      expect(mockEnsureSupplierExistsForGlobalImport).toHaveBeenCalledWith(1, "NEW", {
+        name: "NEW",
+        country: "Unknown",
+        websiteUrl: null,
+      });
+      expect(mockCreateShipment).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ supplier_code: "NEW" }),
+      );
+      expect(summary.created).toBe(1);
+      expect(summary.failed).toBe(0);
+      expect(summary.warnings).toEqual([
+        "Supplier NEW was auto-created as inactive for global review.",
+      ]);
+    });
+  });
+});

--- a/src/lib/__test__/shipment-import-service.test.ts
+++ b/src/lib/__test__/shipment-import-service.test.ts
@@ -115,7 +115,6 @@ describe("shipment import service", () => {
         id: 10,
         code: "EBN",
         wasGloballyMissing: false,
-        wasCompatibilityCreated: true,
       });
       mockEnsureSpeciesLinksForInstitution.mockResolvedValueOnce(undefined);
       mockShipmentHeaderExists.mockResolvedValueOnce(false);
@@ -148,7 +147,6 @@ describe("shipment import service", () => {
         id: 25,
         code: "NEW",
         wasGloballyMissing: true,
-        wasCompatibilityCreated: true,
       });
       mockEnsureSpeciesLinksForInstitution.mockResolvedValueOnce(undefined);
       mockShipmentHeaderExists.mockResolvedValueOnce(false);
@@ -184,7 +182,6 @@ describe("shipment import service", () => {
         id: 26,
         code: "lps historical",
         wasGloballyMissing: true,
-        wasCompatibilityCreated: false,
       });
       mockEnsureSpeciesLinksForInstitution.mockResolvedValueOnce(undefined);
       mockShipmentHeaderExists.mockResolvedValueOnce(false);

--- a/src/lib/__test__/shipment-import-service.test.ts
+++ b/src/lib/__test__/shipment-import-service.test.ts
@@ -86,6 +86,24 @@ describe("shipment import service", () => {
       expect(preview.summary.unknown_suppliers).toBe(0);
       expect(preview.unknown_suppliers).toEqual([]);
     });
+
+    it("preserves imported supplier casing and checks exact global code existence", async () => {
+      mockListSpeciesGlobal.mockResolvedValueOnce([{ id: 1, scientificName: "Caligo atreus" }]);
+      mockListSuppliersGlobal.mockResolvedValueOnce([{ id: 10, code: "EBN" }]);
+
+      const preview = await buildShipmentImportPreviewForInstitution({
+        institutionId: 1,
+        raw_text: [
+          "Species,No. rec,Supplier,Ship date,Arrival date",
+          "Caligo atreus,10, ebn legacy ,12/9/25,12/11/25",
+        ].join("\n"),
+        source: { kind: "paste" },
+      });
+
+      expect(preview.shipments[0]?.supplier_code).toBe("ebn legacy");
+      expect(preview.summary.unknown_suppliers).toBe(1);
+      expect(preview.unknown_suppliers).toEqual(["ebn legacy"]);
+    });
   });
 
   describe("commitShipmentImportForInstitution", () => {
@@ -155,6 +173,42 @@ describe("shipment import service", () => {
       expect(summary.failed).toBe(0);
       expect(summary.warnings).toEqual([
         "Supplier NEW was auto-created as inactive for global review.",
+      ]);
+    });
+
+    it("creates and stores missing import suppliers with the exact trimmed imported value", async () => {
+      const shipments = [shipmentDraft(" lps historical ")];
+      mockListSpeciesGlobal.mockResolvedValueOnce([{ id: 1, scientificName: "Caligo atreus" }]);
+      mockListSuppliersGlobal.mockResolvedValueOnce([]);
+      mockEnsureSupplierExistsForGlobalImport.mockResolvedValueOnce({
+        id: 26,
+        code: "lps historical",
+        wasGloballyMissing: true,
+        wasCompatibilityCreated: false,
+      });
+      mockEnsureSpeciesLinksForInstitution.mockResolvedValueOnce(undefined);
+      mockShipmentHeaderExists.mockResolvedValueOnce(false);
+      mockCreateShipment.mockResolvedValueOnce(123);
+
+      const summary = await commitShipmentImportForInstitution({
+        institutionId: 1,
+        preview_hash: buildPreviewHash(1, shipments),
+        shipments,
+      });
+
+      expect(mockEnsureSupplierExistsForGlobalImport).toHaveBeenCalledWith("lps historical", {
+        name: "lps historical",
+        country: "Unknown",
+        websiteUrl: null,
+      });
+      expect(mockCreateShipment).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ supplier_code: "lps historical" }),
+      );
+      expect(summary.created).toBe(1);
+      expect(summary.failed).toBe(0);
+      expect(summary.warnings).toEqual([
+        "Supplier lps historical was auto-created as inactive for global review.",
       ]);
     });
   });

--- a/src/lib/__test__/shipment-import-service.test.ts
+++ b/src/lib/__test__/shipment-import-service.test.ts
@@ -18,8 +18,6 @@ jest.mock("@/lib/queries/species", () => ({
 
 jest.mock("@/lib/queries/suppliers", () => ({
   ensureSupplierExistsForGlobalImport: jest.fn(),
-  ensureSupplierExistsForTenant: jest.fn(),
-  listSuppliersForPlatform: jest.fn(),
   listSuppliersGlobal: jest.fn(),
 }));
 
@@ -29,11 +27,7 @@ import {
 } from "@/lib/services/shipment-import";
 import { createShipment, shipmentHeaderExists } from "@/lib/queries/shipments";
 import { ensureSpeciesLinksForInstitution, listSpeciesGlobal } from "@/lib/queries/species";
-import {
-  ensureSupplierExistsForGlobalImport,
-  listSuppliersForPlatform,
-  listSuppliersGlobal,
-} from "@/lib/queries/suppliers";
+import { ensureSupplierExistsForGlobalImport, listSuppliersGlobal } from "@/lib/queries/suppliers";
 import type { ShipmentImportDraft } from "@/lib/validation/shipment-import";
 
 const mockCreateShipment = createShipment as jest.Mock;
@@ -41,7 +35,6 @@ const mockShipmentHeaderExists = shipmentHeaderExists as jest.Mock;
 const mockEnsureSpeciesLinksForInstitution = ensureSpeciesLinksForInstitution as jest.Mock;
 const mockListSpeciesGlobal = listSpeciesGlobal as jest.Mock;
 const mockEnsureSupplierExistsForGlobalImport = ensureSupplierExistsForGlobalImport as jest.Mock;
-const mockListSuppliersForPlatform = listSuppliersForPlatform as jest.Mock;
 const mockListSuppliersGlobal = listSuppliersGlobal as jest.Mock;
 
 function buildPreviewHash(institutionId: number, shipments: ShipmentImportDraft[]) {
@@ -90,7 +83,6 @@ describe("shipment import service", () => {
       });
 
       expect(mockListSuppliersGlobal).toHaveBeenCalledTimes(1);
-      expect(mockListSuppliersForPlatform).not.toHaveBeenCalled();
       expect(preview.summary.unknown_suppliers).toBe(0);
       expect(preview.unknown_suppliers).toEqual([]);
     });
@@ -118,8 +110,7 @@ describe("shipment import service", () => {
       });
 
       expect(mockListSuppliersGlobal).toHaveBeenCalledTimes(1);
-      expect(mockListSuppliersForPlatform).not.toHaveBeenCalled();
-      expect(mockEnsureSupplierExistsForGlobalImport).toHaveBeenCalledWith(1, "EBN", {
+      expect(mockEnsureSupplierExistsForGlobalImport).toHaveBeenCalledWith("EBN", {
         name: "EBN",
         country: "Unknown",
         websiteUrl: null,
@@ -151,7 +142,7 @@ describe("shipment import service", () => {
         shipments,
       });
 
-      expect(mockEnsureSupplierExistsForGlobalImport).toHaveBeenCalledWith(1, "NEW", {
+      expect(mockEnsureSupplierExistsForGlobalImport).toHaveBeenCalledWith("NEW", {
         name: "NEW",
         country: "Unknown",
         websiteUrl: null,

--- a/src/lib/__test__/supplier-queries.test.ts
+++ b/src/lib/__test__/supplier-queries.test.ts
@@ -1,0 +1,49 @@
+const mockLimit = jest.fn();
+const mockWhere = jest.fn(() => ({ limit: mockLimit }));
+const mockFrom = jest.fn(() => ({ where: mockWhere }));
+const mockSelect = jest.fn(() => ({ from: mockFrom }));
+const mockReturning = jest.fn();
+const mockValues = jest.fn(() => ({ returning: mockReturning }));
+const mockInsert = jest.fn(() => ({ values: mockValues }));
+
+jest.mock("@/lib/db", () => ({
+  db: {
+    select: mockSelect,
+    insert: mockInsert,
+  },
+}));
+
+import { ensureSupplierExistsForGlobalImport } from "@/lib/queries/suppliers";
+
+describe("supplier queries", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("ensureSupplierExistsForGlobalImport", () => {
+    it("auto-creates missing import suppliers using the exact trimmed code", async () => {
+      mockLimit.mockResolvedValueOnce([]);
+      mockReturning.mockResolvedValueOnce([{ id: 42, code: "lps historical" }]);
+
+      const supplier = await ensureSupplierExistsForGlobalImport(" lps historical ", {
+        name: "lps historical",
+        country: "Unknown",
+        websiteUrl: null,
+      });
+
+      expect(mockValues).toHaveBeenCalledWith({
+        code: "lps historical",
+        name: "lps historical",
+        country: "Unknown",
+        website_url: null,
+        is_active: false,
+      });
+      expect(supplier).toEqual({
+        id: 42,
+        code: "lps historical",
+        wasGloballyMissing: true,
+        wasCompatibilityCreated: false,
+      });
+    });
+  });
+});

--- a/src/lib/__test__/supplier-queries.test.ts
+++ b/src/lib/__test__/supplier-queries.test.ts
@@ -3,7 +3,8 @@ const mockWhere = jest.fn(() => ({ limit: mockLimit }));
 const mockFrom = jest.fn(() => ({ where: mockWhere }));
 const mockSelect = jest.fn(() => ({ from: mockFrom }));
 const mockReturning = jest.fn();
-const mockValues = jest.fn(() => ({ returning: mockReturning }));
+const mockOnConflictDoNothing = jest.fn(() => ({ returning: mockReturning }));
+const mockValues = jest.fn(() => ({ onConflictDoNothing: mockOnConflictDoNothing }));
 const mockInsert = jest.fn(() => ({ values: mockValues }));
 
 jest.mock("@/lib/db", () => ({
@@ -42,7 +43,27 @@ describe("supplier queries", () => {
         id: 42,
         code: "lps historical",
         wasGloballyMissing: true,
-        wasCompatibilityCreated: false,
+      });
+    });
+
+    it("returns the existing row when a concurrent insert wins the race", async () => {
+      // Initial select: no match
+      mockLimit.mockResolvedValueOnce([]);
+      // onConflictDoNothing insert: no-op (concurrent process inserted first)
+      mockReturning.mockResolvedValueOnce([]);
+      // Re-select: finds the row inserted by the other process
+      mockLimit.mockResolvedValueOnce([{ id: 42, code: "lps historical" }]);
+
+      const supplier = await ensureSupplierExistsForGlobalImport(" lps historical ", {
+        name: "lps historical",
+        country: "Unknown",
+        websiteUrl: null,
+      });
+
+      expect(supplier).toEqual({
+        id: 42,
+        code: "lps historical",
+        wasGloballyMissing: true,
       });
     });
   });

--- a/src/lib/__test__/tenant-suppliers-service.test.ts
+++ b/src/lib/__test__/tenant-suppliers-service.test.ts
@@ -1,0 +1,44 @@
+jest.mock("@/auth", () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock("@/lib/tenant", () => ({
+  resolveTenantBySlug: jest.fn(),
+}));
+
+jest.mock("@/lib/queries/suppliers", () => ({
+  listSuppliersGlobal: jest.fn(),
+}));
+
+import { auth } from "@/auth";
+import { listSuppliersGlobal } from "@/lib/queries/suppliers";
+import { getTenantSuppliers } from "@/lib/services/tenant-suppliers";
+import { resolveTenantBySlug } from "@/lib/tenant";
+
+const mockAuth = auth as jest.Mock;
+const mockResolveTenantBySlug = resolveTenantBySlug as jest.Mock;
+const mockListSuppliersGlobal = listSuppliersGlobal as jest.Mock;
+
+describe("tenant suppliers service", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("resolves the tenant slug but returns the global supplier list without tenant filtering", async () => {
+    const user = { id: "1", role: "ADMIN", institutionId: 7 };
+    const suppliers = [{ id: 1, code: "EBN", name: "El Bosque Nuevo", isActive: true }];
+
+    mockAuth.mockResolvedValueOnce({
+      user,
+      expires: new Date(Date.now() + 60_000).toISOString(),
+    });
+    mockResolveTenantBySlug.mockResolvedValueOnce(7);
+    mockListSuppliersGlobal.mockResolvedValueOnce(suppliers);
+
+    await expect(getTenantSuppliers({ slug: "butterfly-house" })).resolves.toBe(suppliers);
+
+    expect(mockResolveTenantBySlug).toHaveBeenCalledWith(user, "butterfly-house");
+    expect(mockListSuppliersGlobal).toHaveBeenCalledTimes(1);
+    expect(mockListSuppliersGlobal).toHaveBeenCalledWith();
+  });
+});

--- a/src/lib/queries/suppliers.ts
+++ b/src/lib/queries/suppliers.ts
@@ -153,7 +153,7 @@ export async function ensureSupplierExistsForGlobalImport(
     websiteUrl?: string | null;
   },
 ) {
-  const normalizedCode = code.toUpperCase();
+  const supplierCode = code.trim();
 
   const [globalMatch] = await db
     .select({
@@ -161,7 +161,7 @@ export async function ensureSupplierExistsForGlobalImport(
       code: suppliers.code,
     })
     .from(suppliers)
-    .where(eq(suppliers.code, normalizedCode))
+    .where(eq(suppliers.code, supplierCode))
     .limit(1);
 
   if (globalMatch) {
@@ -175,8 +175,8 @@ export async function ensureSupplierExistsForGlobalImport(
   const [created] = await db
     .insert(suppliers)
     .values({
-      code: normalizedCode,
-      name: fallbackData?.name ?? normalizedCode,
+      code: supplierCode,
+      name: fallbackData?.name ?? supplierCode,
       country: fallbackData?.country ?? "Unknown",
       website_url: fallbackData?.websiteUrl ?? null,
       is_active: false,

--- a/src/lib/queries/suppliers.ts
+++ b/src/lib/queries/suppliers.ts
@@ -20,32 +20,12 @@ const supplierSelect = {
 };
 
 /**
- * TENANT COMPATIBILITY QUERY
- *
- * Suppliers are global in Phase 1. Keep this function signature so tenant
- * callers can migrate gradually while receiving the global supplier list.
- */
-export async function listSuppliersForTenant(_institutionId: number) {
-  return db.select(supplierSelect).from(suppliers).orderBy(suppliers.name);
-}
-
-/**
  * GLOBAL QUERY
  *
  * List all global supplier rows by code.
  */
 export async function listSuppliersGlobal() {
   return db.select(supplierSelect).from(suppliers).orderBy(desc(suppliers.created_at));
-}
-
-/**
- * PLATFORM QUERY
- *
- * List all global suppliers. The optional institutionId parameter is accepted
- * temporarily for route compatibility and ignored.
- */
-export async function listSuppliersForPlatform(_institutionId?: number) {
-  return listSuppliersGlobal();
 }
 
 /**
@@ -65,11 +45,7 @@ export async function getSupplierById(supplierId: number) {
  * Check if a supplier code already exists globally.
  * Optionally exclude a supplier ID (for update uniqueness checks).
  */
-export async function supplierCodeExistsForTenant(
-  _institutionId: number,
-  code: string,
-  excludeId?: number,
-) {
+export async function supplierCodeExists(code: string, excludeId?: number) {
   const condition = excludeId
     ? and(eq(suppliers.code, code), ne(suppliers.id, excludeId))
     : eq(suppliers.code, code);
@@ -82,10 +58,9 @@ export async function supplierCodeExistsForTenant(
 /**
  * PLATFORM QUERY
  *
- * Create a new global supplier. The institutionId parameter is accepted
- * temporarily for route/service compatibility and ignored.
+ * Create a new global supplier.
  */
-export async function createSupplier(_institutionId: number, input: CreateSupplierBody) {
+export async function createSupplier(input: CreateSupplierBody) {
   const [row] = await db
     .insert(suppliers)
     .values({
@@ -165,60 +140,12 @@ function isForeignKeyViolation(error: unknown): boolean {
 }
 
 /**
- * IMPORT COMPATIBILITY QUERY
- *
- * Ensure a global supplier with the given code exists. Keep this old function
- * name temporarily so callers can migrate gradually.
- */
-export async function ensureSupplierExistsForTenant(
-  _tenantId: number,
-  code: string,
-  fallbackData?: {
-    name?: string;
-    country?: string;
-    websiteUrl?: string | null;
-  },
-) {
-  const normalizedCode = code.toUpperCase();
-
-  const [existing] = await db
-    .select({
-      id: suppliers.id,
-      code: suppliers.code,
-    })
-    .from(suppliers)
-    .where(eq(suppliers.code, normalizedCode))
-    .limit(1);
-
-  if (existing) {
-    return existing;
-  }
-
-  const [created] = await db
-    .insert(suppliers)
-    .values({
-      code: normalizedCode,
-      name: fallbackData?.name ?? normalizedCode,
-      country: fallbackData?.country ?? "Unknown",
-      website_url: fallbackData?.websiteUrl ?? null,
-      is_active: false,
-    })
-    .returning({
-      id: suppliers.id,
-      code: suppliers.code,
-    });
-
-  return created;
-}
-
-/**
  * GLOBAL QUERY
  *
  * Ensure a global supplier code exists for import commit, creating missing
  * codes as inactive for later platform review.
  */
 export async function ensureSupplierExistsForGlobalImport(
-  _tenantId: number,
   code: string,
   fallbackData?: {
     name?: string;

--- a/src/lib/queries/suppliers.ts
+++ b/src/lib/queries/suppliers.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, ne } from "drizzle-orm";
+import { and, asc, eq, ne } from "drizzle-orm";
 
 import { db } from "@/lib/db";
 import { suppliers } from "@/lib/schema";
@@ -22,10 +22,10 @@ const supplierSelect = {
 /**
  * GLOBAL QUERY
  *
- * List all global supplier rows by code.
+ * List all global supplier rows ordered alphabetically by code.
  */
 export async function listSuppliersGlobal() {
-  return db.select(supplierSelect).from(suppliers).orderBy(desc(suppliers.created_at));
+  return db.select(supplierSelect).from(suppliers).orderBy(asc(suppliers.code));
 }
 
 /**
@@ -61,18 +61,23 @@ export async function supplierCodeExists(code: string, excludeId?: number) {
  * Create a new global supplier.
  */
 export async function createSupplier(input: CreateSupplierBody) {
-  const [row] = await db
-    .insert(suppliers)
-    .values({
-      name: input.name,
-      code: input.code,
-      country: input.country,
-      website_url: input.website_url ?? null,
-      is_active: input.is_active ?? true,
-    })
-    .returning(supplierSelect);
+  try {
+    const [row] = await db
+      .insert(suppliers)
+      .values({
+        name: input.name,
+        code: input.code,
+        country: input.country,
+        website_url: input.website_url ?? null,
+        is_active: input.is_active ?? true,
+      })
+      .returning(supplierSelect);
 
-  return row;
+    return row;
+  } catch (error: unknown) {
+    if (isUniqueViolation(error)) throw new Error("CONFLICT");
+    throw error;
+  }
 }
 
 /**
@@ -98,9 +103,8 @@ export async function updateSupplier(supplierId: number, input: UpdateSupplierBo
 
     return row ?? null;
   } catch (error: unknown) {
-    if (isForeignKeyViolation(error)) {
-      throw new Error(SUPPLIER_ERRORS.REFERENCED_BY_SHIPMENTS);
-    }
+    if (isUniqueViolation(error)) throw new Error("CONFLICT");
+    if (isForeignKeyViolation(error)) throw new Error(SUPPLIER_ERRORS.REFERENCED_BY_SHIPMENTS);
     throw error;
   }
 }
@@ -140,6 +144,18 @@ function isForeignKeyViolation(error: unknown): boolean {
 }
 
 /**
+ * Detect PostgreSQL unique constraint violation (error code 23505).
+ */
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code: unknown }).code === "23505"
+  );
+}
+
+/**
  * GLOBAL QUERY
  *
  * Ensure a global supplier code exists for import commit, creating missing
@@ -168,7 +184,6 @@ export async function ensureSupplierExistsForGlobalImport(
     return {
       ...globalMatch,
       wasGloballyMissing: false,
-      wasCompatibilityCreated: false,
     };
   }
 
@@ -181,14 +196,22 @@ export async function ensureSupplierExistsForGlobalImport(
       website_url: fallbackData?.websiteUrl ?? null,
       is_active: false,
     })
+    .onConflictDoNothing()
     .returning({
       id: suppliers.id,
       code: suppliers.code,
     });
 
-  return {
-    ...created,
-    wasGloballyMissing: true,
-    wasCompatibilityCreated: false,
-  };
+  if (created) {
+    return { ...created, wasGloballyMissing: true };
+  }
+
+  // Race: another process inserted first — re-select the winning row.
+  const [existing] = await db
+    .select({ id: suppliers.id, code: suppliers.code })
+    .from(suppliers)
+    .where(eq(suppliers.code, supplierCode))
+    .limit(1);
+
+  return { ...existing!, wasGloballyMissing: true };
 }

--- a/src/lib/queries/suppliers.ts
+++ b/src/lib/queries/suppliers.ts
@@ -9,72 +9,43 @@ export const SUPPLIER_ERRORS = {
   REFERENCED_BY_SHIPMENTS: "Supplier is referenced by existing shipments",
 } as const;
 
+const supplierSelect = {
+  id: suppliers.id,
+  name: suppliers.name,
+  code: suppliers.code,
+  country: suppliers.country,
+  websiteUrl: suppliers.website_url,
+  isActive: suppliers.is_active,
+  createdAt: suppliers.created_at,
+};
+
 /**
- * TENANT QUERY
+ * TENANT COMPATIBILITY QUERY
  *
- * List all suppliers for a tenant.
+ * Suppliers are global in Phase 1. Keep this function signature so tenant
+ * callers can migrate gradually while receiving the global supplier list.
  */
-export async function listSuppliersForTenant(institutionId: number) {
-  return db
-    .select({
-      id: suppliers.id,
-      name: suppliers.name,
-      code: suppliers.code,
-      country: suppliers.country,
-      websiteUrl: suppliers.website_url,
-      isActive: suppliers.is_active,
-      createdAt: suppliers.created_at,
-    })
-    .from(suppliers)
-    .where(eq(suppliers.institution_id, institutionId))
-    .orderBy(suppliers.name);
+export async function listSuppliersForTenant(_institutionId: number) {
+  return db.select(supplierSelect).from(suppliers).orderBy(suppliers.name);
 }
 
 /**
- * GLOBAL TRANSITION QUERY
+ * GLOBAL QUERY
  *
- * List all supplier rows by code. During the Phase 1 global suppliers
- * migration, import preview should answer "does this code exist anywhere?"
- * before the schema has fully dropped tenant ownership.
+ * List all global supplier rows by code.
  */
 export async function listSuppliersGlobal() {
-  return db
-    .select({
-      id: suppliers.id,
-      institutionId: suppliers.institution_id,
-      name: suppliers.name,
-      code: suppliers.code,
-      country: suppliers.country,
-      websiteUrl: suppliers.website_url,
-      isActive: suppliers.is_active,
-      createdAt: suppliers.created_at,
-    })
-    .from(suppliers)
-    .orderBy(desc(suppliers.created_at));
+  return db.select(supplierSelect).from(suppliers).orderBy(desc(suppliers.created_at));
 }
 
 /**
  * PLATFORM QUERY
  *
- * List all suppliers, optionally filtered by institution.
+ * List all global suppliers. The optional institutionId parameter is accepted
+ * temporarily for route compatibility and ignored.
  */
-export async function listSuppliersForPlatform(institutionId?: number) {
-  const condition = institutionId ? eq(suppliers.institution_id, institutionId) : undefined;
-
-  return db
-    .select({
-      id: suppliers.id,
-      institutionId: suppliers.institution_id,
-      name: suppliers.name,
-      code: suppliers.code,
-      country: suppliers.country,
-      websiteUrl: suppliers.website_url,
-      isActive: suppliers.is_active,
-      createdAt: suppliers.created_at,
-    })
-    .from(suppliers)
-    .where(condition)
-    .orderBy(desc(suppliers.created_at));
+export async function listSuppliersForPlatform(_institutionId?: number) {
+  return listSuppliersGlobal();
 }
 
 /**
@@ -82,16 +53,7 @@ export async function listSuppliersForPlatform(institutionId?: number) {
  */
 export async function getSupplierById(supplierId: number) {
   const [row] = await db
-    .select({
-      id: suppliers.id,
-      institutionId: suppliers.institution_id,
-      name: suppliers.name,
-      code: suppliers.code,
-      country: suppliers.country,
-      websiteUrl: suppliers.website_url,
-      isActive: suppliers.is_active,
-      createdAt: suppliers.created_at,
-    })
+    .select(supplierSelect)
     .from(suppliers)
     .where(eq(suppliers.id, supplierId))
     .limit(1);
@@ -100,23 +62,19 @@ export async function getSupplierById(supplierId: number) {
 }
 
 /**
- * Check if a supplier code already exists for a given institution.
+ * Check if a supplier code already exists globally.
  * Optionally exclude a supplier ID (for update uniqueness checks).
  */
 export async function supplierCodeExistsForTenant(
-  institutionId: number,
+  _institutionId: number,
   code: string,
   excludeId?: number,
 ) {
-  const conditions = excludeId
-    ? and(
-        eq(suppliers.institution_id, institutionId),
-        eq(suppliers.code, code),
-        ne(suppliers.id, excludeId),
-      )
-    : and(eq(suppliers.institution_id, institutionId), eq(suppliers.code, code));
+  const condition = excludeId
+    ? and(eq(suppliers.code, code), ne(suppliers.id, excludeId))
+    : eq(suppliers.code, code);
 
-  const [row] = await db.select({ id: suppliers.id }).from(suppliers).where(conditions).limit(1);
+  const [row] = await db.select({ id: suppliers.id }).from(suppliers).where(condition).limit(1);
 
   return !!row;
 }
@@ -124,29 +82,20 @@ export async function supplierCodeExistsForTenant(
 /**
  * PLATFORM QUERY
  *
- * Create a new supplier for a given institution.
+ * Create a new global supplier. The institutionId parameter is accepted
+ * temporarily for route/service compatibility and ignored.
  */
-export async function createSupplier(institutionId: number, input: CreateSupplierBody) {
+export async function createSupplier(_institutionId: number, input: CreateSupplierBody) {
   const [row] = await db
     .insert(suppliers)
     .values({
-      institution_id: institutionId,
       name: input.name,
       code: input.code,
       country: input.country,
       website_url: input.website_url ?? null,
       is_active: input.is_active ?? true,
     })
-    .returning({
-      id: suppliers.id,
-      institutionId: suppliers.institution_id,
-      name: suppliers.name,
-      code: suppliers.code,
-      country: suppliers.country,
-      websiteUrl: suppliers.website_url,
-      isActive: suppliers.is_active,
-      createdAt: suppliers.created_at,
-    });
+    .returning(supplierSelect);
 
   return row;
 }
@@ -170,16 +119,7 @@ export async function updateSupplier(supplierId: number, input: UpdateSupplierBo
       .update(suppliers)
       .set(updateData)
       .where(eq(suppliers.id, supplierId))
-      .returning({
-        id: suppliers.id,
-        institutionId: suppliers.institution_id,
-        name: suppliers.name,
-        code: suppliers.code,
-        country: suppliers.country,
-        websiteUrl: suppliers.website_url,
-        isActive: suppliers.is_active,
-        createdAt: suppliers.created_at,
-      });
+      .returning(supplierSelect);
 
     return row ?? null;
   } catch (error: unknown) {
@@ -225,14 +165,13 @@ function isForeignKeyViolation(error: unknown): boolean {
 }
 
 /**
- * PLATFORM QUERY
+ * IMPORT COMPATIBILITY QUERY
  *
- * Ensure a supplier with the given code exists for the tenant, creating it if necessary.
- * Used by the importer to link shipments to suppliers without requiring pre-creation.
- * Returns the existing or newly created supplier's ID and code.
+ * Ensure a global supplier with the given code exists. Keep this old function
+ * name temporarily so callers can migrate gradually.
  */
 export async function ensureSupplierExistsForTenant(
-  tenantId: number,
+  _tenantId: number,
   code: string,
   fallbackData?: {
     name?: string;
@@ -248,7 +187,7 @@ export async function ensureSupplierExistsForTenant(
       code: suppliers.code,
     })
     .from(suppliers)
-    .where(and(eq(suppliers.institution_id, tenantId), eq(suppliers.code, normalizedCode)))
+    .where(eq(suppliers.code, normalizedCode))
     .limit(1);
 
   if (existing) {
@@ -258,12 +197,11 @@ export async function ensureSupplierExistsForTenant(
   const [created] = await db
     .insert(suppliers)
     .values({
-      institution_id: tenantId,
       code: normalizedCode,
       name: fallbackData?.name ?? normalizedCode,
       country: fallbackData?.country ?? "Unknown",
       website_url: fallbackData?.websiteUrl ?? null,
-      is_active: false, // important for importer
+      is_active: false,
     })
     .returning({
       id: suppliers.id,
@@ -274,15 +212,13 @@ export async function ensureSupplierExistsForTenant(
 }
 
 /**
- * GLOBAL TRANSITION QUERY
+ * GLOBAL QUERY
  *
- * Ensure a supplier code exists for import commit using Phase 1 global
- * semantics while the schema still requires a tenant-compatible supplier row
- * for the shipment FK. Once suppliers are truly global in the schema, this
- * helper can collapse to a simple global code lookup/create.
+ * Ensure a global supplier code exists for import commit, creating missing
+ * codes as inactive for later platform review.
  */
 export async function ensureSupplierExistsForGlobalImport(
-  tenantId: number,
+  _tenantId: number,
   code: string,
   fallbackData?: {
     name?: string;
@@ -296,28 +232,15 @@ export async function ensureSupplierExistsForGlobalImport(
     .select({
       id: suppliers.id,
       code: suppliers.code,
-      name: suppliers.name,
-      country: suppliers.country,
-      websiteUrl: suppliers.website_url,
     })
     .from(suppliers)
     .where(eq(suppliers.code, normalizedCode))
-    .orderBy(desc(suppliers.created_at))
     .limit(1);
 
-  const [tenantMatch] = await db
-    .select({
-      id: suppliers.id,
-      code: suppliers.code,
-    })
-    .from(suppliers)
-    .where(and(eq(suppliers.institution_id, tenantId), eq(suppliers.code, normalizedCode)))
-    .limit(1);
-
-  if (tenantMatch) {
+  if (globalMatch) {
     return {
-      ...tenantMatch,
-      wasGloballyMissing: !globalMatch,
+      ...globalMatch,
+      wasGloballyMissing: false,
       wasCompatibilityCreated: false,
     };
   }
@@ -325,11 +248,10 @@ export async function ensureSupplierExistsForGlobalImport(
   const [created] = await db
     .insert(suppliers)
     .values({
-      institution_id: tenantId,
       code: normalizedCode,
-      name: globalMatch?.name ?? fallbackData?.name ?? normalizedCode,
-      country: globalMatch?.country ?? fallbackData?.country ?? "Unknown",
-      website_url: globalMatch?.websiteUrl ?? fallbackData?.websiteUrl ?? null,
+      name: fallbackData?.name ?? normalizedCode,
+      country: fallbackData?.country ?? "Unknown",
+      website_url: fallbackData?.websiteUrl ?? null,
       is_active: false,
     })
     .returning({
@@ -339,7 +261,7 @@ export async function ensureSupplierExistsForGlobalImport(
 
   return {
     ...created,
-    wasGloballyMissing: !globalMatch,
-    wasCompatibilityCreated: true,
+    wasGloballyMissing: true,
+    wasCompatibilityCreated: false,
   };
 }

--- a/src/lib/queries/suppliers.ts
+++ b/src/lib/queries/suppliers.ts
@@ -31,6 +31,29 @@ export async function listSuppliersForTenant(institutionId: number) {
 }
 
 /**
+ * GLOBAL TRANSITION QUERY
+ *
+ * List all supplier rows by code. During the Phase 1 global suppliers
+ * migration, import preview should answer "does this code exist anywhere?"
+ * before the schema has fully dropped tenant ownership.
+ */
+export async function listSuppliersGlobal() {
+  return db
+    .select({
+      id: suppliers.id,
+      institutionId: suppliers.institution_id,
+      name: suppliers.name,
+      code: suppliers.code,
+      country: suppliers.country,
+      websiteUrl: suppliers.website_url,
+      isActive: suppliers.is_active,
+      createdAt: suppliers.created_at,
+    })
+    .from(suppliers)
+    .orderBy(desc(suppliers.created_at));
+}
+
+/**
  * PLATFORM QUERY
  *
  * List all suppliers, optionally filtered by institution.
@@ -248,4 +271,75 @@ export async function ensureSupplierExistsForTenant(
     });
 
   return created;
+}
+
+/**
+ * GLOBAL TRANSITION QUERY
+ *
+ * Ensure a supplier code exists for import commit using Phase 1 global
+ * semantics while the schema still requires a tenant-compatible supplier row
+ * for the shipment FK. Once suppliers are truly global in the schema, this
+ * helper can collapse to a simple global code lookup/create.
+ */
+export async function ensureSupplierExistsForGlobalImport(
+  tenantId: number,
+  code: string,
+  fallbackData?: {
+    name?: string;
+    country?: string;
+    websiteUrl?: string | null;
+  },
+) {
+  const normalizedCode = code.toUpperCase();
+
+  const [globalMatch] = await db
+    .select({
+      id: suppliers.id,
+      code: suppliers.code,
+      name: suppliers.name,
+      country: suppliers.country,
+      websiteUrl: suppliers.website_url,
+    })
+    .from(suppliers)
+    .where(eq(suppliers.code, normalizedCode))
+    .orderBy(desc(suppliers.created_at))
+    .limit(1);
+
+  const [tenantMatch] = await db
+    .select({
+      id: suppliers.id,
+      code: suppliers.code,
+    })
+    .from(suppliers)
+    .where(and(eq(suppliers.institution_id, tenantId), eq(suppliers.code, normalizedCode)))
+    .limit(1);
+
+  if (tenantMatch) {
+    return {
+      ...tenantMatch,
+      wasGloballyMissing: !globalMatch,
+      wasCompatibilityCreated: false,
+    };
+  }
+
+  const [created] = await db
+    .insert(suppliers)
+    .values({
+      institution_id: tenantId,
+      code: normalizedCode,
+      name: globalMatch?.name ?? fallbackData?.name ?? normalizedCode,
+      country: globalMatch?.country ?? fallbackData?.country ?? "Unknown",
+      website_url: globalMatch?.websiteUrl ?? fallbackData?.websiteUrl ?? null,
+      is_active: false,
+    })
+    .returning({
+      id: suppliers.id,
+      code: suppliers.code,
+    });
+
+  return {
+    ...created,
+    wasGloballyMissing: !globalMatch,
+    wasCompatibilityCreated: true,
+  };
 }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -27,14 +27,15 @@ import type { SpeciesFunFact } from "@/types/butterfly";
  *
  * Tenant model:
  * - Global (shared): butterfly_species
- * - Tenant-scoped (owned by institution): everything else
+ * - Global supplier codes: suppliers
+ * - Tenant-scoped (owned by institution): operational records such as shipments and releases
  *
  * Key safety guarantees:
  * - Global species cannot be deleted if referenced in tenant data (RESTRICT)
  * - Deleting an institution cascades all tenant-owned rows (CASCADE)
  * - Suppliers are soft-deletable via is_active (do not hard delete if referenced)
  * - Shipments store supplier abbreviation (supplier_code) as the USDA/Excel value
- * - DB-level tenant enforcement: a shipment’s supplier_code must exist for the SAME institution
+ * - DB-level supplier enforcement: a shipment’s supplier_code must exist globally
  * - DB-level tenant enforcement: a release_event’s shipment must belong to the SAME institution
  */
 
@@ -224,9 +225,9 @@ export const butterfly_species_institution = pgTable(
 );
 
 /**
- * Suppliers (tenant-scoped)
+ * Suppliers (global)
  *
- * Managed supplier list for the institution.
+ * Shared supplier code list used across institutions.
  * "Delete" in UI should generally mean is_active=false (soft delete).
  *
  * For historical imports:
@@ -236,10 +237,6 @@ export const suppliers = pgTable(
   "suppliers",
   {
     id: serial("id").primaryKey(),
-
-    institution_id: integer("institution_id")
-      .notNull()
-      .references(() => institutions.id, { onDelete: "cascade" }),
 
     name: text("name").notNull(),
     code: text("code").notNull(), // Supplier abbreviation/code used in USDA/Excel imports (e.g., "LPS", "EBN")
@@ -253,17 +250,7 @@ export const suppliers = pgTable(
     updated_at: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => ({
-    // Two institutions can share the same code without collision; uniqueness is tenant-scoped
-    unique_supplier_per_institution: unique("unique_supplier_per_institution").on(
-      table.institution_id,
-      table.code,
-    ),
-
-    // Needed for composite foreign keys that reference (institution_id, id)
-    unique_supplier_id_per_institution: unique("unique_supplier_id_per_institution").on(
-      table.institution_id,
-      table.id,
-    ),
+    unique_supplier_code: unique("unique_supplier_code").on(table.code),
   }),
 );
 
@@ -271,7 +258,7 @@ export const suppliers = pgTable(
  * Shipments (Header)
  *
  * Shipments store supplier_code in the same USDA/Excel format.
- * DB-level tenant enforcement ensures supplier_code exists for the SAME institution.
+ * DB-level supplier enforcement ensures supplier_code exists globally.
  */
 export const shipments = pgTable(
   "shipments",
@@ -291,10 +278,10 @@ export const shipments = pgTable(
     updated_at: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => ({
-    // Tenant enforcement: supplier_code must exist for the same institution.
+    // Supplier enforcement: supplier_code must exist globally.
     fk_shipments_supplier_code: foreignKey({
-      columns: [table.institution_id, table.supplier_code],
-      foreignColumns: [suppliers.institution_id, suppliers.code],
+      columns: [table.supplier_code],
+      foreignColumns: [suppliers.code],
       name: "fk_shipments_supplier_code",
     }).onDelete("restrict"),
 

--- a/src/lib/services/platform-suppliers.ts
+++ b/src/lib/services/platform-suppliers.ts
@@ -1,6 +1,5 @@
 import { auth } from "@/auth";
 import { requireUser, canCrossTenant } from "@/lib/authz";
-import { resolveTenantId, ensureTenantExists } from "@/lib/tenant";
 import {
   listSuppliersForPlatform,
   createSupplier,
@@ -23,16 +22,9 @@ export async function getPlatformSuppliers(institutionId?: number) {
 export async function createPlatformSupplier(data: CreateSupplierBody) {
   const user = requireUser(await auth());
   if (!canCrossTenant(user)) throw new Error("FORBIDDEN");
-  let tenantId: number;
-  try {
-    tenantId = resolveTenantId(user, data.institutionId);
-  } catch {
-    throw new Error("FORBIDDEN");
-  }
-  await ensureTenantExists(tenantId);
-  const codeExists = await supplierCodeExistsForTenant(tenantId, data.code);
+  const codeExists = await supplierCodeExistsForTenant(0, data.code);
   if (codeExists) throw new Error("CONFLICT");
-  return createSupplier(tenantId, data);
+  return createSupplier(0, data);
 }
 
 export async function getPlatformSupplierById(id: number) {
@@ -47,7 +39,7 @@ export async function updatePlatformSupplier(id: number, data: UpdateSupplierBod
   const existing = await getSupplierById(id);
   if (!existing) throw new Error("NOT_FOUND");
   if (data.code !== undefined) {
-    const codeExists = await supplierCodeExistsForTenant(existing.institutionId, data.code, id);
+    const codeExists = await supplierCodeExistsForTenant(0, data.code, id);
     if (codeExists) throw new Error("CONFLICT");
   }
   const updated = await updateSupplier(id, data);

--- a/src/lib/services/platform-suppliers.ts
+++ b/src/lib/services/platform-suppliers.ts
@@ -1,30 +1,30 @@
 import { auth } from "@/auth";
 import { requireUser, canCrossTenant } from "@/lib/authz";
 import {
-  listSuppliersForPlatform,
+  listSuppliersGlobal,
   createSupplier,
   getSupplierById,
   updateSupplier,
   deleteSupplier,
-  supplierCodeExistsForTenant,
+  supplierCodeExists,
   SUPPLIER_ERRORS,
 } from "@/lib/queries/suppliers";
 import type { CreateSupplierBody, UpdateSupplierBody } from "@/lib/validation/suppliers";
 
 export { SUPPLIER_ERRORS };
 
-export async function getPlatformSuppliers(institutionId?: number) {
+export async function getPlatformSuppliers() {
   const user = requireUser(await auth());
   if (!canCrossTenant(user)) throw new Error("FORBIDDEN");
-  return listSuppliersForPlatform(institutionId);
+  return listSuppliersGlobal();
 }
 
 export async function createPlatformSupplier(data: CreateSupplierBody) {
   const user = requireUser(await auth());
   if (!canCrossTenant(user)) throw new Error("FORBIDDEN");
-  const codeExists = await supplierCodeExistsForTenant(0, data.code);
+  const codeExists = await supplierCodeExists(data.code);
   if (codeExists) throw new Error("CONFLICT");
-  return createSupplier(0, data);
+  return createSupplier(data);
 }
 
 export async function getPlatformSupplierById(id: number) {
@@ -39,7 +39,7 @@ export async function updatePlatformSupplier(id: number, data: UpdateSupplierBod
   const existing = await getSupplierById(id);
   if (!existing) throw new Error("NOT_FOUND");
   if (data.code !== undefined) {
-    const codeExists = await supplierCodeExistsForTenant(0, data.code, id);
+    const codeExists = await supplierCodeExists(data.code, id);
     if (codeExists) throw new Error("CONFLICT");
   }
   const updated = await updateSupplier(id, data);

--- a/src/lib/services/shipment-import.ts
+++ b/src/lib/services/shipment-import.ts
@@ -12,7 +12,7 @@ import {
   ensureSpeciesLinksForInstitution,
   listSpeciesGlobal,
 } from "@/lib/queries/species";
-import { ensureSupplierExistsForTenant, listSuppliersForPlatform } from "@/lib/queries/suppliers";
+import { ensureSupplierExistsForGlobalImport, listSuppliersGlobal } from "@/lib/queries/suppliers";
 import {
   groupShipmentImportRows,
   normalizeScientificName,
@@ -140,7 +140,7 @@ export async function buildShipmentImportPreviewForInstitution({
 
   const [speciesRows, supplierRows] = await Promise.all([
     listSpeciesGlobal(),
-    listSuppliersForPlatform(institutionId),
+    listSuppliersGlobal(),
   ]);
 
   const knownSpecies = new Set(
@@ -208,18 +208,13 @@ export async function commitShipmentImportForInstitution({
   const allowSpeciesAutocreate = options?.allow_species_autocreate ?? false;
   const allowDuplicateHeaders = options?.allow_duplicate_headers ?? false;
 
-  const [speciesRows, tenantSupplierRows, globalSupplierRows] = await Promise.all([
+  const [speciesRows, globalSupplierRows] = await Promise.all([
     listSpeciesGlobal(),
-    listSuppliersForPlatform(institutionId),
-    listSuppliersForPlatform(),
+    listSuppliersGlobal(),
   ]);
 
   const speciesLookup = new Map(
     speciesRows.map((species) => [normalizeScientificName(species.scientificName), species.id]),
-  );
-
-  const tenantSuppliers = new Set(
-    tenantSupplierRows.map((supplier) => normalizeSupplierCode(supplier.code)),
   );
 
   const globalSuppliersByCode = new Map<string, (typeof globalSupplierRows)[number]>();
@@ -229,6 +224,7 @@ export async function commitShipmentImportForInstitution({
       globalSuppliersByCode.set(normalizedCode, supplier);
     }
   }
+  const ensuredSupplierCodes = new Set<string>();
 
   let created = 0;
   let failed = 0;
@@ -244,19 +240,33 @@ export async function commitShipmentImportForInstitution({
       const shipmentDate = new Date(shipment.shipment_date);
       const arrivalDate = new Date(shipment.arrival_date);
 
-      if (!tenantSuppliers.has(supplierCode)) {
+      if (!ensuredSupplierCodes.has(supplierCode)) {
         const globalMatch = globalSuppliersByCode.get(supplierCode);
 
-        await ensureSupplierExistsForTenant(institutionId, supplierCode, {
-          name: globalMatch?.name ?? supplierCode,
-          country: globalMatch?.country ?? "Unknown",
-          websiteUrl: globalMatch?.websiteUrl ?? null,
-        });
-
-        tenantSuppliers.add(supplierCode);
-        warnings.push(
-          `Supplier ${supplierCode} was auto-created as inactive for this institution.`,
+        const ensuredSupplier = await ensureSupplierExistsForGlobalImport(
+          institutionId,
+          supplierCode,
+          {
+            name: globalMatch?.name ?? supplierCode,
+            country: globalMatch?.country ?? "Unknown",
+            websiteUrl: globalMatch?.websiteUrl ?? null,
+          },
         );
+
+        ensuredSupplierCodes.add(supplierCode);
+        if (ensuredSupplier.wasGloballyMissing) {
+          globalSuppliersByCode.set(supplierCode, {
+            id: ensuredSupplier.id,
+            institutionId,
+            code: ensuredSupplier.code,
+            name: globalMatch?.name ?? supplierCode,
+            country: globalMatch?.country ?? "Unknown",
+            websiteUrl: globalMatch?.websiteUrl ?? null,
+            isActive: false,
+            createdAt: new Date(),
+          });
+          warnings.push(`Supplier ${supplierCode} was auto-created as inactive for global review.`);
+        }
       }
 
       const unresolvedSpecies: string[] = [];

--- a/src/lib/services/shipment-import.ts
+++ b/src/lib/services/shipment-import.ts
@@ -243,15 +243,11 @@ export async function commitShipmentImportForInstitution({
       if (!ensuredSupplierCodes.has(supplierCode)) {
         const globalMatch = globalSuppliersByCode.get(supplierCode);
 
-        const ensuredSupplier = await ensureSupplierExistsForGlobalImport(
-          institutionId,
-          supplierCode,
-          {
-            name: globalMatch?.name ?? supplierCode,
-            country: globalMatch?.country ?? "Unknown",
-            websiteUrl: globalMatch?.websiteUrl ?? null,
-          },
-        );
+        const ensuredSupplier = await ensureSupplierExistsForGlobalImport(supplierCode, {
+          name: globalMatch?.name ?? supplierCode,
+          country: globalMatch?.country ?? "Unknown",
+          websiteUrl: globalMatch?.websiteUrl ?? null,
+        });
 
         ensuredSupplierCodes.add(supplierCode);
         if (ensuredSupplier.wasGloballyMissing) {

--- a/src/lib/services/shipment-import.ts
+++ b/src/lib/services/shipment-import.ts
@@ -257,7 +257,6 @@ export async function commitShipmentImportForInstitution({
         if (ensuredSupplier.wasGloballyMissing) {
           globalSuppliersByCode.set(supplierCode, {
             id: ensuredSupplier.id,
-            institutionId,
             code: ensuredSupplier.code,
             name: globalMatch?.name ?? supplierCode,
             country: globalMatch?.country ?? "Unknown",

--- a/src/lib/services/tenant-suppliers.ts
+++ b/src/lib/services/tenant-suppliers.ts
@@ -1,11 +1,11 @@
 import { auth } from "@/auth";
 import { requireUser, canReadSuppliers } from "@/lib/authz";
 import { resolveTenantBySlug } from "@/lib/tenant";
-import { listSuppliersForTenant } from "@/lib/queries/suppliers";
+import { listSuppliersGlobal } from "@/lib/queries/suppliers";
 
 export async function getTenantSuppliers({ slug }: { slug: string }) {
   const user = requireUser(await auth());
   if (!canReadSuppliers(user)) throw new Error("FORBIDDEN");
-  const tenantId = await resolveTenantBySlug(user, slug);
-  return listSuppliersForTenant(tenantId);
+  await resolveTenantBySlug(user, slug);
+  return listSuppliersGlobal();
 }

--- a/src/lib/shipment-import-parser.ts
+++ b/src/lib/shipment-import-parser.ts
@@ -73,7 +73,8 @@ export function normalizeScientificName(value: string) {
 }
 
 export function normalizeSupplierCode(value: string) {
-  return value.trim().toUpperCase();
+  // Preserve historical supplier values exactly except for accidental outer whitespace.
+  return value.trim();
 }
 
 export function normalizeHeader(value: string) {

--- a/src/lib/validation/suppliers.ts
+++ b/src/lib/validation/suppliers.ts
@@ -22,11 +22,7 @@ export const supplierIdParamsSchema = z
  * ---------------------------
  */
 
-export const listSuppliersQuerySchema = z
-  .object({
-    institutionId: z.coerce.number().int().positive().optional(),
-  })
-  .strict();
+export const listSuppliersQuerySchema = z.object({}).strict();
 
 /**
  * ---------------------------
@@ -47,7 +43,6 @@ export const createSupplierBodySchema = z
       .transform((v) => sanitizeText(v))
       .optional(),
     is_active: z.boolean().optional(),
-    institutionId: z.coerce.number().int().positive().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Migrate suppliers from a tenant-scoped model to a true global supplier model and align shipment import behavior with that change. This updates the schema, supplier API/contracts, tenant supplier reads, and import preview/commit flow so suppliers are shared across institutions while historical shipment supplier values remain preserved for onboarding/import accuracy.
fixes #84 

## Changes

- Migrated `suppliers` to a global model
- Removed tenant ownership from supplier rows
- Made `suppliers.code` globally unique
- Replaced shipment supplier FK with global `supplier_code -> suppliers.code`
- Updated import preview and commit to use global supplier lookup
- Auto-create missing imported suppliers as inactive global rows
- Preserve imported supplier values after outer trimming only
- Updated tenant supplier reads to return the global supplier list
- Cleaned up platform supplier API validation/contracts to remove `institutionId`
- Updated tests, docs, and migration files

## Test Plan

- [x] `pnpm exec jest --runTestsByPath src/lib/__test__/schema.test.ts src/lib/__test__/shipment-import-service.test.ts`
- [x] `pnpm exec jest --runTestsByPath src/lib/__test__/tenant-suppliers-service.test.ts src/__test__/api/tenant/suppliers.route.test.ts src/lib/__test__/shipment-import-service.test.ts src/__test__/api/platform/shipment-import.route.test.ts`
- [x] `pnpm exec jest --runTestsByPath src/lib/__test__/shipment-import-parser.test.ts src/lib/__test__/shipment-import-service.test.ts src/lib/__test__/supplier-queries.test.ts`
- [x] `pnpm exec tsc --noEmit --project tsconfig.test.json`
- [x] `pnpm db:migrate`
- [x] Manual verification:
  - tenant add-shipment supplier dropdown works
  - platform historical import preview works
  - global supplier migration runs successfully locally