### PR TITLE
fix: resolve backend mini-audit issue 44

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -178,6 +178,44 @@ Notes:
 - `PATCH` replaces the full `fun_facts` array; it does not append a single fact item.
 - The legacy string format for `fun_facts` is no longer accepted.
 
+### Public institutions list contract
+
+`GET /api/public/institutions` supports optional pagination via query params:
+
+- `page` (number, default `1`)
+- `limit` (number, default `50`, max `100`)
+
+Response shape:
+
+```json
+{
+  "institutions": [
+    {
+      "id": 1,
+      "slug": "butterfly-house",
+      "name": "Butterfly House",
+      "city": "Springfield",
+      "state_province": "IL",
+      "country": "US",
+      "website_url": null,
+      "facility_image_url": "https://example.com/img.jpg",
+      "logo_url": null,
+      "stats_active": true
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "limit": 50,
+    "total": 1,
+    "totalPages": 1
+  }
+}
+```
+
+- Results are ordered alphabetically by institution name.
+- Only institutions with `stats_active = true` are returned.
+- Returns `400 INVALID_REQUEST` for non-numeric, zero, negative, or above-max `page`/`limit` values.
+
 ### Public species detail contract
 
 `GET /api/public/institutions/[slug]/species/[scientific_name]` response shape:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -86,7 +86,7 @@ Institution ─┬─ Users
 
 ### Public (`/api/public/*`)
 
-- `/api/public/institutions` — List public institutions.
+- `/api/public/institutions` — List public institutions (paginated; `page`/`limit` query params, default page 1 limit 50, max 100). Returns `institutions` array + `pagination` metadata.
 - `/api/public/institutions/[slug]` — Public institution details.
 - `/api/public/institutions/[slug]/gallery` — Public gallery data for an institution.
 - `/api/public/institutions/[slug]/in-flight` — Current in-flight data for an institution.

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -38,6 +38,23 @@ Composite tenant keys prevent cross-tenant references even if a raw numeric ID e
 institution. The supplier relationship is intentionally global by code so historical imports can
 reuse shared supplier codes across institutions.
 
+## Performance Indexes
+
+Composite indexes are added when a query has a confirmed hot path with a filter + sort on the same table. Single-column indexes on `institution_id` alone are not added — they are generally redundant given the composite FK unique constraints.
+
+Current composite performance indexes:
+
+| Index                                                  | Table                           | Columns                                       | Query                                           |
+| ------------------------------------------------------ | ------------------------------- | --------------------------------------------- | ----------------------------------------------- |
+| `idx_shipment_items_institution_species`               | `shipment_items`                | `(institution_id, butterfly_species_id)`      | Gallery/home aggregation                        |
+| `idx_in_flight_institution_shipment_item`              | `in_flight`                     | `(institution_id, shipment_item_id)`          | In-flight sum aggregation                       |
+| `idx_bsi_institution_id`                               | `butterfly_species_institution` | `(institution_id)`                            | Species list per institution                    |
+| `idx_users_institution_id`                             | `users`                         | `(institution_id)`                            | User lookups per institution                    |
+| `idx_institution_news_institution_id`                  | `institution_news`              | `(institution_id)`                            | News list per institution                       |
+| `idx_shipments_institution_shipment_date`              | `shipments`                     | `(institution_id, shipment_date)`             | Paginated shipment list (filter + sort)         |
+| `idx_release_events_institution_release_date`          | `release_events`                | `(institution_id, release_date)`              | Paginated release list (filter + sort)          |
+| `idx_release_events_institution_shipment_release_date` | `release_events`                | `(institution_id, shipment_id, release_date)` | Shipment-scoped release history (filter + sort) |
+
 ## Docker
 
 - PostgreSQL 17 via `docker-compose.yml`

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -40,9 +40,9 @@ reuse shared supplier codes across institutions.
 
 ## Performance Indexes
 
-Composite indexes are added when a query has a confirmed hot path with a filter + sort on the same table. Single-column indexes on `institution_id` alone are not added — they are generally redundant given the composite FK unique constraints.
+Composite indexes are added when a query has a confirmed hot path with a filter + sort on the same table. Single-column indexes on `institution_id` alone are generally avoided because they are often redundant when another useful index already starts with `institution_id` or when composite FK/unique constraints cover the access pattern. They are still added for documented tenant-only list/look-up hot paths where no more specific `institution_id`-prefixed index already serves the query.
 
-Current composite performance indexes:
+Current performance indexes:
 
 | Index                                                  | Table                           | Columns                                       | Query                                           |
 | ------------------------------------------------------ | ------------------------------- | --------------------------------------------- | ----------------------------------------------- |

