### PR TITLE
fix: refactor shipment release flow

### DIFF
--- a/docs/api/API_ARCHITECTURE_V3.md
+++ b/docs/api/API_ARCHITECTURE_V3.md
@@ -172,14 +172,14 @@ All errors use a consistent JSON envelope:
 
 ### Status codes
 
-| Code  | Meaning                                                                                     |
-| ----- | ------------------------------------------------------------------------------------------- |
-| `400` | Invalid input (validation failure, missing slug header)                                     |
-| `401` | Not authenticated                                                                           |
-| `403` | Permission denied or wrong-tenant slug (slug exists but belongs to a different institution) |
-| `404` | Resource does not exist                                                                     |
-| `409` | Conflict (unique constraint violation)                                                      |
-| `500` | Unexpected internal error                                                                   |
+| Code  | Meaning                                                                                       |
+| ----- | --------------------------------------------------------------------------------------------- |
+| `400` | Invalid input (validation failure, missing slug header)                                       |
+| `401` | Not authenticated                                                                             |
+| `403` | Permission denied or wrong-tenant slug (slug exists but belongs to a different institution)   |
+| `404` | Resource does not exist                                                                       |
+| `409` | Conflict (unique constraint violation or domain-state conflict, e.g. quantity/rollback guard) |
+| `500` | Unexpected internal error                                                                     |
 
 ### Sentinel error → HTTP mapping (route catch blocks)
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -321,7 +321,8 @@ Response shape:
       "shipmentDate": "2026-03-01T00:00:00.000Z",
       "releaseDate": "2026-03-13T00:00:00.000Z",
       "releasedBy": "Alice",
-      "totalReleased": 25
+      "totalReleased": 25,
+      "totalLosses": 4
     }
   ],
   "pagination": {
@@ -350,9 +351,25 @@ Returns `400 INVALID_REQUEST` for non-numeric `page` / `limit` values or
       "shipment_item_id": 101,
       "quantity": 8
     }
+  ],
+  "losses": [
+    {
+      "shipment_item_id": 101,
+      "damaged_in_transit": 0,
+      "diseased_in_transit": 0,
+      "parasite": 0,
+      "non_emergence": 0,
+      "poor_emergence": 2
+    }
   ]
 }
 ```
+
+- `items` and `losses` are event-level final values for the target release event.
+- `items` quantities are nonnegative integers (0 allowed on edit).
+- `losses` quantities are nonnegative integers (0 allowed on edit).
+- A patch that results in all in-flight and all losses being 0 is rejected (`400 INVALID_REQUEST`).
+- If `losses` is omitted, existing `release_event_losses` rows are preserved (non-destructive compatibility behavior).
 
 `GET /api/tenant/releases/[releaseId]` response shape:
 
@@ -370,9 +387,25 @@ Returns `400 INVALID_REQUEST` for non-numeric `page` / `limit` values or
       "shipmentItemId": 101,
       "quantity": 8
     }
+  ],
+  "losses": [
+    {
+      "id": 11,
+      "shipmentItemId": 101,
+      "damagedInTransit": 0,
+      "diseasedInTransit": 0,
+      "parasite": 0,
+      "nonEmergence": 0,
+      "poorEmergence": 2
+    }
   ]
 }
 ```
+
+`DELETE /api/tenant/releases/[releaseId]`:
+
+- Returns `200 OK` with `{ "deleted": true }` on success.
+- Returns `409 CONFLICT` when delete rollback would reduce shipment loss totals below 0.
 
 ### Tenant institution PATCH contract
 
@@ -523,7 +556,9 @@ Response shape:
       "id": 500,
       "shipmentId": 55,
       "releaseDate": "2026-03-13T12:00:00.000Z",
-      "releasedBy": "Release Admin"
+      "releasedBy": "Release Admin",
+      "totalReleased": 20,
+      "totalLosses": 2
     }
   ]
 }
@@ -534,11 +569,26 @@ Response shape:
 ```json
 {
   "released_at": "2026-03-13T12:00:00.000Z",
-  "items": [{ "shipment_item_id": 101, "quantity": 20 }]
+  "items": [{ "shipment_item_id": 101, "quantity": 20 }],
+  "loss_updates": [
+    {
+      "shipment_item_id": 101,
+      "damaged_in_transit": 1,
+      "diseased_in_transit": 0,
+      "parasite": 0,
+      "non_emergence": 0,
+      "poor_emergence": 2
+    }
+  ]
 }
 ```
 
-- `released_at` is optional. `items` is required (min 1, no duplicate `shipment_item_id`).
+- `released_at` is optional.
+- Create supports in-flight only, losses only, or mixed payloads.
+- At least one release item or at least one loss-update value is required.
+- `loss_updates` values are absolute shipment-item totals in create flow (not event deltas).
+- Decreasing an existing shipment-item loss total via create is rejected (`409 CONFLICT`).
+- Duplicate `shipment_item_id` values are rejected within `items` and within `loss_updates`.
 
 ### Tenant in-flight row contracts
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -72,6 +72,9 @@ PostgreSQL 17 managed via Drizzle ORM:
 - **Butterfly Species Institution** — Institution-specific species details (common name, description, image)
 - **Supplier** — Global butterfly vendor/supplier code used by shipments and imports
 - **Shipment** — A butterfly shipment record with quality/damage tracking metrics
+- **Release Event** — A release workflow event linked to a shipment (`release_date`, `released_by`)
+- **In Flight** — Event-level released quantities per shipment item (good-emergence release rows)
+- **Release Event Losses** — Event-level loss attribution rows captured during create/edit release workflows
 
 ### Key Relationships
 
@@ -79,7 +82,9 @@ PostgreSQL 17 managed via Drizzle ORM:
 Institution ─┬─ Users
               ├─ Butterfly Species Institution ── Butterfly Species (global)
               └─ Shipments ─┬─ Butterfly Species (global)