--- a/drizzle/0004_odd_reaper.sql
+++ b/drizzle/0004_odd_reaper.sql
@@ -1,0 +1,3 @@
+CREATE INDEX "idx_release_events_institution_release_date" ON "release_events" USING btree ("institution_id","release_date");--> statement-breakpoint
+CREATE INDEX "idx_release_events_institution_shipment_release_date" ON "release_events" USING btree ("institution_id","shipment_id","release_date");--> statement-breakpoint
+CREATE INDEX "idx_shipments_institution_shipment_date" ON "shipments" USING btree ("institution_id","shipment_date");

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1305 @@
+{
+  "id": "4ad08285-2590-4906-a255-e08c447990f8",
+  "prevId": "080bc418-871d-43d9-91db-c787072387eb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.butterfly_species": {
+      "name": "butterfly_species",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scientific_name": {
+          "name": "scientific_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name": {
+          "name": "common_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_family": {
+          "name": "sub_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifespan_days": {
+          "name": "lifespan_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range": {
+          "name": "range",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_plant": {
+          "name": "host_plant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "habitat": {
+          "name": "habitat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fun_facts": {
+          "name": "fun_facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "img_wings_open": {
+          "name": "img_wings_open",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "img_wings_closed": {
+          "name": "img_wings_closed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_img_1": {
+          "name": "extra_img_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_img_2": {
+          "name": "extra_img_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "butterfly_species_scientific_name_unique": {
+          "name": "butterfly_species_scientific_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scientific_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.butterfly_species_institution": {
+      "name": "butterfly_species_institution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "butterfly_species_id": {
+          "name": "butterfly_species_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name_override": {
+          "name": "common_name_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifespan_override": {
+          "name": "lifespan_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_institution_species": {
+          "name": "unique_institution_species",
+          "columns": [
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bsi_institution_id": {
+          "name": "idx_bsi_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "butterfly_species_institution_butterfly_species_id_butterfly_species_id_fk": {
+          "name": "butterfly_species_institution_butterfly_species_id_butterfly_species_id_fk",
+          "tableFrom": "butterfly_species_institution",
+          "tableTo": "butterfly_species",
+          "columnsFrom": [
+            "butterfly_species_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "butterfly_species_institution_institution_id_institutions_id_fk": {
+          "name": "butterfly_species_institution_institution_id_institutions_id_fk",
+          "tableFrom": "butterfly_species_institution",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_flight": {
+      "name": "in_flight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_event_id": {
+          "name": "release_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_item_id": {
+          "name": "shipment_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_in_flight_shipment_item": {
+          "name": "unique_in_flight_shipment_item",
+          "columns": [
+            {
+              "expression": "release_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_flight_institution_shipment_item": {
+          "name": "idx_in_flight_institution_shipment_item",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_flight_institution_id_institutions_id_fk": {
+          "name": "in_flight_institution_id_institutions_id_fk",
+          "tableFrom": "in_flight",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_in_flight_event_institution": {
+          "name": "fk_in_flight_event_institution",
+          "tableFrom": "in_flight",
+          "tableTo": "release_events",
+          "columnsFrom": [
+            "institution_id",
+            "release_event_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_in_flight_shipment_item_institution": {
+          "name": "fk_in_flight_shipment_item_institution",
+          "tableFrom": "in_flight",
+          "tableTo": "shipment_items",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_item_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institution_news": {
+      "name": "institution_news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_institution_news_institution_id": {
+          "name": "idx_institution_news_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "institution_news_institution_id_institutions_id_fk": {
+          "name": "institution_news_institution_id_institutions_id_fk",
+          "tableFrom": "institution_news",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street_address": {
+          "name": "street_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extended_address": {
+          "name": "extended_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_province": {
+          "name": "state_province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iabes_member": {
+          "name": "iabes_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_colors": {
+          "name": "theme_colors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volunteer_url": {
+          "name": "volunteer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "donation_url": {
+          "name": "donation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_image_url": {
+          "name": "facility_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_active": {
+          "name": "stats_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_slug_unique": {
+          "name": "institutions_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "institutions_email_address_unique": {
+          "name": "institutions_email_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.release_events": {
+      "name": "release_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_by": {
+          "name": "released_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_release_events_institution_release_date": {
+          "name": "idx_release_events_institution_release_date",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_release_events_institution_shipment_release_date": {
+          "name": "idx_release_events_institution_shipment_release_date",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "release_events_institution_id_institutions_id_fk": {
+          "name": "release_events_institution_id_institutions_id_fk",
+          "tableFrom": "release_events",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_release_events_shipment_institution": {
+          "name": "fk_release_events_shipment_institution",
+          "tableFrom": "release_events",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_release_event_id_per_institution": {
+          "name": "unique_release_event_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipment_items": {
+      "name": "shipment_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "butterfly_species_id": {
+          "name": "butterfly_species_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_received": {
+          "name": "number_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emerged_in_transit": {
+          "name": "emerged_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "damaged_in_transit": {
+          "name": "damaged_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "diseased_in_transit": {
+          "name": "diseased_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parasite": {
+          "name": "parasite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "non_emergence": {
+          "name": "non_emergence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "poor_emergence": {
+          "name": "poor_emergence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_shipment_species": {
+          "name": "unique_shipment_species",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipment_items_institution_species": {
+          "name": "idx_shipment_items_institution_species",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_items_institution_id_institutions_id_fk": {
+          "name": "shipment_items_institution_id_institutions_id_fk",
+          "tableFrom": "shipment_items",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shipment_items_butterfly_species_id_butterfly_species_id_fk": {
+          "name": "shipment_items_butterfly_species_id_butterfly_species_id_fk",
+          "tableFrom": "shipment_items",
+          "tableTo": "butterfly_species",
+          "columnsFrom": [
+            "butterfly_species_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fk_shipment_items_shipment_institution": {
+          "name": "fk_shipment_items_shipment_institution",
+          "tableFrom": "shipment_items",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_shipment_item_id_per_institution": {
+          "name": "unique_shipment_item_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipments": {
+      "name": "shipments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_date": {
+          "name": "shipment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrival_date": {
+          "name": "arrival_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shipments_institution_shipment_date": {
+          "name": "idx_shipments_institution_shipment_date",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipments_institution_id_institutions_id_fk": {
+          "name": "shipments_institution_id_institutions_id_fk",
+          "tableFrom": "shipments",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_shipments_supplier_code": {
+          "name": "fk_shipments_supplier_code",
+          "tableFrom": "shipments",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_shipment_id_per_institution": {
+          "name": "unique_shipment_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_supplier_code": {
+          "name": "unique_supplier_code",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_institution_id": {
+          "name": "idx_users_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_institution_id_institutions_id_fk": {
+          "name": "users_institution_id_institutions_id_fk",
+          "tableFrom": "users",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776641119486,
       "tag": "0003_romantic_roughhouse",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1776791250075,
+      "tag": "0004_odd_reaper",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__test__/api/public/institutions.route.test.ts
+++ b/src/__test__/api/public/institutions.route.test.ts
@@ -13,45 +13,122 @@ describe("GET /api/public/institutions", () => {
     };
   };
 
+  const mockInstitution = {
+    id: 1,
+    slug: "test-zoo",
+    name: "Test Zoo",
+    city: "Springfield",
+    state_province: "IL",
+    country: "US",
+    website_url: null,
+    facility_image_url: null,
+    logo_url: null,
+    stats_active: true,
+  };
+
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
-  it("returns 200 on success", async () => {
-    mockDb.db.select.mockReturnValueOnce(createThenableQuery([]));
-    const request = {
-      nextUrl: {
-        searchParams: new URLSearchParams(),
-      },
+  function makeRequest(params: Record<string, string> = {}) {
+    return {
+      nextUrl: { searchParams: new URLSearchParams(params) },
     } as unknown as NextRequest;
+  }
 
-    const res = await GET(request);
+  // ── Success contract ──────────────────────────────────────────────────────
+
+  it("returns 200 with institutions array and pagination metadata", async () => {
+    mockDb.db.select
+      .mockReturnValueOnce(createThenableQuery([mockInstitution]))
+      .mockReturnValueOnce(createThenableQuery([{ total: 1 }]));
+
+    const res = await GET(makeRequest());
     expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(Array.isArray(body.institutions)).toBe(true);
+    expect(body.institutions).toHaveLength(1);
+    expect(body.pagination).toEqual({ page: 1, limit: 50, total: 1, totalPages: 1 });
   });
 
-  it("returns 400 on invalid query params", async () => {
-    const request = {
-      nextUrl: {
-        searchParams: new URLSearchParams({ unexpected: "value" }),
-      },
-    } as unknown as NextRequest;
+  it("returns empty institutions array with pagination metadata when no results", async () => {
+    mockDb.db.select
+      .mockReturnValueOnce(createThenableQuery([]))
+      .mockReturnValueOnce(createThenableQuery([{ total: 0 }]));
 
-    const res = await GET(request);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.institutions).toEqual([]);
+    expect(body.pagination).toEqual({ page: 1, limit: 50, total: 0, totalPages: 1 });
+  });
+
+  it("computes totalPages correctly for multi-page results", async () => {
+    mockDb.db.select
+      .mockReturnValueOnce(createThenableQuery([mockInstitution]))
+      .mockReturnValueOnce(createThenableQuery([{ total: 120 }]));
+
+    const res = await GET(makeRequest({ page: "1", limit: "50" }));
+    const body = await res.json();
+    expect(body.pagination).toEqual({ page: 1, limit: 50, total: 120, totalPages: 3 });
+  });
+
+  it("honours explicit page and limit params", async () => {
+    mockDb.db.select
+      .mockReturnValueOnce(createThenableQuery([]))
+      .mockReturnValueOnce(createThenableQuery([{ total: 5 }]));
+
+    const res = await GET(makeRequest({ page: "2", limit: "10" }));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.pagination.page).toBe(2);
+    expect(body.pagination.limit).toBe(10);
+  });
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  it("returns 400 on unrecognised query params", async () => {
+    const res = await GET(makeRequest({ unexpected: "value" }));
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body?.code ?? body?.error?.code).toBe("INVALID_REQUEST");
   });
+
+  it("returns 400 when page is zero", async () => {
+    const res = await GET(makeRequest({ page: "0" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when page is negative", async () => {
+    const res = await GET(makeRequest({ page: "-1" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when limit exceeds max (100)", async () => {
+    const res = await GET(makeRequest({ limit: "101" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when limit is zero", async () => {
+    const res = await GET(makeRequest({ limit: "0" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when page is non-numeric", async () => {
+    const res = await GET(makeRequest({ page: "abc" }));
+    expect(res.status).toBe(400);
+  });
+
+  // ── Error contract ────────────────────────────────────────────────────────
+
   it("returns 500 on internal error", async () => {
     mockDb.db.select.mockImplementationOnce(() => {
       throw new Error("boom");
     });
-    const request = {
-      nextUrl: {
-        searchParams: new URLSearchParams(),
-      },
-    } as unknown as NextRequest;
 
-    const res = await GET(request);
+    const res = await GET(makeRequest());
     expect(res.status).toBe(500);
   });
 });

--- a/src/__test__/api/public/institutions.route.test.ts
+++ b/src/__test__/api/public/institutions.route.test.ts
@@ -106,9 +106,15 @@ describe("GET /api/public/institutions", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 400 when limit exceeds max (100)", async () => {
+  it("caps limit at max (100) when limit exceeds max", async () => {
+    mockDb.db.select
+      .mockReturnValueOnce(createThenableQuery([]))
+      .mockReturnValueOnce(createThenableQuery([{ total: 0 }]));
+
     const res = await GET(makeRequest({ limit: "101" }));
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pagination.limit).toBe(100);
   });
 
   it("returns 400 when limit is zero", async () => {

--- a/src/app/api/public/institutions/route.ts
+++ b/src/app/api/public/institutions/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest } from "next/server";
-import { eq } from "drizzle-orm";
+import { count, eq } from "drizzle-orm";
 
 import { db } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { institutions } from "@/lib/schema";
-import { publicEmptyQuerySchema } from "@/lib/validation/public";
+import { publicInstitutionsQuerySchema } from "@/lib/validation/public";
 import { ok, internalError, invalidRequest } from "@/lib/api-response";
 
 export async function GET(request: NextRequest) {
@@ -12,28 +12,48 @@ export async function GET(request: NextRequest) {
     const searchParams = request?.nextUrl?.searchParams;
     const query = searchParams ? Object.fromEntries(searchParams) : {};
 
-    const parsed = publicEmptyQuerySchema.safeParse(query);
+    const parsed = publicInstitutionsQuerySchema.safeParse(query);
     if (!parsed.success) {
       return invalidRequest("Invalid query parameters", parsed.error.issues);
     }
 
-    const rows = await db
-      .select({
-        id: institutions.id,
-        slug: institutions.slug,
-        name: institutions.name,
-        city: institutions.city,
-        state_province: institutions.state_province,
-        country: institutions.country,
-        website_url: institutions.website_url,
-        facility_image_url: institutions.facility_image_url,
-        logo_url: institutions.logo_url,
-        stats_active: institutions.stats_active,
-      })
-      .from(institutions)
-      .where(eq(institutions.stats_active, true));
+    const { page, limit } = parsed.data;
+    const offset = (page - 1) * limit;
 
-    return ok({ institutions: rows });
+    const [rows, totalResult] = await Promise.all([
+      db
+        .select({
+          id: institutions.id,
+          slug: institutions.slug,
+          name: institutions.name,
+          city: institutions.city,
+          state_province: institutions.state_province,
+          country: institutions.country,
+          website_url: institutions.website_url,
+          facility_image_url: institutions.facility_image_url,
+          logo_url: institutions.logo_url,
+          stats_active: institutions.stats_active,
+        })
+        .from(institutions)
+        .where(eq(institutions.stats_active, true))
+        .orderBy(institutions.name)
+        .limit(limit)
+        .offset(offset),
+
+      db.select({ total: count() }).from(institutions).where(eq(institutions.stats_active, true)),
+    ]);
+
+    const total = totalResult[0]?.total ?? 0;
+
+    return ok({
+      institutions: rows,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.max(1, Math.ceil(total / limit)),
+      },
+    });
   } catch (error) {
     logger.error("Unexpected GET /public/institutions error:", error);
     return internalError();

--- a/src/lib/__test__/gallery-queries.test.ts
+++ b/src/lib/__test__/gallery-queries.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Gallery query behavior contract tests.
+ *
+ * Request-level deduplication: both getGalleryData and getGalleryDetailData
+ * call the same cache()-wrapped queryGallerySpecies function. Within a React
+ * Server Component request, the second call returns the cached result without
+ * an additional DB round-trip. Jest runs outside that context, so these tests
+ * verify the behavioral contract (correct shapes, shared source data) rather
+ * than the single-invocation property.
+ */
+
+import { createThenableQuery } from "@/__test__/api/_utils/mockDb";
+import * as dbModule from "@/lib/db";
+
+jest.mock("@/lib/db");
+jest.mock("@/lib/queries/subqueries", () => ({
+  inFlightCountSubquery: jest.fn(() => ({
+    butterfly_species_id: "butterfly_species_id",
+    total: "total",
+  })),
+}));
+
+const mockDb = dbModule as unknown as { db: { select: jest.Mock } };
+
+const mockRow = {
+  id: 1,
+  scientific_name: "Papilio glaucus",
+  common_name: "Eastern Tiger Swallowtail",
+  common_name_override: null,
+  family: "Papilionidae",
+  range: ["North America"],
+  img_wings_open: "open.jpg",
+  img_wings_closed: "closed.jpg",
+  extra_img_1: "extra1.jpg",
+  extra_img_2: null,
+  in_flight_count: 3,
+};
+
+const mockRowWithOverride = {
+  ...mockRow,
+  id: 2,
+  common_name_override: "Tiger Swallowtail",
+};
+
+describe("getGalleryData", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns species array with narrowed shape (no extra image columns)", async () => {
+    mockDb.db.select.mockReturnValueOnce(createThenableQuery([mockRow]));
+
+    const { getGalleryData } = await import("@/lib/queries/gallery");
+    const result = await getGalleryData(1);
+
+    expect(result.species).toHaveLength(1);
+    const species = result.species[0];
+    expect(species.id).toBe(1);
+    expect(species.common_name).toBe("Eastern Tiger Swallowtail");
+    expect(species.img_wings_open).toBe("open.jpg");
+    expect(species.in_flight_count).toBe(3);
+    // Narrowed — detail-only image fields must not be present
+    expect("img_wings_closed" in species).toBe(false);
+    expect("extra_img_1" in species).toBe(false);
+  });
+
+  it("applies common_name_override when present", async () => {
+    mockDb.db.select.mockReturnValueOnce(createThenableQuery([mockRowWithOverride]));
+
+    const { getGalleryData } = await import("@/lib/queries/gallery");
+    const result = await getGalleryData(1);
+
+    expect(result.species[0].common_name).toBe("Tiger Swallowtail");
+  });
+
+  it("returns empty array when institution has no species", async () => {
+    mockDb.db.select.mockReturnValueOnce(createThenableQuery([]));
+
+    const { getGalleryData } = await import("@/lib/queries/gallery");
+    const result = await getGalleryData(1);
+
+    expect(result.species).toEqual([]);
+  });
+});
+
+describe("getGalleryDetailData", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns full GallerySpeciesDetail shape including all image columns", async () => {
+    mockDb.db.select.mockReturnValueOnce(createThenableQuery([mockRow]));
+
+    const { getGalleryDetailData } = await import("@/lib/queries/gallery");
+    const result = await getGalleryDetailData(1);
+
+    expect(result).toHaveLength(1);
+    const species = result[0];
+    expect(species.id).toBe(1);
+    expect(species.img_wings_open).toBe("open.jpg");
+    expect(species.img_wings_closed).toBe("closed.jpg");
+    expect(species.extra_img_1).toBe("extra1.jpg");
+    expect(species.extra_img_2).toBeNull();
+    expect(species.in_flight_count).toBe(3);
+  });
+
+  it("applies common_name_override when present", async () => {
+    mockDb.db.select.mockReturnValueOnce(createThenableQuery([mockRowWithOverride]));
+
+    const { getGalleryDetailData } = await import("@/lib/queries/gallery");
+    const result = await getGalleryDetailData(1);
+
+    expect(result[0].common_name).toBe("Tiger Swallowtail");
+  });
+
+  it("coerces in_flight_count to number", async () => {
+    const rowWithStringCount = { ...mockRow, in_flight_count: "7" as unknown as number };
+    mockDb.db.select.mockReturnValueOnce(createThenableQuery([rowWithStringCount]));
+
+    const { getGalleryDetailData } = await import("@/lib/queries/gallery");
+    const result = await getGalleryDetailData(1);
+
+    expect(typeof result[0].in_flight_count).toBe("number");
+    expect(result[0].in_flight_count).toBe(7);
+  });
+});

--- a/src/lib/__test__/release-helpers.test.ts
+++ b/src/lib/__test__/release-helpers.test.ts
@@ -1,0 +1,77 @@
+import { calculateRemaining } from "@/lib/queries/releases";
+
+const baseItem = {
+  id: 1,
+  shipment_id: 10,
+  number_received: 100,
+  damaged_in_transit: 0,
+  diseased_in_transit: 0,
+  parasite: 0,
+  non_emergence: 0,
+  poor_emergence: 0,
+};
+
+describe("calculateRemaining", () => {
+  it("returns full number_received when no losses and nothing released", () => {
+    expect(calculateRemaining(baseItem, 0)).toBe(100);
+  });
+
+  it("subtracts already-released from available", () => {
+    expect(calculateRemaining(baseItem, 40)).toBe(60);
+  });
+
+  it("subtracts all loss columns before applying releases", () => {
+    const item = {
+      ...baseItem,
+      damaged_in_transit: 5,
+      diseased_in_transit: 3,
+      parasite: 2,
+      non_emergence: 4,
+      poor_emergence: 1,
+    };
+    // available = 100 - 15 = 85; remaining = 85 - 20 = 65
+    expect(calculateRemaining(item, 20)).toBe(65);
+  });
+
+  it("returns 0 when exactly fully released", () => {
+    expect(calculateRemaining(baseItem, 100)).toBe(0);
+  });
+
+  it("returns negative when over-released (caller enforces the guard)", () => {
+    expect(calculateRemaining(baseItem, 110)).toBe(-10);
+  });
+
+  it("returns negative when losses exceed number_received", () => {
+    const item = { ...baseItem, damaged_in_transit: 110 };
+    expect(calculateRemaining(item, 0)).toBe(-10);
+  });
+});
+
+describe("N+1 fix: bulk sum minus existing quantity coercion", () => {
+  // Tests the arithmetic invariant of the updateReleaseEventItems N+1 fix:
+  // alreadyReleased = totalForItem - existingRowQuantity
+  it("computes correct alreadyReleased when other rows exist", () => {
+    const totalReleased = 50; // all in_flight rows for this shipment_item
+    const existingQuantity = 20; // the row being updated
+    const alreadyReleased = totalReleased - existingQuantity;
+    expect(alreadyReleased).toBe(30);
+    expect(calculateRemaining({ ...baseItem, number_received: 100 }, alreadyReleased)).toBe(70);
+  });
+
+  it("computes 0 alreadyReleased when only one row and it is the one being updated", () => {
+    const totalReleased = 20; // only row is the existing row
+    const existingQuantity = 20;
+    const alreadyReleased = totalReleased - existingQuantity;
+    expect(alreadyReleased).toBe(0);
+    expect(calculateRemaining(baseItem, alreadyReleased)).toBe(100);
+  });
+
+  it("coerces to 0 for items with no in_flight rows (default fallback)", () => {
+    // When no in_flight row exists for a shipment_item_id, the grouped query
+    // returns no row; the map lookup returns undefined and falls back to 0.
+    const totalReleased = 0;
+    const existingQuantity = 0;
+    const alreadyReleased = totalReleased - existingQuantity;
+    expect(alreadyReleased).toBe(0);
+  });
+});

--- a/src/lib/queries/gallery.ts
+++ b/src/lib/queries/gallery.ts
@@ -21,8 +21,8 @@ export interface GallerySpeciesDetail extends GallerySpecies {
   extra_img_2: string | null;
 }
 
-/** Base gallery query selecting all species columns for an institution. */
-async function queryGallerySpecies(institutionId: number) {
+/** Base gallery query selecting all species columns for an institution (cached per request). */
+const queryGallerySpecies = cache(async (institutionId: number) => {
   const ifc = inFlightCountSubquery(institutionId);
 
   return db
@@ -47,7 +47,7 @@ async function queryGallerySpecies(institutionId: number) {
     .leftJoin(ifc, eq(ifc.butterfly_species_id, butterfly_species.id))
     .where(eq(butterfly_species_institution.institution_id, institutionId))
     .orderBy(butterfly_species.common_name);
-}
+});
 
 /** Resolve overrides and return gallery-ready species list. */
 function resolveOverrides(
@@ -67,8 +67,8 @@ function resolveOverrides(
   }));
 }
 
-/** Gallery species for an institution (page-level, cached per request). */
-export const getGalleryData = cache(async (institutionId: number) => {
+/** Gallery species for an institution (page-level). */
+export async function getGalleryData(institutionId: number) {
   const rows = await queryGallerySpecies(institutionId);
   const species: GallerySpecies[] = resolveOverrides(rows).map((item) => ({
     id: item.id,
@@ -80,7 +80,7 @@ export const getGalleryData = cache(async (institutionId: number) => {
     in_flight_count: item.in_flight_count,
   }));
   return { species };
-});
+}
 
 /** Gallery species with all image columns (API route). */
 export async function getGalleryDetailData(institutionId: number) {

--- a/src/lib/queries/releases.ts
+++ b/src/lib/queries/releases.ts
@@ -74,7 +74,35 @@ function assertInFlightQuantity(quantity: UpdateInFlightQuantityBody["quantity"]
   }
 }
 
-function calculateRemaining(item: LockedShipmentItem, alreadyReleased: number) {
+type DrizzleTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Sum all in-flight quantities for a single shipment item, optionally
+ * excluding one specific in_flight row (used when updating an existing row).
+ */
+async function sumReleasedForItem(
+  tx: DrizzleTx,
+  institutionId: number,
+  shipmentItemId: number,
+  excludeInFlightId?: number,
+): Promise<number> {
+  const conditions = [
+    eq(in_flight.institution_id, institutionId),
+    eq(in_flight.shipment_item_id, shipmentItemId),
+  ];
+  if (excludeInFlightId !== undefined) {
+    conditions.push(ne(in_flight.id, excludeInFlightId));
+  }
+  const [row] = await tx
+    .select({
+      quantity: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as("quantity"),
+    })
+    .from(in_flight)
+    .where(and(...conditions));
+  return Number(row?.quantity ?? 0);
+}
+
+export function calculateRemaining(item: LockedShipmentItem, alreadyReleased: number) {
   const availableBeforeReleases =
     item.number_received -
     item.damaged_in_transit -
@@ -263,6 +291,7 @@ export async function updateReleaseEventItems(
       .select({
         id: in_flight.id,
         shipmentItemId: in_flight.shipment_item_id,
+        quantity: in_flight.quantity,
       })
       .from(in_flight)
       .where(
@@ -310,6 +339,26 @@ export async function updateReleaseEventItems(
 
     const lockedItemById = new Map(lockedItems.map((row) => [row.id, row]));
 
+    // Bulk-fetch total released per shipment item in one query, then subtract
+    // each item's own current quantity in JS — eliminates the per-item N+1.
+    const releasedTotalsRows = await tx
+      .select({
+        shipment_item_id: in_flight.shipment_item_id,
+        total: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as("total"),
+      })
+      .from(in_flight)
+      .where(
+        and(
+          eq(in_flight.institution_id, institutionId),
+          inArray(in_flight.shipment_item_id, shipmentItemIds),
+        ),
+      )
+      .groupBy(in_flight.shipment_item_id);
+
+    const releasedTotalByShipmentItemId = new Map(
+      releasedTotalsRows.map((row) => [row.shipment_item_id, Number(row.total)]),
+    );
+
     for (const item of payload.items) {
       const existing = existingByShipmentItemId.get(item.shipment_item_id);
       const locked = lockedItemById.get(item.shipment_item_id);
@@ -318,20 +367,10 @@ export async function updateReleaseEventItems(
         throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
       }
 
-      const [released] = await tx
-        .select({
-          quantity: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as("quantity"),
-        })
-        .from(in_flight)
-        .where(
-          and(
-            eq(in_flight.institution_id, institutionId),
-            eq(in_flight.shipment_item_id, item.shipment_item_id),
-            ne(in_flight.id, existing.id),
-          ),
-        );
-
-      const remaining = calculateRemaining(locked, Number(released?.quantity ?? 0));
+      // Total released minus the current row's quantity = released by other rows
+      const totalReleased = releasedTotalByShipmentItemId.get(item.shipment_item_id) ?? 0;
+      const alreadyReleased = totalReleased - existing.quantity;
+      const remaining = calculateRemaining(locked, alreadyReleased);
 
       if (item.quantity > remaining) {
         throw new Error(RELEASE_ERRORS.QUANTITY_EXCEEDS_REMAINING);
@@ -610,19 +649,8 @@ export async function createInFlightForRelease(
       throw new Error(RELEASE_ERRORS.IN_FLIGHT_ALREADY_EXISTS);
     }
 
-    const [released] = await tx
-      .select({
-        quantity: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as("quantity"),
-      })
-      .from(in_flight)
-      .where(
-        and(
-          eq(in_flight.institution_id, institutionId),
-          eq(in_flight.shipment_item_id, payload.shipment_item_id),
-        ),
-      );
-
-    const remaining = calculateRemaining(lockedItem, Number(released?.quantity ?? 0));
+    const alreadyReleased = await sumReleasedForItem(tx, institutionId, payload.shipment_item_id);
+    const remaining = calculateRemaining(lockedItem, alreadyReleased);
 
     if (payload.quantity > remaining) {
       throw new Error(RELEASE_ERRORS.QUANTITY_EXCEEDS_REMAINING);
@@ -695,20 +723,13 @@ export async function updateInFlightQuantity(
       throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
     }
 
-    const [released] = await tx
-      .select({
-        quantity: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as("quantity"),
-      })
-      .from(in_flight)
-      .where(
-        and(
-          eq(in_flight.institution_id, institutionId),
-          eq(in_flight.shipment_item_id, target.shipmentItemId),
-          ne(in_flight.id, inFlightId),
-        ),
-      );
-
-    const remaining = calculateRemaining(lockedItem, Number(released?.quantity ?? 0));
+    const alreadyReleased = await sumReleasedForItem(
+      tx,
+      institutionId,
+      target.shipmentItemId,
+      inFlightId,
+    );
+    const remaining = calculateRemaining(lockedItem, alreadyReleased);
 
     if (payload.quantity > remaining) {
       throw new Error(RELEASE_ERRORS.QUANTITY_EXCEEDS_REMAINING);

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -292,6 +292,12 @@ export const shipments = pgTable(
       table.institution_id,
       table.id,
     ),
+
+    // Tenant-scoped shipment list ordered by shipment_date (listShipments)
+    idx_shipments_institution_shipment_date: index("idx_shipments_institution_shipment_date").on(
+      table.institution_id,
+      table.shipment_date,
+    ),
   }),
 );
 
@@ -397,6 +403,16 @@ export const release_events = pgTable(
       table.institution_id,
       table.id,
     ),
+
+    // Tenant-scoped release list ordered by release_date (listInstitutionReleases)
+    idx_release_events_institution_release_date: index(
+      "idx_release_events_institution_release_date",
+    ).on(table.institution_id, table.release_date),
+
+    // Shipment-scoped release history ordered by release_date (listReleaseEventsForShipment)
+    idx_release_events_institution_shipment_release_date: index(
+      "idx_release_events_institution_shipment_release_date",
+    ).on(table.institution_id, table.shipment_id, table.release_date),
   }),
 );
 

--- a/src/lib/validation/public.ts
+++ b/src/lib/validation/public.ts
@@ -4,6 +4,7 @@ import { sanitizedNonEmpty } from "@/lib/validation/sanitize";
 import { institutionSlugSchema } from "@/lib/validation/slug";
 
 const scientificNameRegex = /^[A-Za-z0-9_.-]+$/;
+const PUBLIC_INSTITUTIONS_MAX_LIMIT = 100;
 
 export const institutionSlugParamsSchema = z
   .object({
@@ -22,7 +23,12 @@ export const publicEmptyQuerySchema = z.object({}).strict();
 export const publicInstitutionsQuerySchema = z
   .object({
     page: z.coerce.number().int().positive().default(1),
-    limit: z.coerce.number().int().positive().max(100).default(50),
+    limit: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(50)
+      .transform((value) => Math.min(value, PUBLIC_INSTITUTIONS_MAX_LIMIT)),
   })
   .strict();
 

--- a/src/lib/validation/public.ts
+++ b/src/lib/validation/public.ts
@@ -19,6 +19,13 @@ export const scientificNameParamsSchema = z
 
 export const publicEmptyQuerySchema = z.object({}).strict();
 
+export const publicInstitutionsQuerySchema = z
+  .object({
+    page: z.coerce.number().int().positive().default(1),
+    limit: z.coerce.number().int().positive().max(100).default(50),
+  })
+  .strict();
+
 export const publicTextFilterSchema = z
   .object({
     q: sanitizedNonEmpty(200).optional(),


### PR DESCRIPTION
## Summary

This PR resolves the main findings from backend mini-audit issue #44. It improves release/in-flight query performance, adds targeted composite indexes for tenant-scoped shipment and release queries, adds request-level gallery query deduplication, and introduces soft pagination for the public institutions API. The goal was to address the proven hot paths without expanding scope into unrelated schema changes.

## Changes

- removed the N+1 aggregation query in `updateReleaseEventItems` by replacing per-item sum queries with a single grouped aggregation query
- extracted shared in-flight aggregation logic in `src/lib/queries/releases.ts` for reuse in release/in-flight update paths
- added composite indexes:
  - `shipments (institution_id, shipment_date)`
  - `release_events (institution_id, release_date)`
  - `release_events (institution_id, shipment_id, release_date)`
- added request-level dedupe for gallery queries by moving `cache()` to the shared base gallery query
- added soft pagination to `GET /api/public/institutions`
  - supports `page` and `limit`
  - preserves the top-level `institutions` array
  - adds `pagination: { page, limit, total, totalPages }`
  - validates and caps `limit`
- updated tests for release helpers, gallery query behavior, schema, and public institutions pagination
- updated docs for the public institutions API contract and database index policy

## Test Plan

- [x] Ran pnpm test
- [x] Verified final targeted sweep passes: 121 tests, 0 failures
- [x] Ran TypeScript typecheck: `pnpm exec tsc --noEmit --project tsconfig.test.json`
- [ ] Manual smoke test release edit flow in tenant admin
- [ ] Manual smoke test shipment and release list pages
- [ ] Manual smoke test `/api/public/institutions?page=1&limit=10`
- [ ] Manual smoke test public gallery and gallery detail pages