-                            └─ Supplier (global by code)
+                            ├─ Supplier (global by code)
+                            └─ Release Events ─┬─ In Flight
+                                               └─ Release Event Losses
 ```
 
 ## API Routes
@@ -112,6 +117,12 @@ Institution ─┬─ Users
   - `POST /api/tenant/shipments/import/preview` — Tenant-scoped parse + validate historical input (no writes).
   - `POST /api/tenant/shipments/import/commit` — Tenant-scoped commit using preview hash.
   - `GET /api/tenant/shipments/export?format=xlsx[&from=YYYY-MM-DD][&to=YYYY-MM-DD]` — Tenant-scoped XLSX export, optionally filtered by date range.
+- Tenant release endpoints (requires `x-tenant-slug` header):
+  - `GET /api/tenant/releases` — Paginated release list with additive `totalReleased` and `totalLosses`.
+  - `GET /api/tenant/releases/[releaseId]` — Release detail including `event`, `items` (in-flight), and `losses` (release_event_losses).
+  - `POST /api/tenant/shipments/[id]/releases` — Create release; accepts `items` plus create-only `loss_updates` absolute shipment totals.
+  - `PATCH /api/tenant/releases/[releaseId]` — Edit release; accepts event-level `items` and event-level `losses`.
+  - `DELETE /api/tenant/releases/[releaseId]` — Delete release; rolls back in-flight and release-attributed loss quantities, with underflow protection.
 
 ### Backend Architecture
 

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -33,6 +33,8 @@ Tenant isolation is enforced at the database level using composite foreign keys 
 - `release_events (institution_id, shipment_id) -> shipments (institution_id, id)` — `CASCADE`
 - `in_flight (institution_id, release_event_id) -> release_events (institution_id, id)` — `CASCADE`
 - `in_flight (institution_id, shipment_item_id) -> shipment_items (institution_id, id)` — `RESTRICT`
+- `release_event_losses (institution_id, release_event_id) -> release_events (institution_id, id)` — `CASCADE`
+- `release_event_losses (institution_id, shipment_item_id) -> shipment_items (institution_id, id)` — `RESTRICT`
 
 Composite tenant keys prevent cross-tenant references even if a raw numeric ID exists in another
 institution. The supplier relationship is intentionally global by code so historical imports can
@@ -54,6 +56,8 @@ Current performance indexes:
 | `idx_shipments_institution_shipment_date`              | `shipments`                     | `(institution_id, shipment_date)`             | Paginated shipment list (filter + sort)         |
 | `idx_release_events_institution_release_date`          | `release_events`                | `(institution_id, release_date)`              | Paginated release list (filter + sort)          |
 | `idx_release_events_institution_shipment_release_date` | `release_events`                | `(institution_id, shipment_id, release_date)` | Shipment-scoped release history (filter + sort) |
+| `idx_release_event_losses_institution_event`           | `release_event_losses`          | `(institution_id, release_event_id)`          | Release detail loss-attribution lookup          |
+| `idx_release_event_losses_institution_shipment_item`   | `release_event_losses`          | `(institution_id, shipment_item_id)`          | Edit/delete rollback loss aggregation           |
 
 ## Docker
 

--- a/drizzle/0005_pale_chimera.sql
+++ b/drizzle/0005_pale_chimera.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "release_event_losses" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"institution_id" integer NOT NULL,
+	"release_event_id" integer NOT NULL,
+	"shipment_item_id" integer NOT NULL,
+	"damaged_in_transit" integer DEFAULT 0 NOT NULL,
+	"diseased_in_transit" integer DEFAULT 0 NOT NULL,
+	"parasite" integer DEFAULT 0 NOT NULL,
+	"non_emergence" integer DEFAULT 0 NOT NULL,
+	"poor_emergence" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "ck_release_event_losses_damaged_nonnegative" CHECK ("release_event_losses"."damaged_in_transit" >= 0),
+	CONSTRAINT "ck_release_event_losses_diseased_nonnegative" CHECK ("release_event_losses"."diseased_in_transit" >= 0),
+	CONSTRAINT "ck_release_event_losses_parasite_nonnegative" CHECK ("release_event_losses"."parasite" >= 0),
+	CONSTRAINT "ck_release_event_losses_non_emergence_nonnegative" CHECK ("release_event_losses"."non_emergence" >= 0),
+	CONSTRAINT "ck_release_event_losses_poor_emergence_nonnegative" CHECK ("release_event_losses"."poor_emergence" >= 0)
+);
+--> statement-breakpoint
+ALTER TABLE "release_event_losses" ADD CONSTRAINT "release_event_losses_institution_id_institutions_id_fk" FOREIGN KEY ("institution_id") REFERENCES "public"."institutions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "release_event_losses" ADD CONSTRAINT "fk_release_event_losses_event_institution" FOREIGN KEY ("institution_id","release_event_id") REFERENCES "public"."release_events"("institution_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "release_event_losses" ADD CONSTRAINT "fk_release_event_losses_shipment_item_institution" FOREIGN KEY ("institution_id","shipment_item_id") REFERENCES "public"."shipment_items"("institution_id","id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_release_event_losses_shipment_item" ON "release_event_losses" USING btree ("release_event_id","shipment_item_id");--> statement-breakpoint
+CREATE INDEX "idx_release_event_losses_institution_event" ON "release_event_losses" USING btree ("institution_id","release_event_id");--> statement-breakpoint
+CREATE INDEX "idx_release_event_losses_institution_shipment_item" ON "release_event_losses" USING btree ("institution_id","shipment_item_id");

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1520 @@
+{
+  "id": "2daacc6a-f6a2-4673-a4c0-c1e640ed22c8",
+  "prevId": "4ad08285-2590-4906-a255-e08c447990f8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.butterfly_species": {
+      "name": "butterfly_species",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scientific_name": {
+          "name": "scientific_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name": {
+          "name": "common_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_family": {
+          "name": "sub_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifespan_days": {
+          "name": "lifespan_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range": {
+          "name": "range",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_plant": {
+          "name": "host_plant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "habitat": {
+          "name": "habitat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fun_facts": {
+          "name": "fun_facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "img_wings_open": {
+          "name": "img_wings_open",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "img_wings_closed": {
+          "name": "img_wings_closed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_img_1": {
+          "name": "extra_img_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_img_2": {
+          "name": "extra_img_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "butterfly_species_scientific_name_unique": {
+          "name": "butterfly_species_scientific_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scientific_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.butterfly_species_institution": {
+      "name": "butterfly_species_institution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "butterfly_species_id": {
+          "name": "butterfly_species_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name_override": {
+          "name": "common_name_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifespan_override": {
+          "name": "lifespan_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_institution_species": {
+          "name": "unique_institution_species",
+          "columns": [
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bsi_institution_id": {
+          "name": "idx_bsi_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "butterfly_species_institution_butterfly_species_id_butterfly_species_id_fk": {
+          "name": "butterfly_species_institution_butterfly_species_id_butterfly_species_id_fk",
+          "tableFrom": "butterfly_species_institution",
+          "tableTo": "butterfly_species",
+          "columnsFrom": [
+            "butterfly_species_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "butterfly_species_institution_institution_id_institutions_id_fk": {
+          "name": "butterfly_species_institution_institution_id_institutions_id_fk",
+          "tableFrom": "butterfly_species_institution",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_flight": {
+      "name": "in_flight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_event_id": {
+          "name": "release_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_item_id": {
+          "name": "shipment_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_in_flight_shipment_item": {
+          "name": "unique_in_flight_shipment_item",
+          "columns": [
+            {
+              "expression": "release_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_flight_institution_shipment_item": {
+          "name": "idx_in_flight_institution_shipment_item",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_flight_institution_id_institutions_id_fk": {
+          "name": "in_flight_institution_id_institutions_id_fk",
+          "tableFrom": "in_flight",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_in_flight_event_institution": {
+          "name": "fk_in_flight_event_institution",
+          "tableFrom": "in_flight",
+          "tableTo": "release_events",
+          "columnsFrom": [
+            "institution_id",
+            "release_event_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_in_flight_shipment_item_institution": {
+          "name": "fk_in_flight_shipment_item_institution",
+          "tableFrom": "in_flight",
+          "tableTo": "shipment_items",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_item_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institution_news": {
+      "name": "institution_news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_institution_news_institution_id": {
+          "name": "idx_institution_news_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "institution_news_institution_id_institutions_id_fk": {
+          "name": "institution_news_institution_id_institutions_id_fk",
+          "tableFrom": "institution_news",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street_address": {
+          "name": "street_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extended_address": {
+          "name": "extended_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_province": {
+          "name": "state_province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iabes_member": {
+          "name": "iabes_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_colors": {
+          "name": "theme_colors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volunteer_url": {
+          "name": "volunteer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "donation_url": {
+          "name": "donation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_image_url": {
+          "name": "facility_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_active": {
+          "name": "stats_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_slug_unique": {
+          "name": "institutions_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "institutions_email_address_unique": {
+          "name": "institutions_email_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.release_event_losses": {
+      "name": "release_event_losses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_event_id": {
+          "name": "release_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_item_id": {
+          "name": "shipment_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "damaged_in_transit": {
+          "name": "damaged_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "diseased_in_transit": {
+          "name": "diseased_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parasite": {
+          "name": "parasite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "non_emergence": {
+          "name": "non_emergence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "poor_emergence": {
+          "name": "poor_emergence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_release_event_losses_shipment_item": {
+          "name": "unique_release_event_losses_shipment_item",
+          "columns": [
+            {
+              "expression": "release_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_release_event_losses_institution_event": {
+          "name": "idx_release_event_losses_institution_event",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_release_event_losses_institution_shipment_item": {
+          "name": "idx_release_event_losses_institution_shipment_item",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "release_event_losses_institution_id_institutions_id_fk": {
+          "name": "release_event_losses_institution_id_institutions_id_fk",
+          "tableFrom": "release_event_losses",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_release_event_losses_event_institution": {
+          "name": "fk_release_event_losses_event_institution",
+          "tableFrom": "release_event_losses",
+          "tableTo": "release_events",
+          "columnsFrom": [
+            "institution_id",
+            "release_event_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_release_event_losses_shipment_item_institution": {
+          "name": "fk_release_event_losses_shipment_item_institution",
+          "tableFrom": "release_event_losses",
+          "tableTo": "shipment_items",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_item_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_release_event_losses_damaged_nonnegative": {
+          "name": "ck_release_event_losses_damaged_nonnegative",
+          "value": "\"release_event_losses\".\"damaged_in_transit\" >= 0"
+        },
+        "ck_release_event_losses_diseased_nonnegative": {
+          "name": "ck_release_event_losses_diseased_nonnegative",
+          "value": "\"release_event_losses\".\"diseased_in_transit\" >= 0"
+        },
+        "ck_release_event_losses_parasite_nonnegative": {
+          "name": "ck_release_event_losses_parasite_nonnegative",
+          "value": "\"release_event_losses\".\"parasite\" >= 0"
+        },
+        "ck_release_event_losses_non_emergence_nonnegative": {
+          "name": "ck_release_event_losses_non_emergence_nonnegative",
+          "value": "\"release_event_losses\".\"non_emergence\" >= 0"
+        },
+        "ck_release_event_losses_poor_emergence_nonnegative": {
+          "name": "ck_release_event_losses_poor_emergence_nonnegative",
+          "value": "\"release_event_losses\".\"poor_emergence\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.release_events": {
+      "name": "release_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_by": {
+          "name": "released_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_release_events_institution_release_date": {
+          "name": "idx_release_events_institution_release_date",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_release_events_institution_shipment_release_date": {
+          "name": "idx_release_events_institution_shipment_release_date",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "release_events_institution_id_institutions_id_fk": {
+          "name": "release_events_institution_id_institutions_id_fk",
+          "tableFrom": "release_events",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_release_events_shipment_institution": {
+          "name": "fk_release_events_shipment_institution",
+          "tableFrom": "release_events",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_release_event_id_per_institution": {
+          "name": "unique_release_event_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipment_items": {
+      "name": "shipment_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "butterfly_species_id": {
+          "name": "butterfly_species_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_received": {
+          "name": "number_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emerged_in_transit": {
+          "name": "emerged_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "damaged_in_transit": {
+          "name": "damaged_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "diseased_in_transit": {
+          "name": "diseased_in_transit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parasite": {
+          "name": "parasite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "non_emergence": {
+          "name": "non_emergence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "poor_emergence": {
+          "name": "poor_emergence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_shipment_species": {
+          "name": "unique_shipment_species",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipment_items_institution_species": {
+          "name": "idx_shipment_items_institution_species",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "butterfly_species_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_items_institution_id_institutions_id_fk": {
+          "name": "shipment_items_institution_id_institutions_id_fk",
+          "tableFrom": "shipment_items",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shipment_items_butterfly_species_id_butterfly_species_id_fk": {
+          "name": "shipment_items_butterfly_species_id_butterfly_species_id_fk",
+          "tableFrom": "shipment_items",
+          "tableTo": "butterfly_species",
+          "columnsFrom": [
+            "butterfly_species_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fk_shipment_items_shipment_institution": {
+          "name": "fk_shipment_items_shipment_institution",
+          "tableFrom": "shipment_items",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "institution_id",
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "institution_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_shipment_item_id_per_institution": {
+          "name": "unique_shipment_item_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipments": {
+      "name": "shipments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_date": {
+          "name": "shipment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrival_date": {
+          "name": "arrival_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shipments_institution_shipment_date": {
+          "name": "idx_shipments_institution_shipment_date",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shipment_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipments_institution_id_institutions_id_fk": {
+          "name": "shipments_institution_id_institutions_id_fk",
+          "tableFrom": "shipments",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_shipments_supplier_code": {
+          "name": "fk_shipments_supplier_code",
+          "tableFrom": "shipments",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_shipment_id_per_institution": {
+          "name": "unique_shipment_id_per_institution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "institution_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_supplier_code": {
+          "name": "unique_supplier_code",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_institution_id": {
+          "name": "idx_users_institution_id",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_institution_id_institutions_id_fk": {
+          "name": "users_institution_id_institutions_id_fk",
+          "tableFrom": "users",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1776791250075,
       "tag": "0004_odd_reaper",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777043238117,
+      "tag": "0005_pale_chimera",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__test__/api/tenant/releases.route.test.ts
+++ b/src/__test__/api/tenant/releases.route.test.ts
@@ -228,8 +228,16 @@ describe("Tenant Releases API", () => {
       const body = await response.json();
       expect(Array.isArray(body.releases)).toBe(true);
       expect(body.releases).toHaveLength(1);
-      expect(body.releases[0].id).toBe(9);
-      expect(body.releases[0].totalLosses).toBe(4);
+      expect(body.releases[0]).toEqual({
+        id: 9,
+        shipmentId: 55,
+        supplierCode: "SUP-1",
+        shipmentDate: "2026-03-01",
+        releaseDate: "2026-03-13",
+        releasedBy: "Alice",
+        totalReleased: 25,
+        totalLosses: 4,
+      });
       expect(body.pagination).toEqual({ page: 1, limit: 50, total: 1, totalPages: 1 });
       expect(mockGetTenantReleases).toHaveBeenCalledWith({ slug: SLUG, page: 1, limit: 50 });
     });

--- a/src/__test__/api/tenant/releases.route.test.ts
+++ b/src/__test__/api/tenant/releases.route.test.ts
@@ -7,6 +7,12 @@ jest.mock("@/lib/services/tenant-shipments", () => ({
     SHIPMENT_NOT_FOUND: "Shipment not found",
     SHIPMENT_ITEM_NOT_FOUND: "Shipment item not found",
     QUANTITY_EXCEEDS_REMAINING: "Quantity exceeds remaining available butterflies",
+    NEGATIVE_LOSS_DELTA:
+      "Create release loss_updates cannot decrease shipment loss totals; use shipment edit for corrections",
+    EMPTY_RELEASE_EVENT:
+      "Release must include at least one in-flight or loss quantity; delete release instead",
+    LOSS_TOTAL_UNDERFLOW:
+      "Release edit would reduce shipment loss totals below zero; adjust shipment totals first",
   },
   createTenantRelease: jest.fn(),
 }));
@@ -22,8 +28,10 @@ jest.mock("@/lib/services/tenant-releases", () => ({
     IN_FLIGHT_ALREADY_EXISTS: "In-flight row already exists for this release item",
     SHIPMENT_ITEM_RELEASE_MISMATCH: "Shipment item does not belong to the release shipment",
     QUANTITY_EXCEEDS_REMAINING: "Quantity exceeds remaining available butterflies",
-    RELEASE_ITEMS_MUST_MATCH:
-      "Release update must include every existing in-flight row for the release event",
+    EMPTY_RELEASE_EVENT:
+      "Release must include at least one in-flight or loss quantity; delete release instead",
+    LOSS_TOTAL_UNDERFLOW:
+      "Release edit would reduce shipment loss totals below zero; adjust shipment totals first",
   },
   getTenantReleases: jest.fn(),
   getTenantReleaseById: jest.fn(),
@@ -140,6 +148,14 @@ function validCreateReleasePayload() {
   };
 }
 
+function validLossOnlyReleasePayload() {
+  return {
+    released_at: "2026-03-13T12:00:00.000Z",
+    items: [],
+    loss_updates: [{ shipment_item_id: 101, poor_emergence: 2 }],
+  };
+}
+
 function validInFlightPayload() {
   return {
     shipment_item_id: 101,
@@ -200,6 +216,7 @@ describe("Tenant Releases API", () => {
             releaseDate: "2026-03-13",
             releasedBy: "Alice",
             totalReleased: 25,
+            totalLosses: 4,
           },
         ],
         pagination: { page: 1, limit: 50, total: 1, totalPages: 1 },
@@ -212,6 +229,7 @@ describe("Tenant Releases API", () => {
       expect(Array.isArray(body.releases)).toBe(true);
       expect(body.releases).toHaveLength(1);
       expect(body.releases[0].id).toBe(9);
+      expect(body.releases[0].totalLosses).toBe(4);
       expect(body.pagination).toEqual({ page: 1, limit: 50, total: 1, totalPages: 1 });
       expect(mockGetTenantReleases).toHaveBeenCalledWith({ slug: SLUG, page: 1, limit: 50 });
     });
@@ -342,6 +360,19 @@ describe("Tenant Releases API", () => {
       expect((await response.json()).error.code).toBe("CONFLICT");
     });
 
+    it("returns 409 when create loss_updates attempts to decrease existing losses", async () => {
+      mockCreateTenantRelease.mockRejectedValueOnce(
+        new Error(SHIPMENT_RELEASE_ERRORS.NEGATIVE_LOSS_DELTA),
+      );
+
+      const response = (await postReleaseFromShipment(
+        makePostShipmentReleaseRequest("55", validCreateReleasePayload(), SLUG),
+        shipmentRouteContext("55"),
+      ))!;
+      expect(response.status).toBe(409);
+      expect((await response.json()).error.code).toBe("CONFLICT");
+    });
+
     it("returns 201 on successful release creation", async () => {
       mockCreateTenantRelease.mockResolvedValueOnce({
         event: {
@@ -365,6 +396,27 @@ describe("Tenant Releases API", () => {
       const body = await response.json();
       expect(body.release.event.id).toBe(500);
       expect(body.release.items).toHaveLength(2);
+      expect(mockCreateTenantRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: SLUG, shipmentId: 55 }),
+      );
+    });
+
+    it("returns 201 for a losses-only release payload (no in-flight rows)", async () => {
+      mockCreateTenantRelease.mockResolvedValueOnce({
+        event: {
+          id: 501,
+          shipmentId: 55,
+          releaseDate: "2026-03-13T12:00:00.000Z",
+          releasedBy: "Release Admin",
+        },
+        items: [],
+      });
+
+      const response = (await postReleaseFromShipment(
+        makePostShipmentReleaseRequest("55", validLossOnlyReleasePayload(), SLUG),
+        shipmentRouteContext("55"),
+      ))!;
+      expect(response.status).toBe(201);
       expect(mockCreateTenantRelease).toHaveBeenCalledWith(
         expect.objectContaining({ slug: SLUG, shipmentId: 55 }),
       );
@@ -582,7 +634,7 @@ describe("Tenant Releases API", () => {
       expect((await response.json()).error.code).toBe("NOT_FOUND");
     });
 
-    it("returns 200 with event and items", async () => {
+    it("returns 200 with event, items, and losses", async () => {
       mockGetTenantReleaseById.mockResolvedValueOnce({
         event: {
           id: 500,
@@ -593,6 +645,17 @@ describe("Tenant Releases API", () => {
         items: [
           { id: 1, shipmentItemId: 101, quantity: 20 },
           { id: 2, shipmentItemId: 102, quantity: 5 },
+        ],
+        losses: [
+          {
+            id: 11,
+            shipmentItemId: 101,
+            damagedInTransit: 0,
+            diseasedInTransit: 0,
+            parasite: 0,
+            nonEmergence: 0,
+            poorEmergence: 2,
+          },
         ],
       });
 
@@ -605,6 +668,8 @@ describe("Tenant Releases API", () => {
       const body = await response.json();
       expect(body.event.id).toBe(500);
       expect(body.items).toHaveLength(2);
+      expect(body.losses).toHaveLength(1);
+      expect(body.losses[0].poorEmergence).toBe(2);
       expect(mockGetTenantReleaseById).toHaveBeenCalledWith({ slug: SLUG, releaseId: 500 });
     });
   });
@@ -735,9 +800,9 @@ describe("Tenant Releases API", () => {
       expect((await response.json()).error.code).toBe("INVALID_REQUEST");
     });
 
-    it("returns 400 when payload omits an existing release in-flight row", async () => {
+    it("returns 400 when patch would result in an empty release", async () => {
       mockUpdateTenantRelease.mockRejectedValueOnce(
-        new Error(TENANT_RELEASE_ERRORS.RELEASE_ITEMS_MUST_MATCH),
+        new Error(TENANT_RELEASE_ERRORS.EMPTY_RELEASE_EVENT),
       );
 
       const response = (await patchReleaseById(
@@ -746,6 +811,19 @@ describe("Tenant Releases API", () => {
       ))!;
       expect(response.status).toBe(400);
       expect((await response.json()).error.code).toBe("INVALID_REQUEST");
+    });
+
+    it("returns 409 when loss rollback would underflow shipment totals", async () => {
+      mockUpdateTenantRelease.mockRejectedValueOnce(
+        new Error(TENANT_RELEASE_ERRORS.LOSS_TOTAL_UNDERFLOW),
+      );
+
+      const response = (await patchReleaseById(
+        makeReleasePatchRequest("500", validReleasePatchPayload(), SLUG),
+        releaseRouteContext("500"),
+      ))!;
+      expect(response.status).toBe(409);
+      expect((await response.json()).error.code).toBe("CONFLICT");
     });
 
     it("returns 200 on successful update", async () => {
@@ -826,6 +904,19 @@ describe("Tenant Releases API", () => {
       ))!;
       expect(response.status).toBe(404);
       expect((await response.json()).error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 409 when delete rollback would underflow shipment losses", async () => {
+      mockDeleteTenantRelease.mockRejectedValueOnce(
+        new Error(TENANT_RELEASE_ERRORS.LOSS_TOTAL_UNDERFLOW),
+      );
+
+      const response = (await deleteReleaseById(
+        makeReleaseDetailRequest("500", "DELETE", SLUG),
+        releaseRouteContext("500"),
+      ))!;
+      expect(response.status).toBe(409);
+      expect((await response.json()).error.code).toBe("CONFLICT");
     });
 
     it("returns 200 on successful delete", async () => {

--- a/src/__test__/api/tenant/shipments.route.test.ts
+++ b/src/__test__/api/tenant/shipments.route.test.ts
@@ -747,8 +747,20 @@ describe("Shipments API", () => {
 
     it("returns 200 with release events list", async () => {
       mockGetTenantShipmentReleases.mockResolvedValueOnce([
-        { id: 3, releaseDate: new Date("2025-03-10"), releasedBy: "Alice" },
-        { id: 1, releaseDate: new Date("2025-03-01"), releasedBy: "Bob" },
+        {
+          id: 3,
+          releaseDate: new Date("2025-03-10"),
+          releasedBy: "Alice",
+          totalReleased: 12,
+          totalLosses: 4,
+        },
+        {
+          id: 1,
+          releaseDate: new Date("2025-03-01"),
+          releasedBy: "Bob",
+          totalReleased: 5,
+          totalLosses: 0,
+        },
       ]);
 
       const response = (await getShipmentReleases(
@@ -760,6 +772,8 @@ describe("Shipments API", () => {
       const body = await response.json();
       expect(body.releaseEvents).toHaveLength(2);
       expect(body.releaseEvents[0].id).toBe(3);
+      expect(body.releaseEvents[0].totalReleased).toBe(12);
+      expect(body.releaseEvents[0].totalLosses).toBe(4);
       expect(mockGetTenantShipmentReleases).toHaveBeenCalledWith({ slug: SLUG, id: 5 });
     });
   });

--- a/src/__test__/api/tenant/shipments.route.test.ts
+++ b/src/__test__/api/tenant/shipments.route.test.ts
@@ -771,9 +771,23 @@ describe("Shipments API", () => {
 
       const body = await response.json();
       expect(body.releaseEvents).toHaveLength(2);
-      expect(body.releaseEvents[0].id).toBe(3);
-      expect(body.releaseEvents[0].totalReleased).toBe(12);
-      expect(body.releaseEvents[0].totalLosses).toBe(4);
+      expect(body.releaseEvents[0]).toEqual({
+        id: 3,
+        releaseDate: "2025-03-10T00:00:00.000Z",
+        releasedBy: "Alice",
+        totalReleased: 12,
+        totalLosses: 4,
+      });
+      expect(body.releaseEvents[1]).toEqual({
+        id: 1,
+        releaseDate: "2025-03-01T00:00:00.000Z",
+        releasedBy: "Bob",
+        totalReleased: 5,
+        totalLosses: 0,
+      });
+      expect(new Date(body.releaseEvents[0].releaseDate).getTime()).toBeGreaterThan(
+        new Date(body.releaseEvents[1].releaseDate).getTime(),
+      );
       expect(mockGetTenantShipmentReleases).toHaveBeenCalledWith({ slug: SLUG, id: 5 });
     });
   });

--- a/src/app/[institution]/(tenant)/shipments/[id]/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/[id]/page.tsx
@@ -33,17 +33,11 @@ import {
 } from "@/components/ui/table";
 import {
   computeItemRemaining,
+  type ReleaseHistoryRow,
   type ShipmentDetailResponse,
   type ShipmentItemRow,
   type SpeciesPickerOption,
 } from "@/components/tenant/shipments/types";
-
-type ShipmentReleaseRow = {
-  id: number;
-  releaseDate: string;
-  releasedBy: string;
-  totalReleased: number;
-};
 
 const dateFormatter = new Intl.DateTimeFormat("en-US", {
   month: "short",
@@ -83,7 +77,7 @@ export default function ShipmentDetailPage() {
   const shipmentId = Number(params?.id);
 
   const [data, setData] = useState<ShipmentDetailResponse | null>(null);
-  const [releases, setReleases] = useState<ShipmentReleaseRow[]>([]);
+  const [releases, setReleases] = useState<ReleaseHistoryRow[]>([]);
   const [status, setStatus] = useState<"idle" | "loading" | "error">("loading");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -139,7 +133,10 @@ export default function ShipmentDetailPage() {
           const releasesResult = await releasesResponse.json().catch(() => null);
           if (signal?.aborted) return;
           const events = Array.isArray(releasesResult?.releaseEvents)
-            ? releasesResult.releaseEvents
+            ? (releasesResult.releaseEvents as ReleaseHistoryRow[]).map((row) => ({
+                ...row,
+                totalLosses: Number(row.totalLosses ?? 0),
+              }))
             : [];
           setReleases(events);
         } else {
@@ -540,6 +537,7 @@ export default function ShipmentDetailPage() {
                     <TableHead>Release date</TableHead>
                     <TableHead>Released by</TableHead>
                     <TableHead className="text-right">Released</TableHead>
+                    <TableHead className="text-right">Losses</TableHead>
                     <TableHead className="text-right">Action</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -551,6 +549,7 @@ export default function ShipmentDetailPage() {
                       </TableCell>
                       <TableCell>{release.releasedBy}</TableCell>
                       <TableCell className="text-right">{release.totalReleased}</TableCell>
+                      <TableCell className="text-right">{release.totalLosses}</TableCell>
                       <TableCell className="text-right">
                         <Button asChild size="sm" variant="outline">
                           <Link

--- a/src/app/[institution]/(tenant)/shipments/[id]/release/[releaseId]/edit/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/[id]/release/[releaseId]/edit/page.tsx
@@ -2,16 +2,29 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { notFound, useParams, useRouter } from "next/navigation";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { ROUTES } from "@/lib/routes";
 
 import {
-  ReleaseComposer,
-  type ReleaseQuantities,
-} from "@/components/tenant/releases/release-composer";
+  ReleaseEditComposer,
+  type ReleaseEditLossesByItem,
+  type ReleaseEditLossField,
+  type ReleaseEditLossValues,
+  type ReleaseEditQuantities,
+} from "@/components/tenant/releases/release-edit-composer";
 import type {
   ReleaseEventDetail,
   ShipmentDetailResponse,
@@ -38,14 +51,19 @@ export default function EditReleasePage() {
 
   const [release, setRelease] = useState<ReleaseEventDetail | null>(null);
   const [shipment, setShipment] = useState<ShipmentDetailResponse | null>(null);
-  const [values, setValues] = useState<ReleaseQuantities>({});
-  const [originalValues, setOriginalValues] = useState<ReleaseQuantities>({});
+  const [releaseValues, setReleaseValues] = useState<ReleaseEditQuantities>({});
+  const [originalReleaseValues, setOriginalReleaseValues] = useState<ReleaseEditQuantities>({});
+  const [lossValues, setLossValues] = useState<ReleaseEditLossesByItem>({});
+  const [originalLossValues, setOriginalLossValues] = useState<ReleaseEditLossesByItem>({});
   const [status, setStatus] = useState<"idle" | "loading" | "error">("loading");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const tenantHeaders = useMemo(() => ({ "x-tenant-slug": slug }), [slug]);
   const detailHref = ROUTES.tenant.shipmentById(slug, shipmentId);
+  const errorMessageId = "release-edit-error-message";
 
   const handleGoBack = () => router.back();
 
@@ -89,12 +107,26 @@ export default function EditReleasePage() {
         setRelease(releaseJson);
         setShipment(shJson);
 
-        const initialValues: ReleaseQuantities = {};
+        const initialReleaseValues: ReleaseEditQuantities = {};
         for (const item of releaseJson.items as ReleaseEventDetail["items"]) {
-          initialValues[item.shipmentItemId] = item.quantity;
+          initialReleaseValues[item.shipmentItemId] = item.quantity;
         }
-        setValues(initialValues);
-        setOriginalValues(initialValues);
+
+        const initialLossValues: ReleaseEditLossesByItem = {};
+        for (const row of releaseJson.losses as ReleaseEventDetail["losses"]) {
+          initialLossValues[row.shipmentItemId] = {
+            damagedInTransit: row.damagedInTransit,
+            diseasedInTransit: row.diseasedInTransit,
+            parasite: row.parasite,
+            nonEmergence: row.nonEmergence,
+            poorEmergence: row.poorEmergence,
+          };
+        }
+
+        setReleaseValues(initialReleaseValues);
+        setOriginalReleaseValues(initialReleaseValues);
+        setLossValues(initialLossValues);
+        setOriginalLossValues(initialLossValues);
         setStatus("idle");
       } catch (err) {
         if (ac.signal.aborted) return;
@@ -106,31 +138,111 @@ export default function EditReleasePage() {
     return () => ac.abort();
   }, [releaseId, shipmentId, tenantHeaders]);
 
-  const handleChange = useCallback((itemId: number, quantity: number) => {
-    setValues((current) => ({ ...current, [itemId]: quantity }));
+  const handleReleaseChange = useCallback((itemId: number, quantity: number) => {
+    setReleaseValues((current) => ({ ...current, [itemId]: quantity }));
   }, []);
 
-  const total = useMemo(
-    () => Object.values(values).reduce((acc, value) => acc + (value || 0), 0),
-    [values],
+  const handleLossChange = useCallback(
+    (itemId: number, field: ReleaseEditLossField, quantity: number) => {
+      setLossValues((current) => {
+        const currentItem: ReleaseEditLossValues = current[itemId] ?? {
+          damagedInTransit: 0,
+          diseasedInTransit: 0,
+          parasite: 0,
+          nonEmergence: 0,
+          poorEmergence: 0,
+        };
+        return {
+          ...current,
+          [itemId]: {
+            ...currentItem,
+            [field]: quantity,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const trackedItemIds = useMemo(() => {
+    if (!release) return [];
+    const ids = new Set<number>();
+    for (const item of release.items) ids.add(item.shipmentItemId);
+    for (const row of release.losses) ids.add(row.shipmentItemId);
+    return Array.from(ids);
+  }, [release]);
+
+  const trackedItems = useMemo(() => {
+    if (!shipment || trackedItemIds.length === 0) return [];
+    const idSet = new Set(trackedItemIds);
+    return shipment.items.filter((item) => idSet.has(item.id));
+  }, [shipment, trackedItemIds]);
+
+  const totalReleased = useMemo(
+    () => Object.values(releaseValues).reduce((acc, value) => acc + (value || 0), 0),
+    [releaseValues],
+  );
+
+  const totalLosses = useMemo(
+    () =>
+      Object.values(lossValues).reduce(
+        (acc, row) =>
+          acc +
+          row.damagedInTransit +
+          row.diseasedInTransit +
+          row.parasite +
+          row.nonEmergence +
+          row.poorEmergence,
+        0,
+      ),
+    [lossValues],
   );
 
   const handleSave = async () => {
     if (!release) return;
+    if (trackedItems.length === 0) {
+      setErrorMessage("This release has no editable rows.");
+      return;
+    }
 
-    // The PATCH endpoint can only update existing in_flight rows; it cannot
-    // add or remove species. Restrict to the original shipment_item_ids and
-    // require quantity > 0 (positive integer per release validation).
-    const items = release.items
-      .map((row) => ({
-        shipment_item_id: row.shipmentItemId,
-        quantity: values[row.shipmentItemId] ?? 0,
-      }))
-      .filter((item) => item.quantity > 0);
+    const items = trackedItems.map((item) => ({
+      shipment_item_id: item.id,
+      quantity: releaseValues[item.id] ?? 0,
+    }));
 
-    if (items.length !== release.items.length) {
+    const losses = trackedItems.map((item) => {
+      const row = lossValues[item.id] ?? {
+        damagedInTransit: 0,
+        diseasedInTransit: 0,
+        parasite: 0,
+        nonEmergence: 0,
+        poorEmergence: 0,
+      };
+      return {
+        shipment_item_id: item.id,
+        damaged_in_transit: row.damagedInTransit,
+        diseased_in_transit: row.diseasedInTransit,
+        parasite: row.parasite,
+        non_emergence: row.nonEmergence,
+        poor_emergence: row.poorEmergence,
+      };
+    });
+
+    const nextTotalReleased = items.reduce((sum, row) => sum + row.quantity, 0);
+    const nextTotalLosses = losses.reduce(
+      (sum, row) =>
+        sum +
+        row.damaged_in_transit +
+        row.diseased_in_transit +
+        row.parasite +
+        row.non_emergence +
+        row.poor_emergence,
+      0,
+    );
+
+    if (nextTotalReleased === 0 && nextTotalLosses === 0) {
       setErrorMessage(
-        "Quantities must remain positive for every species in this release. To remove a species, delete and recreate the release.",
+        "Release must include at least one in-flight or loss quantity. Delete release instead.",
       );
       return;
     }
@@ -141,7 +253,7 @@ export default function EditReleasePage() {
       const response = await fetch(`/api/tenant/releases/${releaseId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json", ...tenantHeaders },
-        body: JSON.stringify({ items }),
+        body: JSON.stringify({ items, losses }),
       });
       const result = await response.json().catch(() => null);
       if (!response.ok) {
@@ -151,6 +263,34 @@ export default function EditReleasePage() {
       router.push(detailHref);
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleDeleteRelease = async () => {
+    setDeleteOpen(false);
+    setDeleting(true);
+    setErrorMessage(null);
+    try {
+      const response = await fetch(`/api/tenant/releases/${releaseId}`, {
+        method: "DELETE",
+        headers: tenantHeaders,
+      });
+      const result = await response.json().catch(() => null);
+      if (!response.ok) {
+        if (response.status === 409) {
+          setErrorMessage(
+            result?.error?.message ??
+              "Delete Release could not be completed because undo would reduce shipment loss totals below zero. Adjust shipment totals first, then retry.",
+          );
+          return;
+        }
+        setErrorMessage(result?.error?.message ?? "Unable to delete release.");
+        return;
+      }
+
+      router.push(detailHref);
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -184,12 +324,6 @@ export default function EditReleasePage() {
     );
   }
 
-  // Restrict the composer to the species that are part of this release so
-  // users don't see species they cannot interact with via the PATCH API.
-  const composerItems = shipment.items.filter((item) =>
-    release.items.some((row) => row.shipmentItemId === item.id),
-  );
-
   return (
     <div className="flex flex-col gap-6 pb-32">
       <div>
@@ -202,27 +336,43 @@ export default function EditReleasePage() {
           {shipment.shipment.supplierCode} · Released {formatDate(release.event.releaseDate)} by{" "}
           {release.event.releasedBy}
         </p>
+        <div className="mt-3">
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => setDeleteOpen(true)}
+            disabled={saving || deleting}
+          >
+            <Trash2 className="size-4" />
+            Delete Release
+          </Button>
+        </div>
       </div>
 
       {errorMessage && (
-        <div className="text-destructive text-sm" role="alert">
+        <div id={errorMessageId} className="text-destructive text-sm" role="alert">
           {errorMessage}
         </div>
       )}
 
       <Card>
         <CardHeader>
-          <CardTitle>Released butterflies</CardTitle>
+          <CardTitle>Release quantities</CardTitle>
           <CardDescription>
-            Adjust the per-species counts. The release date and operator are read-only.
+            Adjust this release&apos;s in-flight and loss-attribution values. Loss fields are
+            event-level quantities for this release only.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <ReleaseComposer
-            items={composerItems}
-            values={values}
-            onChange={handleChange}
-            alreadyAllocated={originalValues}
+          <ReleaseEditComposer
+            items={trackedItems}
+            releaseValues={releaseValues}
+            lossValues={lossValues}
+            originalReleaseValues={originalReleaseValues}
+            originalLossValues={originalLossValues}
+            onReleaseChange={handleReleaseChange}
+            onLossChange={handleLossChange}
+            errorMessageId={errorMessage ? errorMessageId : undefined}
           />
         </CardContent>
       </Card>
@@ -230,14 +380,44 @@ export default function EditReleasePage() {
       <div className="bg-background sticky bottom-0 -mx-4 border-t px-4 py-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
         <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-4">
           <div>
-            <div className="text-muted-foreground text-xs uppercase">Total released</div>
-            <div className="text-2xl font-semibold">{total}</div>
+            <div className="text-muted-foreground text-xs uppercase">This release</div>
+            <div
+              className="text-2xl font-semibold"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              {totalReleased} released · {totalLosses} losses
+            </div>
           </div>
-          <Button size="lg" onClick={handleSave} disabled={saving || total === 0}>
+          <Button
+            size="lg"
+            onClick={handleSave}
+            disabled={saving || deleting || (totalReleased === 0 && totalLosses === 0)}
+          >
             {saving ? "Saving…" : "Save changes"}
           </Button>
         </div>
       </div>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this release?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will undo the in-flight quantities and event-attributed loss quantities recorded
+              by this release. If shipment totals were edited later, delete can be blocked to
+              prevent negative loss totals.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDeleteRelease} disabled={deleting}>
+              {deleting ? "Deleting…" : "Delete Release"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/app/[institution]/(tenant)/shipments/[id]/release/new/page.tsx
+++ b/src/app/[institution]/(tenant)/shipments/[id]/release/new/page.tsx
@@ -112,12 +112,16 @@ export default function CreateReleasePage() {
   }, [values]);
 
   const totalGood = categoryTotals.goodEmergence;
+  const totalAllocated = useMemo(
+    () => Object.values(categoryTotals).reduce((acc, value) => acc + value, 0),
+    [categoryTotals],
+  );
 
   /** Validate that no item has been over-allocated relative to its cap. */
   const validate = useCallback((): string | null => {
     if (!data) return "Shipment not loaded yet.";
-    if (totalGood === 0) {
-      return "Set a Good Emergence quantity on at least one species before saving.";
+    if (totalAllocated === 0) {
+      return "Set at least one category quantity before saving.";
     }
     for (const item of data.items) {
       const allocated = sumCategories(values[item.id]);
@@ -127,7 +131,7 @@ export default function CreateReleasePage() {
       }
     }
     return null;
-  }, [data, totalGood, values]);
+  }, [data, totalAllocated, values]);
 
   const handleSubmit = async () => {
     const validationError = validate();
@@ -242,7 +246,7 @@ export default function CreateReleasePage() {
       <div className="bg-background sticky bottom-0 -mx-4 border-t px-4 py-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
         <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-4">
           <ReleaseSummary totalGood={totalGood} categoryTotals={categoryTotals} />
-          <Button size="lg" onClick={handleSubmit} disabled={submitting || totalGood === 0}>
+          <Button size="lg" onClick={handleSubmit} disabled={submitting || totalAllocated === 0}>
             {submitting ? "Saving…" : "Save release"}
           </Button>
         </div>

--- a/src/app/api/tenant/releases/[releaseId]/route.ts
+++ b/src/app/api/tenant/releases/[releaseId]/route.ts
@@ -52,6 +52,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     return ok({
       event: result.event,
       items: result.items,
+      losses: result.losses ?? [],
     });
   } catch (error) {
     const authError = mapAuthError(error);
@@ -107,11 +108,15 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         return notFound(error.message);
       }
 
-      if (error.message === RELEASE_ERRORS.RELEASE_ITEMS_MUST_MATCH) {
+      if (error.message === RELEASE_ERRORS.EMPTY_RELEASE_EVENT) {
         return invalidRequest(error.message);
       }
 
       if (error.message === RELEASE_ERRORS.QUANTITY_EXCEEDS_REMAINING) {
+        return conflict(error.message);
+      }
+
+      if (error.message === RELEASE_ERRORS.LOSS_TOTAL_UNDERFLOW) {
         return conflict(error.message);
       }
     }
@@ -151,6 +156,10 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
     if (error instanceof Error) {
       if (error.message === RELEASE_ERRORS.RELEASE_EVENT_NOT_FOUND) {
         return notFound(error.message);
+      }
+
+      if (error.message === RELEASE_ERRORS.LOSS_TOTAL_UNDERFLOW) {
+        return conflict(error.message);
       }
     }
 

--- a/src/app/api/tenant/shipments/[id]/releases/route.ts
+++ b/src/app/api/tenant/shipments/[id]/releases/route.ts
@@ -106,6 +106,10 @@ export async function POST(request: NextRequest, context: RouteContext) {
         return conflict(error.message);
       }
 
+      if (error.message === RELEASE_ERRORS.NEGATIVE_LOSS_DELTA) {
+        return conflict(error.message);
+      }
+
       if (error.message === "UNAUTHORIZED") return unauthorized();
       if (error.message === "FORBIDDEN") return forbidden();
       if (error.message === "NOT_FOUND") return notFound("Institution not found");

--- a/src/components/tenant/releases/release-edit-composer.tsx
+++ b/src/components/tenant/releases/release-edit-composer.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { useMemo } from "react";
+import Image from "next/image";
+import { Bug, Minus, Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  SpeciesSearchToolbar,
+  type SpeciesFilters,
+} from "@/components/shared/species-search-toolbar";
+import { useSpeciesSearch, type SpeciesItem } from "@/hooks/use-species-search";
+
+import { type ShipmentItemRow } from "@/components/tenant/shipments/types";
+
+export type ReleaseEditQuantities = Record<number, number>;
+
+export type ReleaseEditLossField =
+  | "damagedInTransit"
+  | "diseasedInTransit"
+  | "parasite"
+  | "nonEmergence"
+  | "poorEmergence";
+
+export type ReleaseEditLossValues = Record<ReleaseEditLossField, number>;
+export type ReleaseEditLossesByItem = Record<number, ReleaseEditLossValues>;
+
+interface ReleaseEditComposerProps {
+  items: ShipmentItemRow[];
+  releaseValues: ReleaseEditQuantities;
+  lossValues: ReleaseEditLossesByItem;
+  originalReleaseValues: ReleaseEditQuantities;
+  originalLossValues: ReleaseEditLossesByItem;
+  onReleaseChange: (itemId: number, quantity: number) => void;
+  onLossChange: (itemId: number, field: ReleaseEditLossField, quantity: number) => void;
+  errorMessageId?: string;
+}
+
+type ComposerSpeciesItem = SpeciesItem & ShipmentItemRow;
+
+const ZERO_LOSSES: ReleaseEditLossValues = {
+  damagedInTransit: 0,
+  diseasedInTransit: 0,
+  parasite: 0,
+  nonEmergence: 0,
+  poorEmergence: 0,
+};
+
+const LOSS_FIELDS: Array<{ field: ReleaseEditLossField; label: string; shortLabel: string }> = [
+  { field: "damagedInTransit", label: "Damaged", shortLabel: "Damaged" },
+  { field: "diseasedInTransit", label: "Diseased", shortLabel: "Diseased" },
+  { field: "parasite", label: "Parasite", shortLabel: "Parasite" },
+  { field: "nonEmergence", label: "No emergence", shortLabel: "No emergence" },
+  { field: "poorEmergence", label: "Poor emergence", shortLabel: "Poor emergence" },
+];
+
+function getLossValues(
+  map: ReleaseEditLossesByItem,
+  shipmentItemId: number,
+): ReleaseEditLossValues {
+  return map[shipmentItemId] ?? ZERO_LOSSES;
+}
+
+function sumLosses(values: ReleaseEditLossValues) {
+  return (
+    values.damagedInTransit +
+    values.diseasedInTransit +
+    values.parasite +
+    values.nonEmergence +
+    values.poorEmergence
+  );
+}
+
+function clampNonNegativeInteger(next: number) {
+  if (!Number.isFinite(next)) return 0;
+  return Math.max(0, Math.floor(next));
+}
+
+/**
+ * Compute the max in-flight quantity for this edit row so the UI reflects the
+ * same core invariant the backend validates after applying event-level loss
+ * deltas: desired in-flight must be <= remaining for the shipment item.
+ */
+function computeReleaseCap(params: {
+  item: ShipmentItemRow;
+  desiredLosses: ReleaseEditLossValues;
+  originalLosses: ReleaseEditLossValues;
+  originalRelease: number;
+}) {
+  const { item, desiredLosses, originalLosses, originalRelease } = params;
+
+  const currentShipmentLossTotal =
+    item.damagedInTransit +
+    item.diseasedInTransit +
+    item.parasite +
+    item.nonEmergence +
+    item.poorEmergence;
+
+  const originalEventLossTotal = sumLosses(originalLosses);
+  const desiredEventLossTotal = sumLosses(desiredLosses);
+  const shipmentLossesOutsideEvent = Math.max(0, currentShipmentLossTotal - originalEventLossTotal);
+  const releasedOutsideEvent = Math.max(0, item.inFlightQuantity - originalRelease);
+
+  const cap =
+    item.numberReceived - shipmentLossesOutsideEvent - desiredEventLossTotal - releasedOutsideEvent;
+
+  return Math.max(0, cap);
+}
+
+/**
+ * Compute a per-loss-field cap that keeps the row internally consistent with
+ * the selected in-flight quantity for this release event.
+ */
+function computeLossFieldCap(params: {
+  item: ShipmentItemRow;
+  field: ReleaseEditLossField;
+  desiredRelease: number;
+  desiredLosses: ReleaseEditLossValues;
+  originalLosses: ReleaseEditLossValues;
+  originalRelease: number;
+}) {
+  const { item, field, desiredRelease, desiredLosses, originalLosses, originalRelease } = params;
+
+  const currentShipmentLossTotal =
+    item.damagedInTransit +
+    item.diseasedInTransit +
+    item.parasite +
+    item.nonEmergence +
+    item.poorEmergence;
+
+  const originalEventLossTotal = sumLosses(originalLosses);
+  const shipmentLossesOutsideEvent = Math.max(0, currentShipmentLossTotal - originalEventLossTotal);
+  const releasedOutsideEvent = Math.max(0, item.inFlightQuantity - originalRelease);
+
+  const desiredLossesExcludingField = sumLosses(desiredLosses) - desiredLosses[field];
+  const cap =
+    item.numberReceived -
+    releasedOutsideEvent -
+    shipmentLossesOutsideEvent -
+    desiredRelease -
+    desiredLossesExcludingField;
+
+  return Math.max(0, cap);
+}
+
+interface CompactStepperProps {
+  label: string;
+  value: number;
+  cap: number;
+  ariaLabel: string;
+  ariaDescribedBy?: string;
+  onChange: (next: number) => void;
+}
+
+function CompactStepper({
+  label,
+  value,
+  cap,
+  ariaLabel,
+  ariaDescribedBy,
+  onChange,
+}: CompactStepperProps) {
+  const clamp = (next: number) => Math.max(0, Math.min(cap, clampNonNegativeInteger(next)));
+
+  return (
+    <div className="space-y-1">
+      <div className="text-muted-foreground text-[11px] font-medium md:hidden">{label}</div>
+      <div className="inline-flex w-full items-center gap-1">
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          className="size-8 shrink-0"
+          onClick={() => onChange(clamp(value - 1))}
+          disabled={value <= 0}
+          aria-label={`Decrease ${ariaLabel}`}
+        >
+          <Minus className="size-3.5" />
+        </Button>
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={0}
+          max={cap}
+          step={1}
+          value={value}
+          aria-label={ariaLabel}
+          aria-describedby={ariaDescribedBy}
+          className="h-8 w-full min-w-16 px-1 text-center text-sm tabular-nums"
+          onChange={(event) => onChange(clamp(Number(event.target.value)))}
+        />
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          className="size-8 shrink-0"
+          onClick={() => onChange(clamp(value + 1))}
+          disabled={value >= cap}
+          aria-label={`Increase ${ariaLabel}`}
+        >
+          <Plus className="size-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Compact edit composer for release events:
+ * - Desktop: row/card with species column + six compact quantity columns.
+ * - Mobile: species card with stacked category controls underneath.
+ */
+export function ReleaseEditComposer({
+  items,
+  releaseValues,
+  lossValues,
+  originalReleaseValues,
+  originalLossValues,
+  onReleaseChange,
+  onLossChange,
+  errorMessageId,
+}: ReleaseEditComposerProps) {
+  const adapted = useMemo<ComposerSpeciesItem[]>(
+    () =>
+      items.map((item) => ({
+        ...item,
+        scientific_name: item.scientificName,
+        common_name: item.commonName,
+        family: "",
+      })),
+    [items],
+  );
+
+  const search = useSpeciesSearch<ComposerSpeciesItem>({
+    items: adapted,
+    pageSize: 24,
+  });
+
+  return (
+    <div className="space-y-4">
+      <SpeciesSearchToolbar
+        query={search.query}
+        sortField={search.sortField}
+        sortDirection={search.sortDirection}
+        filters={{ families: search.activeFamilies }}
+        families={search.families}
+        onQueryChange={search.setQuery}
+        onSortChange={search.setSort}
+        onFiltersChange={(filters: SpeciesFilters) => search.setActiveFamilies(filters.families)}
+        onReset={search.resetAll}
+      />
+
+      {search.visibleResults.length === 0 ? (
+        <div className="text-muted-foreground rounded-md border p-6 text-center text-sm">
+          No butterflies in this release match your filters.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <div className="text-muted-foreground hidden grid-cols-[minmax(230px,2fr)_repeat(6,minmax(100px,1fr))] gap-2 px-3 text-[11px] font-medium tracking-wide uppercase md:grid">
+            <div>Species</div>
+            <div className="text-center">Released</div>
+            {LOSS_FIELDS.map((column) => (
+              <div key={column.field} className="text-center">
+                {column.shortLabel}
+              </div>
+            ))}
+          </div>
+
+          <ul className="grid gap-2">
+            {search.visibleResults.map((item) => {
+              const desiredRelease = releaseValues[item.id] ?? 0;
+              const originalRelease = originalReleaseValues[item.id] ?? 0;
+              const desiredLosses = getLossValues(lossValues, item.id);
+              const originalLosses = getLossValues(originalLossValues, item.id);
+              const desiredLossTotal = sumLosses(desiredLosses);
+              const releaseCap = computeReleaseCap({
+                item,
+                desiredLosses,
+                originalLosses,
+                originalRelease,
+              });
+
+              return (
+                <li
+                  key={item.id}
+                  className="bg-card grid gap-3 rounded-lg border p-3 md:grid-cols-[minmax(230px,2fr)_repeat(6,minmax(100px,1fr))] md:items-center md:gap-2"
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <div className="bg-muted relative size-12 shrink-0 overflow-hidden rounded">
+                      {item.imageOpen ? (
+                        <Image
+                          src={item.imageOpen}
+                          alt=""
+                          width={96}
+                          height={96}
+                          quality={80}
+                          className="size-full object-cover"
+                        />
+                      ) : (
+                        <Bug className="text-muted-foreground absolute inset-0 m-auto size-4" />
+                      )}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium">{item.commonName}</div>
+                      <div className="text-muted-foreground truncate text-xs italic">
+                        {item.scientificName}
+                      </div>
+                      <div className="text-muted-foreground text-[11px]">
+                        {desiredRelease} released · {desiredLossTotal} losses
+                      </div>
+                    </div>
+                  </div>
+
+                  <CompactStepper
+                    label="Released"
+                    value={desiredRelease}
+                    cap={releaseCap}
+                    ariaLabel={`Released quantity for ${item.commonName}`}
+                    ariaDescribedBy={errorMessageId}
+                    onChange={(next) => onReleaseChange(item.id, next)}
+                  />
+
+                  {LOSS_FIELDS.map(({ field, label }) => {
+                    const value = desiredLosses[field];
+                    const fieldCap = computeLossFieldCap({
+                      item,
+                      field,
+                      desiredRelease,
+                      desiredLosses,
+                      originalLosses,
+                      originalRelease,
+                    });
+                    return (
+                      <CompactStepper
+                        key={field}
+                        label={label}
+                        value={value}
+                        cap={fieldCap}
+                        ariaLabel={`${label} quantity for ${item.commonName}`}
+                        ariaDescribedBy={errorMessageId}
+                        onChange={(next) => onLossChange(item.id, field, next)}
+                      />
+                    );
+                  })}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      {search.hasMore && (
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={search.loadMore}
+            aria-label="Load more butterfly species"
+          >
+            Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/tenant/shipments/types.ts
+++ b/src/components/tenant/shipments/types.ts
@@ -61,6 +61,7 @@ export type ReleaseHistoryRow = {
   releaseDate: string;
   releasedBy: string;
   totalReleased: number;
+  totalLosses: number;
 };
 
 export type ReleaseEventDetail = {
@@ -71,6 +72,15 @@ export type ReleaseEventDetail = {
     releasedBy: string;
   };
   items: { id: number; shipmentItemId: number; quantity: number }[];
+  losses: {
+    id: number;
+    shipmentItemId: number;
+    damagedInTransit: number;
+    diseasedInTransit: number;
+    parasite: number;
+    nonEmergence: number;
+    poorEmergence: number;
+  }[];
 };
 
 /**

--- a/src/lib/__test__/release-helpers.test.ts
+++ b/src/lib/__test__/release-helpers.test.ts
@@ -1,4 +1,9 @@
-import { calculateRemaining } from "@/lib/queries/releases";
+import {
+  calculateRemaining,
+  computeCreateLossDelta,
+  computeDeleteLossRollbackPatch,
+  RELEASE_ERRORS,
+} from "@/lib/queries/releases";
 
 const baseItem = {
   id: 1,
@@ -73,5 +78,94 @@ describe("N+1 fix: bulk sum minus existing quantity coercion", () => {
     const existingQuantity = 0;
     const alreadyReleased = totalReleased - existingQuantity;
     expect(alreadyReleased).toBe(0);
+  });
+});
+
+describe("computeCreateLossDelta", () => {
+  const baseLosses = {
+    damaged_in_transit: 2,
+    diseased_in_transit: 3,
+    parasite: 1,
+    non_emergence: 4,
+    poor_emergence: 5,
+  };
+
+  it("returns absolutePatch plus positive attributionDelta for increases", () => {
+    const result = computeCreateLossDelta(baseLosses, {
+      poor_emergence: 8,
+      parasite: 1,
+      non_emergence: 6,
+    });
+
+    expect(result.absolutePatch).toEqual({
+      poor_emergence: 8,
+      parasite: 1,
+      non_emergence: 6,
+    });
+    expect(result.attributionDelta).toEqual({
+      poor_emergence: 3,
+      non_emergence: 2,
+    });
+  });
+
+  it("returns empty attributionDelta when absolute values are unchanged", () => {
+    const result = computeCreateLossDelta(baseLosses, {
+      damaged_in_transit: 2,
+      diseased_in_transit: 3,
+    });
+
+    expect(result.absolutePatch).toEqual({
+      damaged_in_transit: 2,
+      diseased_in_transit: 3,
+    });
+    expect(result.attributionDelta).toEqual({});
+  });
+
+  it("throws when an absolute loss total decreases in create flow", () => {
+    expect(() =>
+      computeCreateLossDelta(baseLosses, {
+        poor_emergence: 4,
+      }),
+    ).toThrow(RELEASE_ERRORS.NEGATIVE_LOSS_DELTA);
+  });
+});
+
+describe("computeDeleteLossRollbackPatch", () => {
+  const currentLosses = {
+    damaged_in_transit: 5,
+    diseased_in_transit: 4,
+    parasite: 3,
+    non_emergence: 6,
+    poor_emergence: 2,
+  };
+
+  it("subtracts event-level losses from current shipment loss totals", () => {
+    const patch = computeDeleteLossRollbackPatch(currentLosses, {
+      damaged_in_transit: 1,
+      diseased_in_transit: 2,
+      parasite: 0,
+      non_emergence: 1,
+      poor_emergence: 2,
+    });
+
+    expect(patch).toEqual({
+      damaged_in_transit: 4,
+      diseased_in_transit: 2,
+      parasite: 3,
+      non_emergence: 5,
+      poor_emergence: 0,
+    });
+  });
+
+  it("throws when rollback would drive any loss column below zero", () => {
+    expect(() =>
+      computeDeleteLossRollbackPatch(currentLosses, {
+        damaged_in_transit: 0,
+        diseased_in_transit: 0,
+        parasite: 4,
+        non_emergence: 0,
+        poor_emergence: 0,
+      }),
+    ).toThrow(RELEASE_ERRORS.LOSS_TOTAL_UNDERFLOW);
   });
 });

--- a/src/lib/__test__/schema.test.ts
+++ b/src/lib/__test__/schema.test.ts
@@ -10,6 +10,7 @@ import {
   shipment_items,
   release_events,
   in_flight,
+  release_event_losses,
 } from "@/lib/schema";
 
 describe("schema", () => {
@@ -25,6 +26,7 @@ describe("schema", () => {
       expect(getTableName(shipment_items)).toBe("shipment_items");
       expect(getTableName(release_events)).toBe("release_events");
       expect(getTableName(in_flight)).toBe("in_flight");
+      expect(getTableName(release_event_losses)).toBe("release_event_losses");
     });
   });
 
@@ -211,6 +213,23 @@ describe("schema", () => {
       expect(columns).toContain("shipment_item_id");
       expect(columns).toContain("quantity");
       expect(columns).toContain("created_at");
+    });
+  });
+
+  describe("release_event_losses", () => {
+    it("has required columns", () => {
+      const columns = Object.keys(release_event_losses);
+      expect(columns).toContain("id");
+      expect(columns).toContain("institution_id");
+      expect(columns).toContain("release_event_id");
+      expect(columns).toContain("shipment_item_id");
+      expect(columns).toContain("damaged_in_transit");
+      expect(columns).toContain("diseased_in_transit");
+      expect(columns).toContain("parasite");
+      expect(columns).toContain("non_emergence");
+      expect(columns).toContain("poor_emergence");
+      expect(columns).toContain("created_at");
+      expect(columns).toContain("updated_at");
     });
   });
 });

--- a/src/lib/__test__/validation-releases.test.ts
+++ b/src/lib/__test__/validation-releases.test.ts
@@ -36,8 +36,24 @@ describe("createReleaseFromShipmentSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects an empty items array", () => {
+  it("rejects a payload with no release items and no loss updates", () => {
     const result = createReleaseFromShipmentSchema.safeParse({ items: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a losses-only payload with empty items", () => {
+    const result = createReleaseFromShipmentSchema.safeParse({
+      items: [],
+      loss_updates: [{ shipment_item_id: 1, poor_emergence: 2 }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a losses-only payload when loss_updates rows are no-op", () => {
+    const result = createReleaseFromShipmentSchema.safeParse({
+      items: [],
+      loss_updates: [{ shipment_item_id: 1 }],
+    });
     expect(result.success).toBe(false);
   });
 
@@ -177,7 +193,31 @@ describe("updateReleaseEventItemsSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects an empty items array", () => {
+  it("accepts event-level losses payload", () => {
+    const result = updateReleaseEventItemsSchema.safeParse({
+      items: [],
+      losses: [
+        {
+          shipment_item_id: 1,
+          damaged_in_transit: 0,
+          diseased_in_transit: 0,
+          parasite: 0,
+          non_emergence: 0,
+          poor_emergence: 2,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows zero quantities in items (edit can clear rows)", () => {
+    const result = updateReleaseEventItemsSchema.safeParse({
+      items: [{ shipment_item_id: 1, quantity: 0 }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects payloads with no items and no losses", () => {
     expect(updateReleaseEventItemsSchema.safeParse({ items: [] }).success).toBe(false);
   });
 
@@ -186,6 +226,49 @@ describe("updateReleaseEventItemsSchema", () => {
       items: [
         { shipment_item_id: 1, quantity: 1 },
         { shipment_item_id: 1, quantity: 2 },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicate shipment_item_id values in losses", () => {
+    const result = updateReleaseEventItemsSchema.safeParse({
+      items: [{ shipment_item_id: 1, quantity: 1 }],
+      losses: [
+        {
+          shipment_item_id: 2,
+          damaged_in_transit: 0,
+          diseased_in_transit: 0,
+          parasite: 0,
+          non_emergence: 0,
+          poor_emergence: 1,
+        },
+        {
+          shipment_item_id: 2,
+          damaged_in_transit: 1,
+          diseased_in_transit: 0,
+          parasite: 0,
+          non_emergence: 0,
+          poor_emergence: 0,
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown keys inside losses rows", () => {
+    const result = updateReleaseEventItemsSchema.safeParse({
+      items: [{ shipment_item_id: 1, quantity: 1 }],
+      losses: [
+        {
+          shipment_item_id: 2,
+          damaged_in_transit: 0,
+          diseased_in_transit: 0,
+          parasite: 0,
+          non_emergence: 0,
+          poor_emergence: 1,
+          extra: 1,
+        },
       ],
     });
     expect(result.success).toBe(false);

--- a/src/lib/queries/releases.ts
+++ b/src/lib/queries/releases.ts
@@ -1,7 +1,13 @@
 import { and, count, desc, eq, inArray, ne, sql } from "drizzle-orm";
 
 import { db } from "@/lib/db";
-import { in_flight, release_events, shipment_items, shipments } from "@/lib/schema";
+import {
+  in_flight,
+  release_event_losses,
+  release_events,
+  shipment_items,
+  shipments,
+} from "@/lib/schema";
 
 import type {
   CreateInFlightBody,
@@ -20,8 +26,12 @@ export const RELEASE_ERRORS = {
   INVALID_QUANTITY: "Quantity must be a positive integer",
   SHIPMENT_ITEM_RELEASE_MISMATCH: "Shipment item does not belong to the release shipment",
   QUANTITY_EXCEEDS_REMAINING: "Quantity exceeds remaining available butterflies",
-  RELEASE_ITEMS_MUST_MATCH:
-    "Release update must include every existing in-flight row for the release event",
+  NEGATIVE_LOSS_DELTA:
+    "Create release loss_updates cannot decrease shipment loss totals; use shipment edit for corrections",
+  LOSS_TOTAL_UNDERFLOW:
+    "Release edit would reduce shipment loss totals below zero; adjust shipment totals first",
+  EMPTY_RELEASE_EVENT:
+    "Release must include at least one in-flight or loss quantity; delete release instead",
 } as const;
 
 type LockedShipmentItem = {
@@ -42,11 +52,62 @@ const LOSS_COLUMNS = [
   "non_emergence",
   "poor_emergence",
 ] as const;
+type LossColumn = (typeof LOSS_COLUMNS)[number];
+type LossValues = Record<LossColumn, number>;
 
 type ReleaseItemInput = {
   shipment_item_id: number;
   quantity: number;
 };
+
+type ReleaseLossRowInput = {
+  shipment_item_id: number;
+} & LossValues;
+
+/**
+ * Create-flow loss_updates are absolute shipment_item totals. Convert those to
+ * positive event attribution deltas and reject any decrease attempts.
+ */
+export function computeCreateLossDelta(
+  existing: LossValues,
+  update: Partial<Record<LossColumn, number>>,
+) {
+  const absolutePatch: Partial<Record<LossColumn, number>> = {};
+  const attributionDelta: Partial<Record<LossColumn, number>> = {};
+
+  for (const column of LOSS_COLUMNS) {
+    const next = update[column];
+    if (typeof next !== "number") continue;
+
+    const delta = next - existing[column];
+    if (delta < 0) {
+      throw new Error(RELEASE_ERRORS.NEGATIVE_LOSS_DELTA);
+    }
+
+    absolutePatch[column] = next;
+    if (delta > 0) {
+      attributionDelta[column] = delta;
+    }
+  }
+
+  return { absolutePatch, attributionDelta };
+}
+
+/**
+ * Delete-flow rollback: subtract event-level loss attribution from current
+ * shipment loss totals. Throws when subtraction would underflow.
+ */
+export function computeDeleteLossRollbackPatch(existing: LossValues, eventLoss: LossValues) {
+  const next = { ...existing };
+  for (const column of LOSS_COLUMNS) {
+    const rolledBack = next[column] - eventLoss[column];
+    if (rolledBack < 0) {
+      throw new Error(RELEASE_ERRORS.LOSS_TOTAL_UNDERFLOW);
+    }
+    next[column] = rolledBack;
+  }
+  return next;
+}
 
 function isPositiveInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value > 0;
@@ -66,6 +127,46 @@ function assertReleaseItems(items: ReleaseItemInput[]) {
 
     seen.add(item.shipment_item_id);
   }
+}
+
+function assertUpdateReleaseItems(items: ReleaseItemInput[]) {
+  const seen = new Set<number>();
+
+  for (const item of items) {
+    if (
+      typeof item.quantity !== "number" ||
+      !Number.isInteger(item.quantity) ||
+      item.quantity < 0
+    ) {
+      throw new Error(RELEASE_ERRORS.INVALID_QUANTITY);
+    }
+
+    if (seen.has(item.shipment_item_id)) {
+      throw new Error(RELEASE_ERRORS.DUPLICATE_SHIPMENT_ITEM);
+    }
+
+    seen.add(item.shipment_item_id);
+  }
+}
+
+function toLossValues(row?: Partial<LossValues>): LossValues {
+  return {
+    damaged_in_transit: row?.damaged_in_transit ?? 0,
+    diseased_in_transit: row?.diseased_in_transit ?? 0,
+    parasite: row?.parasite ?? 0,
+    non_emergence: row?.non_emergence ?? 0,
+    poor_emergence: row?.poor_emergence ?? 0,
+  };
+}
+
+function sumLossValues(values: LossValues) {
+  return (
+    values.damaged_in_transit +
+    values.diseased_in_transit +
+    values.parasite +
+    values.non_emergence +
+    values.poor_emergence
+  );
 }
 
 function assertInFlightQuantity(quantity: UpdateInFlightQuantityBody["quantity"]) {
@@ -122,6 +223,32 @@ export function calculateRemaining(item: LockedShipmentItem, alreadyReleased: nu
 export async function listInstitutionReleases(institutionId: number, page: number, limit: number) {
   const offset = (page - 1) * limit;
 
+  const inFlightTotals = db
+    .select({
+      releaseEventId: in_flight.release_event_id,
+      totalReleased: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as("total_released"),
+    })
+    .from(in_flight)
+    .where(eq(in_flight.institution_id, institutionId))
+    .groupBy(in_flight.release_event_id)
+    .as("in_flight_totals");
+
+  const lossTotals = db
+    .select({
+      releaseEventId: release_event_losses.release_event_id,
+      totalLosses: sql<number>`coalesce(sum(
+        ${release_event_losses.damaged_in_transit}
+        + ${release_event_losses.diseased_in_transit}
+        + ${release_event_losses.parasite}
+        + ${release_event_losses.non_emergence}
+        + ${release_event_losses.poor_emergence}
+      ), 0)::int`.as("total_losses"),
+    })
+    .from(release_event_losses)
+    .where(eq(release_event_losses.institution_id, institutionId))
+    .groupBy(release_event_losses.release_event_id)
+    .as("loss_totals");
+
   const [rows, totalResult] = await Promise.all([
     db
       .select({
@@ -131,9 +258,10 @@ export async function listInstitutionReleases(institutionId: number, page: numbe
         releasedBy: release_events.released_by,
         supplierCode: shipments.supplier_code,
         shipmentDate: shipments.shipment_date,
-        totalReleased: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as(
+        totalReleased: sql<number>`coalesce(${inFlightTotals.totalReleased}, 0)::int`.as(
           "total_released",
         ),
+        totalLosses: sql<number>`coalesce(${lossTotals.totalLosses}, 0)::int`.as("total_losses"),
       })
       .from(release_events)
       .innerJoin(
@@ -143,22 +271,9 @@ export async function listInstitutionReleases(institutionId: number, page: numbe
           eq(shipments.institution_id, release_events.institution_id),
         ),
       )
-      .leftJoin(
-        in_flight,
-        and(
-          eq(in_flight.release_event_id, release_events.id),
-          eq(in_flight.institution_id, release_events.institution_id),
-        ),
-      )
+      .leftJoin(inFlightTotals, eq(inFlightTotals.releaseEventId, release_events.id))
+      .leftJoin(lossTotals, eq(lossTotals.releaseEventId, release_events.id))
       .where(eq(release_events.institution_id, institutionId))
-      .groupBy(
-        release_events.id,
-        release_events.shipment_id,
-        release_events.release_date,
-        release_events.released_by,
-        shipments.supplier_code,
-        shipments.shipment_date,
-      )
       .orderBy(desc(release_events.release_date))
       .limit(limit)
       .offset(offset),
@@ -188,33 +303,56 @@ export async function listInstitutionReleases(institutionId: number, page: numbe
  * render a meaningful "Released" column without an extra round-trip.
  */
 export async function listReleaseEventsForShipment(institutionId: number, shipmentId: number) {
+  const inFlightTotals = db
+    .select({
+      releaseEventId: in_flight.release_event_id,
+      totalReleased: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as("total_released"),
+    })
+    .from(in_flight)
+    .where(eq(in_flight.institution_id, institutionId))
+    .groupBy(in_flight.release_event_id)
+    .as("in_flight_totals");
+
+  const lossTotals = db
+    .select({
+      releaseEventId: release_event_losses.release_event_id,
+      totalLosses: sql<number>`coalesce(sum(
+        ${release_event_losses.damaged_in_transit}
+        + ${release_event_losses.diseased_in_transit}
+        + ${release_event_losses.parasite}
+        + ${release_event_losses.non_emergence}
+        + ${release_event_losses.poor_emergence}
+      ), 0)::int`.as("total_losses"),
+    })
+    .from(release_event_losses)
+    .where(eq(release_event_losses.institution_id, institutionId))
+    .groupBy(release_event_losses.release_event_id)
+    .as("loss_totals");
+
   return db
     .select({
       id: release_events.id,
       releaseDate: release_events.release_date,
       releasedBy: release_events.released_by,
-      totalReleased: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as("total_released"),
+      totalReleased: sql<number>`coalesce(${inFlightTotals.totalReleased}, 0)::int`.as(
+        "total_released",
+      ),
+      totalLosses: sql<number>`coalesce(${lossTotals.totalLosses}, 0)::int`.as("total_losses"),
     })
     .from(release_events)
-    .leftJoin(
-      in_flight,
-      and(
-        eq(in_flight.release_event_id, release_events.id),
-        eq(in_flight.institution_id, release_events.institution_id),
-      ),
-    )
+    .leftJoin(inFlightTotals, eq(inFlightTotals.releaseEventId, release_events.id))
+    .leftJoin(lossTotals, eq(lossTotals.releaseEventId, release_events.id))
     .where(
       and(
         eq(release_events.institution_id, institutionId),
         eq(release_events.shipment_id, shipmentId),
       ),
     )
-    .groupBy(release_events.id, release_events.release_date, release_events.released_by)
     .orderBy(desc(release_events.release_date));
 }
 
 /**
- * Fetch a release event and its in-flight items.
+ * Fetch a release event and its in-flight + loss attribution items.
  */
 export async function getReleaseEventWithItems(institutionId: number, releaseEventId: number) {
   const [event] = await db
@@ -249,7 +387,26 @@ export async function getReleaseEventWithItems(institutionId: number, releaseEve
     )
     .orderBy(in_flight.id);
 
-  return { event, items };
+  const losses = await db
+    .select({
+      id: release_event_losses.id,
+      shipmentItemId: release_event_losses.shipment_item_id,
+      damagedInTransit: release_event_losses.damaged_in_transit,
+      diseasedInTransit: release_event_losses.diseased_in_transit,
+      parasite: release_event_losses.parasite,
+      nonEmergence: release_event_losses.non_emergence,
+      poorEmergence: release_event_losses.poor_emergence,
+    })
+    .from(release_event_losses)
+    .where(
+      and(
+        eq(release_event_losses.release_event_id, releaseEventId),
+        eq(release_event_losses.institution_id, institutionId),
+      ),
+    )
+    .orderBy(release_event_losses.id);
+
+  return { event, items, losses };
 }
 
 /**
@@ -260,7 +417,7 @@ export async function updateReleaseEventItems(
   releaseEventId: number,
   payload: UpdateReleaseEventItemsBody,
 ) {
-  assertReleaseItems(payload.items);
+  assertUpdateReleaseItems(payload.items);
 
   return db.transaction(async (tx) => {
     const [releaseEvent] = await tx
@@ -281,13 +438,7 @@ export async function updateReleaseEventItems(
       throw new Error(RELEASE_ERRORS.RELEASE_EVENT_NOT_FOUND);
     }
 
-    const shipmentItemIds = payload.items.map((item) => item.shipment_item_id);
-
-    // Read every in-flight row for the release event so we can enforce that
-    // the caller supplied an update for each one. Partial updates (omitting
-    // an existing row) would silently leave that row untouched, which is
-    // almost never what the UI intends.
-    const existingRows = await tx
+    const existingInFlightRows = await tx
       .select({
         id: in_flight.id,
         shipmentItemId: in_flight.shipment_item_id,
@@ -302,15 +453,71 @@ export async function updateReleaseEventItems(
       )
       .for("update");
 
-    const payloadSet = new Set(shipmentItemIds);
-    if (
-      existingRows.length !== payloadSet.size ||
-      existingRows.some((row) => !payloadSet.has(row.shipmentItemId))
-    ) {
-      throw new Error(RELEASE_ERRORS.RELEASE_ITEMS_MUST_MATCH);
+    const existingLossRows = await tx
+      .select({
+        id: release_event_losses.id,
+        shipmentItemId: release_event_losses.shipment_item_id,
+        damaged_in_transit: release_event_losses.damaged_in_transit,
+        diseased_in_transit: release_event_losses.diseased_in_transit,
+        parasite: release_event_losses.parasite,
+        non_emergence: release_event_losses.non_emergence,
+        poor_emergence: release_event_losses.poor_emergence,
+      })
+      .from(release_event_losses)
+      .where(
+        and(
+          eq(release_event_losses.institution_id, institutionId),
+          eq(release_event_losses.release_event_id, releaseEventId),
+        ),
+      )
+      .for("update");
+
+    const existingInFlightByShipmentItemId = new Map(
+      existingInFlightRows.map((row) => [row.shipmentItemId, row]),
+    );
+    const existingLossByShipmentItemId = new Map(
+      existingLossRows.map((row) => [row.shipmentItemId, row]),
+    );
+
+    const desiredInFlightByShipmentItemId = new Map<number, number>(
+      payload.items.map((row) => [row.shipment_item_id, row.quantity]),
+    );
+
+    // Edit semantics: `losses` are event-level final values for this release.
+    // To preserve current UI behavior during rollout, omitted `losses` means
+    // "leave existing event losses unchanged".
+    const desiredLossByShipmentItemId = new Map<number, LossValues>();
+    if (Array.isArray(payload.losses)) {
+      for (const row of payload.losses) {
+        desiredLossByShipmentItemId.set(row.shipment_item_id, toLossValues(row));
+      }
+    } else {
+      for (const row of existingLossRows) {
+        desiredLossByShipmentItemId.set(
+          row.shipmentItemId,
+          toLossValues({
+            damaged_in_transit: row.damaged_in_transit,
+            diseased_in_transit: row.diseased_in_transit,
+            parasite: row.parasite,
+            non_emergence: row.non_emergence,
+            poor_emergence: row.poor_emergence,
+          }),
+        );
+      }
     }
 
-    const existingByShipmentItemId = new Map(existingRows.map((row) => [row.shipmentItemId, row]));
+    const touchedItemIdSet = new Set<number>([
+      ...existingInFlightRows.map((row) => row.shipmentItemId),
+      ...existingLossRows.map((row) => row.shipmentItemId),
+      ...Array.from(desiredInFlightByShipmentItemId.keys()),
+      ...Array.from(desiredLossByShipmentItemId.keys()),
+    ]);
+
+    if (touchedItemIdSet.size === 0) {
+      throw new Error(RELEASE_ERRORS.EMPTY_RELEASE_EVENT);
+    }
+
+    const touchedItemIds = Array.from(touchedItemIdSet);
 
     const lockedItems = await tx
       .select({
@@ -328,19 +535,71 @@ export async function updateReleaseEventItems(
         and(
           eq(shipment_items.institution_id, institutionId),
           eq(shipment_items.shipment_id, releaseEvent.shipmentId),
-          inArray(shipment_items.id, shipmentItemIds),
+          inArray(shipment_items.id, touchedItemIds),
         ),
       )
       .for("update");
 
-    if (lockedItems.length !== shipmentItemIds.length) {
+    if (lockedItems.length !== touchedItemIds.length) {
       throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
     }
 
-    const lockedItemById = new Map(lockedItems.map((row) => [row.id, row]));
+    const lockedItemById = new Map(lockedItems.map((row) => [row.id, { ...row }]));
+    const originalLockedItemById = new Map(lockedItems.map((row) => [row.id, row]));
+    const shipmentLossPatchByItemId = new Map<number, LossValues>();
+
+    // Apply event-level loss deltas to shipment source-of-truth loss totals.
+    for (const shipmentItemId of touchedItemIds) {
+      const existingEventLoss = toLossValues(
+        existingLossByShipmentItemId.get(shipmentItemId)
+          ? {
+              damaged_in_transit:
+                existingLossByShipmentItemId.get(shipmentItemId)!.damaged_in_transit,
+              diseased_in_transit:
+                existingLossByShipmentItemId.get(shipmentItemId)!.diseased_in_transit,
+              parasite: existingLossByShipmentItemId.get(shipmentItemId)!.parasite,
+              non_emergence: existingLossByShipmentItemId.get(shipmentItemId)!.non_emergence,
+              poor_emergence: existingLossByShipmentItemId.get(shipmentItemId)!.poor_emergence,
+            }
+          : undefined,
+      );
+      const desiredEventLoss = desiredLossByShipmentItemId.get(shipmentItemId) ?? toLossValues();
+      const row = lockedItemById.get(shipmentItemId);
+      const originalRow = originalLockedItemById.get(shipmentItemId);
+      if (!row || !originalRow) {
+        throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
+      }
+
+      for (const column of LOSS_COLUMNS) {
+        const next = row[column] + (desiredEventLoss[column] - existingEventLoss[column]);
+        if (next < 0) {
+          throw new Error(RELEASE_ERRORS.LOSS_TOTAL_UNDERFLOW);
+        }
+        row[column] = next;
+      }
+
+      const nextLosses = toLossValues({
+        damaged_in_transit: row.damaged_in_transit,
+        diseased_in_transit: row.diseased_in_transit,
+        parasite: row.parasite,
+        non_emergence: row.non_emergence,
+        poor_emergence: row.poor_emergence,
+      });
+      const originalLosses = toLossValues({
+        damaged_in_transit: originalRow.damaged_in_transit,
+        diseased_in_transit: originalRow.diseased_in_transit,
+        parasite: originalRow.parasite,
+        non_emergence: originalRow.non_emergence,
+        poor_emergence: originalRow.poor_emergence,
+      });
+
+      if (LOSS_COLUMNS.some((column) => nextLosses[column] !== originalLosses[column])) {
+        shipmentLossPatchByItemId.set(shipmentItemId, nextLosses);
+      }
+    }
 
     // Bulk-fetch total released per shipment item in one query, then subtract
-    // each item's own current quantity in JS — eliminates the per-item N+1.
+    // the current release event's row quantity in JS.
     const releasedTotalsRows = await tx
       .select({
         shipment_item_id: in_flight.shipment_item_id,
@@ -350,7 +609,7 @@ export async function updateReleaseEventItems(
       .where(
         and(
           eq(in_flight.institution_id, institutionId),
-          inArray(in_flight.shipment_item_id, shipmentItemIds),
+          inArray(in_flight.shipment_item_id, touchedItemIds),
         ),
       )
       .groupBy(in_flight.shipment_item_id);
@@ -359,27 +618,140 @@ export async function updateReleaseEventItems(
       releasedTotalsRows.map((row) => [row.shipment_item_id, Number(row.total)]),
     );
 
-    for (const item of payload.items) {
-      const existing = existingByShipmentItemId.get(item.shipment_item_id);
-      const locked = lockedItemById.get(item.shipment_item_id);
-
-      if (!existing || !locked) {
+    // Validate desired in-flight quantities against post-loss shipment state.
+    for (const shipmentItemId of touchedItemIds) {
+      const locked = lockedItemById.get(shipmentItemId);
+      if (!locked) {
         throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
       }
 
-      // Total released minus the current row's quantity = released by other rows
-      const totalReleased = releasedTotalByShipmentItemId.get(item.shipment_item_id) ?? 0;
-      const alreadyReleased = totalReleased - existing.quantity;
+      const existingEventInFlight =
+        existingInFlightByShipmentItemId.get(shipmentItemId)?.quantity ?? 0;
+      const desiredEventInFlight = desiredInFlightByShipmentItemId.get(shipmentItemId) ?? 0;
+      const totalReleased = releasedTotalByShipmentItemId.get(shipmentItemId) ?? 0;
+      const alreadyReleased = totalReleased - existingEventInFlight;
       const remaining = calculateRemaining(locked, alreadyReleased);
 
-      if (item.quantity > remaining) {
+      if (desiredEventInFlight > remaining) {
         throw new Error(RELEASE_ERRORS.QUANTITY_EXCEEDS_REMAINING);
       }
+    }
 
+    const finalInFlightTotal = Array.from(desiredInFlightByShipmentItemId.values()).reduce(
+      (sum, qty) => sum + qty,
+      0,
+    );
+    const finalLossTotal = Array.from(desiredLossByShipmentItemId.values()).reduce(
+      (sum, values) => sum + sumLossValues(values),
+      0,
+    );
+    if (finalInFlightTotal === 0 && finalLossTotal === 0) {
+      throw new Error(RELEASE_ERRORS.EMPTY_RELEASE_EVENT);
+    }
+
+    for (const [shipmentItemId, patch] of shipmentLossPatchByItemId) {
       await tx
-        .update(in_flight)
-        .set({ quantity: item.quantity, updated_at: new Date() })
-        .where(and(eq(in_flight.id, existing.id), eq(in_flight.institution_id, institutionId)));
+        .update(shipment_items)
+        .set({ ...patch, updated_at: new Date() })
+        .where(
+          and(
+            eq(shipment_items.id, shipmentItemId),
+            eq(shipment_items.institution_id, institutionId),
+          ),
+        );
+    }
+
+    const existingInFlightItemIds = new Set<number>();
+    for (const existingRow of existingInFlightRows) {
+      existingInFlightItemIds.add(existingRow.shipmentItemId);
+      const desiredQuantity = desiredInFlightByShipmentItemId.get(existingRow.shipmentItemId) ?? 0;
+      if (desiredQuantity === 0) {
+        await tx
+          .delete(in_flight)
+          .where(
+            and(eq(in_flight.id, existingRow.id), eq(in_flight.institution_id, institutionId)),
+          );
+        continue;
+      }
+
+      if (desiredQuantity !== existingRow.quantity) {
+        await tx
+          .update(in_flight)
+          .set({ quantity: desiredQuantity, updated_at: new Date() })
+          .where(
+            and(eq(in_flight.id, existingRow.id), eq(in_flight.institution_id, institutionId)),
+          );
+      }
+    }
+
+    const newInFlightRows = Array.from(desiredInFlightByShipmentItemId.entries())
+      .filter(
+        ([shipmentItemId, quantity]) =>
+          quantity > 0 && !existingInFlightItemIds.has(shipmentItemId),
+      )
+      .map(([shipmentItemId, quantity]) => ({
+        institution_id: institutionId,
+        release_event_id: releaseEventId,
+        shipment_item_id: shipmentItemId,
+        quantity,
+      }));
+
+    if (newInFlightRows.length > 0) {
+      await tx.insert(in_flight).values(newInFlightRows);
+    }
+
+    const existingLossItemIds = new Set<number>();
+    for (const existingRow of existingLossRows) {
+      existingLossItemIds.add(existingRow.shipmentItemId);
+      const desiredLosses =
+        desiredLossByShipmentItemId.get(existingRow.shipmentItemId) ?? toLossValues();
+      if (sumLossValues(desiredLosses) === 0) {
+        await tx
+          .delete(release_event_losses)
+          .where(
+            and(
+              eq(release_event_losses.id, existingRow.id),
+              eq(release_event_losses.institution_id, institutionId),
+            ),
+          );
+        continue;
+      }
+
+      const currentLosses = toLossValues({
+        damaged_in_transit: existingRow.damaged_in_transit,
+        diseased_in_transit: existingRow.diseased_in_transit,
+        parasite: existingRow.parasite,
+        non_emergence: existingRow.non_emergence,
+        poor_emergence: existingRow.poor_emergence,
+      });
+
+      if (LOSS_COLUMNS.some((column) => desiredLosses[column] !== currentLosses[column])) {
+        await tx
+          .update(release_event_losses)
+          .set({ ...desiredLosses, updated_at: new Date() })
+          .where(
+            and(
+              eq(release_event_losses.id, existingRow.id),
+              eq(release_event_losses.institution_id, institutionId),
+            ),
+          );
+      }
+    }
+
+    const newLossRows = Array.from(desiredLossByShipmentItemId.entries())
+      .filter(
+        ([shipmentItemId, losses]) =>
+          sumLossValues(losses) > 0 && !existingLossItemIds.has(shipmentItemId),
+      )
+      .map(([shipmentItemId, losses]) => ({
+        institution_id: institutionId,
+        release_event_id: releaseEventId,
+        shipment_item_id: shipmentItemId,
+        ...losses,
+      }));
+
+    if (newLossRows.length > 0) {
+      await tx.insert(release_event_losses).values(newLossRows);
     }
 
     return { updated: true };
@@ -447,35 +819,60 @@ export async function createReleaseFromShipment(
       throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
     }
 
-    // Apply loss updates in memory + via UPDATE statements so downstream
-    // remaining checks see the corrected inventory.
+    // Create flow accepts absolute loss totals; we apply those to
+    // shipment_items and separately persist only positive per-event deltas.
     const lockedMutableItems = new Map(lockedItems.map((row) => [row.id, { ...row }]));
+    const lossAttributionRows: Array<{ shipment_item_id: number } & LossValues> = [];
     for (const update of lossUpdates) {
       const row = lockedMutableItems.get(update.shipment_item_id);
       if (!row) {
         throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
       }
 
-      const patch: Partial<Record<(typeof LOSS_COLUMNS)[number], number>> = {};
-      for (const column of LOSS_COLUMNS) {
-        const next = update[column];
-        if (typeof next === "number") {
-          row[column] = next;
-          patch[column] = next;
-        }
-      }
+      const { absolutePatch, attributionDelta } = computeCreateLossDelta(
+        {
+          damaged_in_transit: row.damaged_in_transit,
+          diseased_in_transit: row.diseased_in_transit,
+          parasite: row.parasite,
+          non_emergence: row.non_emergence,
+          poor_emergence: row.poor_emergence,
+        },
+        update,
+      );
 
-      if (Object.keys(patch).length === 0) continue;
+      if (Object.keys(absolutePatch).length === 0) continue;
+
+      // Keep in-memory row in sync with the absolute write so remaining checks
+      // below read post-update source-of-truth values.
+      for (const [column, value] of Object.entries(absolutePatch) as Array<[LossColumn, number]>) {
+        row[column] = value;
+      }
 
       await tx
         .update(shipment_items)
-        .set({ ...patch, updated_at: new Date() })
+        .set({ ...absolutePatch, updated_at: new Date() })
         .where(
           and(
             eq(shipment_items.id, update.shipment_item_id),
             eq(shipment_items.institution_id, institutionId),
           ),
         );
+
+      const totalDelta = Object.values(attributionDelta).reduce(
+        (sum, value) => sum + (typeof value === "number" ? value : 0),
+        0,
+      );
+
+      if (totalDelta > 0) {
+        lossAttributionRows.push({
+          shipment_item_id: update.shipment_item_id,
+          damaged_in_transit: attributionDelta.damaged_in_transit ?? 0,
+          diseased_in_transit: attributionDelta.diseased_in_transit ?? 0,
+          parasite: attributionDelta.parasite ?? 0,
+          non_emergence: attributionDelta.non_emergence ?? 0,
+          poor_emergence: attributionDelta.poor_emergence ?? 0,
+        });
+      }
     }
 
     // Replace the original lockedItems list with the mutated copies so the
@@ -552,22 +949,40 @@ export async function createReleaseFromShipment(
         releasedBy: release_events.released_by,
       });
 
-    const inFlightRows = await tx
-      .insert(in_flight)
-      .values(
-        payload.items.map((item) => ({
+    const inFlightRows =
+      payload.items.length > 0
+        ? await tx
+            .insert(in_flight)
+            .values(
+              payload.items.map((item) => ({
+                institution_id: institutionId,
+                release_event_id: releaseEvent.id,
+                shipment_item_id: item.shipment_item_id,
+                quantity: item.quantity,
+              })),
+            )
+            .returning({
+              id: in_flight.id,
+              releaseEventId: in_flight.release_event_id,
+              shipmentItemId: in_flight.shipment_item_id,
+              quantity: in_flight.quantity,
+            })
+        : [];
+
+    if (lossAttributionRows.length > 0) {
+      await tx.insert(release_event_losses).values(
+        lossAttributionRows.map((row) => ({
           institution_id: institutionId,
           release_event_id: releaseEvent.id,
-          shipment_item_id: item.shipment_item_id,
-          quantity: item.quantity,
+          shipment_item_id: row.shipment_item_id,
+          damaged_in_transit: row.damaged_in_transit,
+          diseased_in_transit: row.diseased_in_transit,
+          parasite: row.parasite,
+          non_emergence: row.non_emergence,
+          poor_emergence: row.poor_emergence,
         })),
-      )
-      .returning({
-        id: in_flight.id,
-        releaseEventId: in_flight.release_event_id,
-        shipmentItemId: in_flight.shipment_item_id,
-        quantity: in_flight.quantity,
-      });
+      );
+    }
 
     return {
       event: releaseEvent,
@@ -816,7 +1231,7 @@ export async function deleteReleaseEvent(institutionId: number, releaseEventId: 
       throw new Error(RELEASE_ERRORS.RELEASE_EVENT_NOT_FOUND);
     }
 
-    const relatedItems = await tx
+    const relatedInFlightItems = await tx
       .select({ shipmentItemId: in_flight.shipment_item_id })
       .from(in_flight)
       .where(
@@ -826,11 +1241,48 @@ export async function deleteReleaseEvent(institutionId: number, releaseEventId: 
         ),
       );
 
-    const shipmentItemIds = Array.from(new Set(relatedItems.map((row) => row.shipmentItemId)));
+    const relatedLossRows = await tx
+      .select({
+        shipmentItemId: release_event_losses.shipment_item_id,
+        damaged_in_transit: release_event_losses.damaged_in_transit,
+        diseased_in_transit: release_event_losses.diseased_in_transit,
+        parasite: release_event_losses.parasite,
+        non_emergence: release_event_losses.non_emergence,
+        poor_emergence: release_event_losses.poor_emergence,
+      })
+      .from(release_event_losses)
+      .where(
+        and(
+          eq(release_event_losses.institution_id, institutionId),
+          eq(release_event_losses.release_event_id, releaseEventId),
+        ),
+      );
 
+    const shipmentItemIds = Array.from(
+      new Set([
+        ...relatedInFlightItems.map((row) => row.shipmentItemId),
+        ...relatedLossRows.map((row) => row.shipmentItemId),
+      ]),
+    );
+
+    let lockedShipmentItems: Array<{
+      id: number;
+      damaged_in_transit: number;
+      diseased_in_transit: number;
+      parasite: number;
+      non_emergence: number;
+      poor_emergence: number;
+    }> = [];
     if (shipmentItemIds.length > 0) {
-      await tx
-        .select({ id: shipment_items.id })
+      lockedShipmentItems = await tx
+        .select({
+          id: shipment_items.id,
+          damaged_in_transit: shipment_items.damaged_in_transit,
+          diseased_in_transit: shipment_items.diseased_in_transit,
+          parasite: shipment_items.parasite,
+          non_emergence: shipment_items.non_emergence,
+          poor_emergence: shipment_items.poor_emergence,
+        })
         .from(shipment_items)
         .where(
           and(
@@ -839,6 +1291,48 @@ export async function deleteReleaseEvent(institutionId: number, releaseEventId: 
           ),
         )
         .for("update");
+
+      if (lockedShipmentItems.length !== shipmentItemIds.length) {
+        throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
+      }
+    }
+
+    if (relatedLossRows.length > 0) {
+      const lockedById = new Map(lockedShipmentItems.map((row) => [row.id, row]));
+
+      for (const lossRow of relatedLossRows) {
+        const locked = lockedById.get(lossRow.shipmentItemId);
+        if (!locked) {
+          throw new Error(RELEASE_ERRORS.SHIPMENT_ITEM_NOT_FOUND);
+        }
+
+        const patch = computeDeleteLossRollbackPatch(
+          toLossValues({
+            damaged_in_transit: locked.damaged_in_transit,
+            diseased_in_transit: locked.diseased_in_transit,
+            parasite: locked.parasite,
+            non_emergence: locked.non_emergence,
+            poor_emergence: locked.poor_emergence,
+          }),
+          toLossValues({
+            damaged_in_transit: lossRow.damaged_in_transit,
+            diseased_in_transit: lossRow.diseased_in_transit,
+            parasite: lossRow.parasite,
+            non_emergence: lossRow.non_emergence,
+            poor_emergence: lossRow.poor_emergence,
+          }),
+        );
+
+        await tx
+          .update(shipment_items)
+          .set({ ...patch, updated_at: new Date() })
+          .where(
+            and(
+              eq(shipment_items.id, lossRow.shipmentItemId),
+              eq(shipment_items.institution_id, institutionId),
+            ),
+          );
+      }
     }
 
     const [deleted] = await tx

--- a/src/lib/queries/releases.ts
+++ b/src/lib/queries/releases.ts
@@ -223,13 +223,34 @@ export function calculateRemaining(item: LockedShipmentItem, alreadyReleased: nu
 export async function listInstitutionReleases(institutionId: number, page: number, limit: number) {
   const offset = (page - 1) * limit;
 
+  const pagedReleaseEvents = db
+    .select({
+      id: release_events.id,
+      institutionId: release_events.institution_id,
+      shipmentId: release_events.shipment_id,
+      releaseDate: release_events.release_date,
+      releasedBy: release_events.released_by,
+    })
+    .from(release_events)
+    .where(eq(release_events.institution_id, institutionId))
+    .orderBy(desc(release_events.release_date))
+    .limit(limit)
+    .offset(offset)
+    .as("paged_release_events");
+
   const inFlightTotals = db
     .select({
       releaseEventId: in_flight.release_event_id,
       totalReleased: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as("total_released"),
     })
     .from(in_flight)
-    .where(eq(in_flight.institution_id, institutionId))
+    .innerJoin(
+      pagedReleaseEvents,
+      and(
+        eq(pagedReleaseEvents.id, in_flight.release_event_id),
+        eq(pagedReleaseEvents.institutionId, in_flight.institution_id),
+      ),
+    )
     .groupBy(in_flight.release_event_id)
     .as("in_flight_totals");
 
@@ -245,17 +266,23 @@ export async function listInstitutionReleases(institutionId: number, page: numbe
       ), 0)::int`.as("total_losses"),
     })
     .from(release_event_losses)
-    .where(eq(release_event_losses.institution_id, institutionId))
+    .innerJoin(
+      pagedReleaseEvents,
+      and(
+        eq(pagedReleaseEvents.id, release_event_losses.release_event_id),
+        eq(pagedReleaseEvents.institutionId, release_event_losses.institution_id),
+      ),
+    )
     .groupBy(release_event_losses.release_event_id)
     .as("loss_totals");
 
   const [rows, totalResult] = await Promise.all([
     db
       .select({
-        id: release_events.id,
-        shipmentId: release_events.shipment_id,
-        releaseDate: release_events.release_date,
-        releasedBy: release_events.released_by,
+        id: pagedReleaseEvents.id,
+        shipmentId: pagedReleaseEvents.shipmentId,
+        releaseDate: pagedReleaseEvents.releaseDate,
+        releasedBy: pagedReleaseEvents.releasedBy,
         supplierCode: shipments.supplier_code,
         shipmentDate: shipments.shipment_date,
         totalReleased: sql<number>`coalesce(${inFlightTotals.totalReleased}, 0)::int`.as(
@@ -263,20 +290,17 @@ export async function listInstitutionReleases(institutionId: number, page: numbe
         ),
         totalLosses: sql<number>`coalesce(${lossTotals.totalLosses}, 0)::int`.as("total_losses"),
       })
-      .from(release_events)
+      .from(pagedReleaseEvents)
       .innerJoin(
         shipments,
         and(
-          eq(shipments.id, release_events.shipment_id),
-          eq(shipments.institution_id, release_events.institution_id),
+          eq(shipments.id, pagedReleaseEvents.shipmentId),
+          eq(shipments.institution_id, pagedReleaseEvents.institutionId),
         ),
       )
-      .leftJoin(inFlightTotals, eq(inFlightTotals.releaseEventId, release_events.id))
-      .leftJoin(lossTotals, eq(lossTotals.releaseEventId, release_events.id))
-      .where(eq(release_events.institution_id, institutionId))
-      .orderBy(desc(release_events.release_date))
-      .limit(limit)
-      .offset(offset),
+      .leftJoin(inFlightTotals, eq(inFlightTotals.releaseEventId, pagedReleaseEvents.id))
+      .leftJoin(lossTotals, eq(lossTotals.releaseEventId, pagedReleaseEvents.id))
+      .orderBy(desc(pagedReleaseEvents.releaseDate)),
 
     db
       .select({ total: count() })
@@ -303,13 +327,35 @@ export async function listInstitutionReleases(institutionId: number, page: numbe
  * render a meaningful "Released" column without an extra round-trip.
  */
 export async function listReleaseEventsForShipment(institutionId: number, shipmentId: number) {
+  const shipmentReleaseEvents = db
+    .select({
+      id: release_events.id,
+      institutionId: release_events.institution_id,
+      releaseDate: release_events.release_date,
+      releasedBy: release_events.released_by,
+    })
+    .from(release_events)
+    .where(
+      and(
+        eq(release_events.institution_id, institutionId),
+        eq(release_events.shipment_id, shipmentId),
+      ),
+    )
+    .as("shipment_release_events");
+
   const inFlightTotals = db
     .select({
       releaseEventId: in_flight.release_event_id,
       totalReleased: sql<number>`coalesce(sum(${in_flight.quantity}), 0)::int`.as("total_released"),
     })
     .from(in_flight)
-    .where(eq(in_flight.institution_id, institutionId))
+    .innerJoin(
+      shipmentReleaseEvents,
+      and(
+        eq(shipmentReleaseEvents.id, in_flight.release_event_id),
+        eq(shipmentReleaseEvents.institutionId, in_flight.institution_id),
+      ),
+    )
     .groupBy(in_flight.release_event_id)
     .as("in_flight_totals");
 
@@ -325,30 +371,30 @@ export async function listReleaseEventsForShipment(institutionId: number, shipme
       ), 0)::int`.as("total_losses"),
     })
     .from(release_event_losses)
-    .where(eq(release_event_losses.institution_id, institutionId))
+    .innerJoin(
+      shipmentReleaseEvents,
+      and(
+        eq(shipmentReleaseEvents.id, release_event_losses.release_event_id),
+        eq(shipmentReleaseEvents.institutionId, release_event_losses.institution_id),
+      ),
+    )
     .groupBy(release_event_losses.release_event_id)
     .as("loss_totals");
 
   return db
     .select({
-      id: release_events.id,
-      releaseDate: release_events.release_date,
-      releasedBy: release_events.released_by,
+      id: shipmentReleaseEvents.id,
+      releaseDate: shipmentReleaseEvents.releaseDate,
+      releasedBy: shipmentReleaseEvents.releasedBy,
       totalReleased: sql<number>`coalesce(${inFlightTotals.totalReleased}, 0)::int`.as(
         "total_released",
       ),
       totalLosses: sql<number>`coalesce(${lossTotals.totalLosses}, 0)::int`.as("total_losses"),
     })
-    .from(release_events)
-    .leftJoin(inFlightTotals, eq(inFlightTotals.releaseEventId, release_events.id))
-    .leftJoin(lossTotals, eq(lossTotals.releaseEventId, release_events.id))
-    .where(
-      and(
-        eq(release_events.institution_id, institutionId),
-        eq(release_events.shipment_id, shipmentId),
-      ),
-    )
-    .orderBy(desc(release_events.release_date));
+    .from(shipmentReleaseEvents)
+    .leftJoin(inFlightTotals, eq(inFlightTotals.releaseEventId, shipmentReleaseEvents.id))
+    .leftJoin(lossTotals, eq(lossTotals.releaseEventId, shipmentReleaseEvents.id))
+    .orderBy(desc(shipmentReleaseEvents.releaseDate));
 }
 
 /**

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,4 +1,5 @@
 import {
+  check,
   integer,
   pgTable,
   serial,
@@ -11,6 +12,7 @@ import {
   foreignKey,
   unique,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import type { SpeciesFunFact } from "@/types/butterfly";
 
 /**
@@ -466,5 +468,81 @@ export const in_flight = pgTable(
       foreignColumns: [shipment_items.institution_id, shipment_items.id],
       name: "fk_in_flight_shipment_item_institution",
     }).onDelete("restrict"),
+  }),
+);
+
+/**
+ * Release Event Loss Attribution
+ *
+ * Stores event-level loss quantities attributed during a specific release.
+ * `shipment_items` remains the source of truth for current totals; this table
+ * is workflow/history attribution only.
+ */
+export const release_event_losses = pgTable(
+  "release_event_losses",
+  {
+    id: serial("id").primaryKey(),
+
+    institution_id: integer("institution_id")
+      .notNull()
+      .references(() => institutions.id, { onDelete: "cascade" }),
+
+    release_event_id: integer("release_event_id").notNull(),
+    shipment_item_id: integer("shipment_item_id").notNull(),
+
+    damaged_in_transit: integer("damaged_in_transit").notNull().default(0),
+    diseased_in_transit: integer("diseased_in_transit").notNull().default(0),
+    parasite: integer("parasite").notNull().default(0),
+    non_emergence: integer("non_emergence").notNull().default(0),
+    poor_emergence: integer("poor_emergence").notNull().default(0),
+
+    created_at: timestamp("created_at").defaultNow().notNull(),
+    updated_at: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    unique_release_event_losses_shipment_item: uniqueIndex(
+      "unique_release_event_losses_shipment_item",
+    ).on(table.release_event_id, table.shipment_item_id),
+
+    idx_release_event_losses_institution_event: index(
+      "idx_release_event_losses_institution_event",
+    ).on(table.institution_id, table.release_event_id),
+
+    idx_release_event_losses_institution_shipment_item: index(
+      "idx_release_event_losses_institution_shipment_item",
+    ).on(table.institution_id, table.shipment_item_id),
+
+    fk_release_event_losses_event_institution: foreignKey({
+      columns: [table.institution_id, table.release_event_id],
+      foreignColumns: [release_events.institution_id, release_events.id],
+      name: "fk_release_event_losses_event_institution",
+    }).onDelete("cascade"),
+
+    fk_release_event_losses_shipment_item_institution: foreignKey({
+      columns: [table.institution_id, table.shipment_item_id],
+      foreignColumns: [shipment_items.institution_id, shipment_items.id],
+      name: "fk_release_event_losses_shipment_item_institution",
+    }).onDelete("restrict"),
+
+    ck_release_event_losses_damaged_nonnegative: check(
+      "ck_release_event_losses_damaged_nonnegative",
+      sql`${table.damaged_in_transit} >= 0`,
+    ),
+    ck_release_event_losses_diseased_nonnegative: check(
+      "ck_release_event_losses_diseased_nonnegative",
+      sql`${table.diseased_in_transit} >= 0`,
+    ),
+    ck_release_event_losses_parasite_nonnegative: check(
+      "ck_release_event_losses_parasite_nonnegative",
+      sql`${table.parasite} >= 0`,
+    ),
+    ck_release_event_losses_non_emergence_nonnegative: check(
+      "ck_release_event_losses_non_emergence_nonnegative",
+      sql`${table.non_emergence} >= 0`,
+    ),
+    ck_release_event_losses_poor_emergence_nonnegative: check(
+      "ck_release_event_losses_poor_emergence_nonnegative",
+      sql`${table.poor_emergence} >= 0`,
+    ),
   }),
 );

--- a/src/lib/validation/releases.ts
+++ b/src/lib/validation/releases.ts
@@ -7,6 +7,21 @@ const releaseItemSchema = z
   })
   .strict();
 
+const updateReleaseItemSchema = z
+  .object({
+    shipment_item_id: z.coerce.number().int().positive(),
+    quantity: z.coerce.number().int().nonnegative(),
+  })
+  .strict();
+
+const releaseLossColumns = [
+  "damaged_in_transit",
+  "diseased_in_transit",
+  "parasite",
+  "non_emergence",
+  "poor_emergence",
+] as const;
+
 /**
  * Loss-column corrections that can be applied atomically alongside a release
  * POST. Each row carries absolute new values for any loss columns the client
@@ -28,7 +43,7 @@ const releaseLossUpdateSchema = z
 export const createReleaseFromShipmentSchema = z
   .object({
     released_at: z.coerce.date().optional(),
-    items: z.array(releaseItemSchema).min(1, "At least one release item is required"),
+    items: z.array(releaseItemSchema).default([]),
     loss_updates: z.array(releaseLossUpdateSchema).optional().default([]),
   })
   .strict()
@@ -59,6 +74,20 @@ export const createReleaseFromShipmentSchema = z
         break;
       }
       lossSeen.add(row.shipment_item_id);
+    }
+
+    // Create-release can be "release + losses" OR "losses-only" (e.g. poor emergence),
+    // but should still reject truly empty/no-op payloads.
+    const hasAnyLossValue = (data.loss_updates ?? []).some((row) =>
+      releaseLossColumns.some((column) => typeof row[column] === "number"),
+    );
+
+    if (data.items.length === 0 && !hasAnyLossValue) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "At least one release item or loss update is required",
+        path: ["items"],
+      });
     }
   });
 
@@ -92,12 +121,34 @@ export const createInFlightBodySchema = z
 
 export type CreateInFlightBody = z.infer<typeof createInFlightBodySchema>;
 
+const updateReleaseLossRowSchema = z
+  .object({
+    shipment_item_id: z.coerce.number().int().positive(),
+    damaged_in_transit: z.coerce.number().int().nonnegative(),
+    diseased_in_transit: z.coerce.number().int().nonnegative(),
+    parasite: z.coerce.number().int().nonnegative(),
+    non_emergence: z.coerce.number().int().nonnegative(),
+    poor_emergence: z.coerce.number().int().nonnegative(),
+  })
+  .strict();
+
 export const updateReleaseEventItemsSchema = z
   .object({
-    items: z.array(releaseItemSchema).min(1, "At least one release item is required"),
+    items: z.array(updateReleaseItemSchema).default([]),
+    // Edit-flow event-level losses. Distinct name from create `loss_updates`
+    // to avoid mixing absolute-total and event-level semantics.
+    losses: z.array(updateReleaseLossRowSchema).optional(),
   })
   .strict()
   .superRefine((data, ctx) => {
+    if (data.items.length === 0 && (!data.losses || data.losses.length === 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "At least one release item or losses row is required",
+        path: ["items"],
+      });
+    }
+
     const seen = new Set<number>();
 
     for (const item of data.items) {
@@ -111,6 +162,19 @@ export const updateReleaseEventItemsSchema = z
       }
 
       seen.add(item.shipment_item_id);
+    }
+
+    const lossSeen = new Set<number>();
+    for (const row of data.losses ?? []) {
+      if (lossSeen.has(row.shipment_item_id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Shipment items must be unique in losses",
+          path: ["losses"],
+        });
+        break;
+      }
+      lossSeen.add(row.shipment_item_id);
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes the shipment release flow by adding event-level loss attribution while keeping `shipment_items` as the source of truth for current shipment totals.

This resolves confusing behavior around loss-only and mixed releases by making release events track both released/in-flight quantities and loss quantities.

Closes #93 

## Changes

- Added `release_event_losses` table with tenant-safe foreign keys, indexes, and non-negative checks
- Updated create release flow:
  - create still accepts absolute shipment loss totals via `loss_updates`
  - stores only positive deltas as release-event loss attribution
  - rejects negative loss deltas
- Updated release read paths:
  - release detail now includes `losses`
  - release history now includes `totalLosses`
- Updated edit release flow:
  - edit uses event-level `losses`
  - applies deltas back to `shipment_items`
  - blocks all-zero release saves
  - preserves existing losses when `losses` is omitted
- Updated delete release behavior:
  - rolls back event-attributed loss quantities from `shipment_items`
  - blocks rollback if it would underflow shipment totals
- Updated release UI:
  - release history now shows Released and Losses
  - edit page supports released quantities and loss quantities
  - added Delete Release action with confirmation
  - compacted edit composer layout
  - added accessibility improvements for errors and live totals
- Updated docs and session changelog

## Test Plan

- [x] `pnpm exec jest --runTestsByPath src/lib/__test__/schema.test.ts`
- [x] `pnpm exec jest --runTestsByPath src/lib/__test__/release-helpers.test.ts src/__test__/api/tenant/releases.route.test.ts`
- [x] `pnpm exec jest --runTestsByPath src/__test__/api/tenant/releases.route.test.ts src/__test__/api/tenant/shipments.route.test.ts`
- [x] `pnpm exec jest --runTestsByPath src/lib/__test__/validation-releases.test.ts src/__test__/api/tenant/releases.route.test.ts src/__test__/api/tenant/shipments.route.test.ts`
- [x] `pnpm exec tsc --noEmit --project tsconfig.json`

## Manual Testing

- [ ] Create good-only release
- [ ] Create losses-only release
- [ ] Create mixed release with released + poor emergence
- [ ] Verify shipment release history shows Released and Losses
- [ ] Edit release quantities and verify shipment totals update correctly
- [ ] Try saving an all-zero release and confirm it is blocked
- [ ] Delete release and confirm attributed quantities roll back