### PR TITLE
feat(suppliers): added platform level suppliers

### DIFF
--- a/src/__test__/api/platform/suppliers.route.test.ts
+++ b/src/__test__/api/platform/suppliers.route.test.ts
@@ -164,6 +164,21 @@ describe("Platform Suppliers API", () => {
       );
     });
 
+    it("accepts supplier websites without a protocol", async () => {
+      mockCreatePlatformSupplier.mockResolvedValueOnce({
+        ...sampleSupplier,
+        websiteUrl: "example.com",
+      });
+
+      const response = (await postSupplier(
+        makePostRequest({ ...validCreatePayload(), website_url: "example.com" }),
+      ))!;
+      expect(response.status).toBe(201);
+      expect(mockCreatePlatformSupplier).toHaveBeenCalledWith(
+        expect.objectContaining({ website_url: "example.com" }),
+      );
+    });
+
     it("returns 409 when supplier code already exists", async () => {
       mockCreatePlatformSupplier.mockRejectedValueOnce(new Error("CONFLICT"));
 
@@ -274,6 +289,23 @@ describe("Platform Suppliers API", () => {
 
       const body = await response.json();
       expect(body.supplier.name).toBe("Updated Name");
+    });
+
+    it("accepts website updates without a protocol", async () => {
+      mockUpdatePlatformSupplier.mockResolvedValueOnce({
+        ...sampleSupplier,
+        websiteUrl: "example.com",
+      });
+
+      const response = (await patchSupplierById(
+        makePatchRequest("1", { website_url: "example.com" }),
+        routeContext("1"),
+      ))!;
+      expect(response.status).toBe(200);
+      expect(mockUpdatePlatformSupplier).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ website_url: "example.com" }),
+      );
     });
 
     it("returns 404 when supplier not found", async () => {

--- a/src/app/(platform)/admin/suppliers/page.tsx
+++ b/src/app/(platform)/admin/suppliers/page.tsx
@@ -1,9 +1,22 @@
-// placeholder for suppliers management page
-export default function PlatformSuppliersPage() {
-  return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-10">
-      <h1 className="text-2xl font-bold">Suppliers Management</h1>
-      <p>This is a placeholder for the suppliers management page.</p>
-    </div>
-  );
+import SuppliersClient from "@/components/platform/suppliers/suppliers-client";
+import type { PlatformSupplierSummary } from "@/components/platform/suppliers/suppliers.utils";
+import { getPlatformSuppliers } from "@/lib/services/platform-suppliers";
+
+export default async function PlatformSuppliersPage() {
+  const rawSuppliers = await getPlatformSuppliers();
+
+  const suppliers: PlatformSupplierSummary[] = rawSuppliers.map((supplier) => ({
+    id: supplier.id,
+    name: supplier.name,
+    code: supplier.code,
+    country: supplier.country,
+    websiteUrl: supplier.websiteUrl,
+    isActive: supplier.isActive,
+    createdAt:
+      supplier.createdAt instanceof Date
+        ? supplier.createdAt.toISOString()
+        : String(supplier.createdAt),
+  }));
+
+  return <SuppliersClient suppliers={suppliers} />;
 }

--- a/src/components/platform/suppliers/supplier-delete-dialog.tsx
+++ b/src/components/platform/suppliers/supplier-delete-dialog.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+import type { PlatformSupplierSummary } from "./suppliers.utils";
+
+type ApiErrorResponse = {
+  error?: {
+    message?: string;
+  };
+};
+
+interface SupplierDeleteDialogProps {
+  supplier: PlatformSupplierSummary | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDeleted: (supplierId: number) => void;
+}
+
+export default function SupplierDeleteDialog({
+  supplier,
+  open,
+  onOpenChange,
+  onDeleted,
+}: SupplierDeleteDialogProps) {
+  async function handleDelete() {
+    if (!supplier) {
+      return;
+    }
+
+    const response = await fetch(`/api/platform/suppliers/${supplier.id}`, {
+      method: "DELETE",
+    });
+
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as ApiErrorResponse;
+      toast.error(body.error?.message ?? "Unable to delete supplier.");
+      return;
+    }
+
+    onDeleted(supplier.id);
+    toast.success("Supplier deleted.");
+    onOpenChange(false);
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogMedia>
+            <AlertTriangle aria-hidden="true" />
+          </AlertDialogMedia>
+          <AlertDialogTitle>Delete supplier?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {supplier ? (
+              <>
+                This will permanently remove <strong>{supplier.name}</strong> from the global
+                supplier catalog.
+              </>
+            ) : (
+              "This will permanently remove the selected supplier from the global supplier catalog."
+            )}
+          </AlertDialogDescription>
+          <AlertDialogDescription>
+            If the supplier is already referenced by shipments, deletion will be blocked.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={handleDelete}>
+            Delete supplier
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/platform/suppliers/supplier-form-dialog.tsx
+++ b/src/components/platform/suppliers/supplier-form-dialog.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useEffect } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+
+import { normalizePlatformSupplier, type PlatformSupplierRecord } from "./suppliers.utils";
+
+const websiteInputSchema = z
+  .string()
+  .trim()
+  .refine((value) => !value || isValidWebsiteInput(value), {
+    message: "Enter a valid website",
+  });
+
+function isValidWebsiteInput(value: string) {
+  if (/\s/.test(value)) return false;
+
+  const candidate = /^[a-z][a-z\d+\-.]*:\/\//i.test(value) ? value : `https://${value}`;
+
+  try {
+    const url = new URL(candidate);
+    return url.hostname.includes(".");
+  } catch {
+    return false;
+  }
+}
+
+const supplierFormSchema = z.object({
+  name: z.string().trim().min(1, "Supplier name is required").max(200),
+  code: z.string().trim().min(1, "Supplier code is required").max(50),
+  country: z.string().trim().min(1, "Country is required").max(100),
+  website_url: websiteInputSchema,
+  is_active: z.boolean(),
+});
+
+type SupplierFormInput = z.input<typeof supplierFormSchema>;
+type SupplierFormOutput = z.output<typeof supplierFormSchema>;
+
+type ApiErrorResponse = {
+  error?: {
+    message?: string;
+  };
+};
+
+interface SupplierFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  supplier: PlatformSupplierRecord | null;
+  onSaved: (supplier: PlatformSupplierRecord, mode: "create" | "edit") => void;
+}
+
+const defaultValues: SupplierFormInput = {
+  name: "",
+  code: "",
+  country: "",
+  website_url: "",
+  is_active: true,
+};
+
+export default function SupplierFormDialog({
+  open,
+  onOpenChange,
+  supplier,
+  onSaved,
+}: SupplierFormDialogProps) {
+  const isEdit = supplier !== null;
+
+  const form = useForm<SupplierFormInput, undefined, SupplierFormOutput>({
+    resolver: zodResolver(supplierFormSchema),
+    mode: "onBlur",
+    defaultValues,
+  });
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    form.reset(
+      supplier
+        ? {
+            name: supplier.name,
+            code: supplier.code,
+            country: supplier.country,
+            website_url: supplier.websiteUrl ?? "",
+            is_active: supplier.isActive,
+          }
+        : defaultValues,
+    );
+  }, [form, open, supplier]);
+
+  async function onSubmit(values: SupplierFormOutput) {
+    const payload: {
+      name: string;
+      code: string;
+      country: string;
+      website_url?: string | null;
+      is_active: boolean;
+    } = {
+      name: values.name,
+      code: values.code,
+      country: values.country,
+      is_active: values.is_active,
+    };
+
+    if (values.website_url) {
+      payload.website_url = values.website_url;
+    } else if (isEdit) {
+      payload.website_url = null;
+    }
+
+    const endpoint = isEdit ? `/api/platform/suppliers/${supplier.id}` : "/api/platform/suppliers";
+
+    const response = await fetch(endpoint, {
+      method: isEdit ? "PATCH" : "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorBody = (await response.json().catch(() => ({}))) as ApiErrorResponse;
+
+      if (response.status === 409) {
+        form.setError("code", {
+          message: "Supplier code already exists or is referenced by shipments.",
+        });
+        return;
+      }
+
+      toast.error(
+        errorBody.error?.message ?? `Unable to ${isEdit ? "update" : "create"} supplier.`,
+      );
+      return;
+    }
+
+    const data = (await response.json()) as {
+      supplier: {
+        id: number;
+        name: string;
+        code: string;
+        country: string;
+        websiteUrl: string | null;
+        isActive: boolean;
+        createdAt: string;
+      };
+    };
+
+    onSaved(normalizePlatformSupplier(data.supplier), isEdit ? "edit" : "create");
+    toast.success(isEdit ? "Supplier updated." : "Supplier created.");
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Edit Supplier" : "Add Supplier"}</DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Update this global supplier record."
+              : "Create a supplier record available across the platform."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Supplier name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Costa Rica Butterflies" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="code"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Supplier code</FormLabel>
+                    <FormControl>
+                      <Input placeholder="CRB" {...field} />
+                    </FormControl>
+                    <FormDescription>Used in shipment imports and records.</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="country"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Country</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Costa Rica" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="website_url"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Website</FormLabel>
+                    <FormControl>
+                      <Input type="text" placeholder="example.com" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="is_active"
+              render={({ field }) => (
+                <FormItem className="border-border flex items-center justify-between gap-4 rounded-md border p-4">
+                  <div className="space-y-1">
+                    <FormLabel>Active supplier</FormLabel>
+                    <FormDescription>
+                      Active suppliers appear first and remain available for shipment workflows.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      aria-label="Supplier active status"
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                {form.formState.isSubmitting
+                  ? isEdit
+                    ? "Saving..."
+                    : "Creating..."
+                  : isEdit
+                    ? "Save changes"
+                    : "Create supplier"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/platform/suppliers/supplier-form-dialog.tsx
+++ b/src/components/platform/suppliers/supplier-form-dialog.tsx
@@ -29,9 +29,18 @@ import { Switch } from "@/components/ui/switch";
 
 import { normalizePlatformSupplier, type PlatformSupplierRecord } from "./suppliers.utils";
 
+const WEBSITE_MAX_LENGTH = 300;
+
+function sanitizeWebsiteInput(value: string) {
+  return value.trim().replace(/[\u0000-\u001F\u007F]/g, "");
+}
+
 const websiteInputSchema = z
   .string()
-  .trim()
+  .transform(sanitizeWebsiteInput)
+  .refine((value) => value.length <= WEBSITE_MAX_LENGTH, {
+    message: `Website must be at most ${WEBSITE_MAX_LENGTH} characters`,
+  })
   .refine((value) => !value || isValidWebsiteInput(value), {
     message: "Enter a valid website",
   });

--- a/src/components/platform/suppliers/supplier-form-dialog.tsx
+++ b/src/components/platform/suppliers/supplier-form-dialog.tsx
@@ -26,34 +26,16 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { sanitizedNonEmpty } from "@/lib/validation/sanitize";
+import { supplierWebsiteSchema } from "@/lib/validation/suppliers";
 
 import { normalizePlatformSupplier, type PlatformSupplierRecord } from "./suppliers.utils";
 
-const websiteInputSchema = z
-  .string()
-  .trim()
-  .refine((value) => !value || isValidWebsiteInput(value), {
-    message: "Enter a valid website",
-  });
-
-function isValidWebsiteInput(value: string) {
-  if (/\s/.test(value)) return false;
-
-  const candidate = /^[a-z][a-z\d+\-.]*:\/\//i.test(value) ? value : `https://${value}`;
-
-  try {
-    const url = new URL(candidate);
-    return url.hostname.includes(".");
-  } catch {
-    return false;
-  }
-}
-
 const supplierFormSchema = z.object({
-  name: z.string().trim().min(1, "Supplier name is required").max(200),
-  code: z.string().trim().min(1, "Supplier code is required").max(50),
-  country: z.string().trim().min(1, "Country is required").max(100),
-  website_url: websiteInputSchema,
+  name: sanitizedNonEmpty(200),
+  code: sanitizedNonEmpty(50),
+  country: sanitizedNonEmpty(100),
+  website_url: supplierWebsiteSchema.or(z.literal("")),
   is_active: z.boolean(),
 });
 

--- a/src/components/platform/suppliers/suppliers-cards.tsx
+++ b/src/components/platform/suppliers/suppliers-cards.tsx
@@ -1,0 +1,76 @@
+import { Pencil, Trash2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+import type { PlatformSupplierSummary } from "./suppliers.utils";
+
+interface SuppliersCardsProps {
+  suppliers: PlatformSupplierSummary[];
+  onEdit: (supplier: PlatformSupplierSummary) => void;
+  onDelete: (supplier: PlatformSupplierSummary) => void;
+}
+
+export default function SuppliersCards({ suppliers, onEdit, onDelete }: SuppliersCardsProps) {
+  if (suppliers.length === 0) {
+    return (
+      <Card className="md:hidden">
+        <CardContent className="py-8 text-center">
+          <p className="text-muted-foreground text-sm">No suppliers found.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 md:hidden">
+      {suppliers.map((supplier) => (
+        <Card key={supplier.id}>
+          <CardContent className="flex flex-col gap-4 pt-6">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 space-y-1">
+                <p className="text-base font-medium break-words">{supplier.name}</p>
+                <p className="text-muted-foreground text-sm break-words">{supplier.code}</p>
+              </div>
+              <Badge variant={supplier.isActive ? "default" : "secondary"}>
+                {supplier.isActive ? "Active" : "Inactive"}
+              </Badge>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1">
+                <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                  Country
+                </p>
+                <p className="text-sm">{supplier.country}</p>
+              </div>
+
+              <div className="space-y-1">
+                <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                  Website
+                </p>
+                {supplier.websiteUrl ? (
+                  <p className="truncate text-sm">{supplier.websiteUrl}</p>
+                ) : (
+                  <p className="text-muted-foreground text-sm">None</p>
+                )}
+              </div>
+            </div>
+
+            <div className="flex gap-2">
+              <Button className="flex-1" variant="outline" onClick={() => onEdit(supplier)}>
+                <Pencil aria-hidden="true" className="size-4" />
+                Edit
+              </Button>
+              <Button className="flex-1" variant="outline" onClick={() => onDelete(supplier)}>
+                <Trash2 aria-hidden="true" className="size-4" />
+                Delete
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/platform/suppliers/suppliers-client.tsx
+++ b/src/components/platform/suppliers/suppliers-client.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { Package } from "lucide-react";
+import { startTransition, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+import SupplierDeleteDialog from "./supplier-delete-dialog";
+import SupplierFormDialog from "./supplier-form-dialog";
+import SuppliersCards from "./suppliers-cards";
+import SuppliersHeader from "./suppliers-header";
+import SuppliersTable from "./suppliers-table";
+import SuppliersToolbar from "./suppliers-toolbar";
+import {
+  filterSuppliers,
+  toPlatformSupplierSummary,
+  type PlatformSupplierRecord,
+  type PlatformSupplierSummary,
+} from "./suppliers.utils";
+
+const PAGE_SIZE = 15;
+
+interface SuppliersClientProps {
+  suppliers: PlatformSupplierSummary[];
+}
+
+export default function SuppliersClient({ suppliers: initialSuppliers }: SuppliersClientProps) {
+  const [suppliers, setSuppliers] = useState(initialSuppliers);
+  const [search, setSearch] = useState("");
+  const [showInactive, setShowInactive] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingSupplier, setEditingSupplier] = useState<PlatformSupplierSummary | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<PlatformSupplierSummary | null>(null);
+
+  const filteredSuppliers = useMemo(
+    () => filterSuppliers(suppliers, search, showInactive),
+    [search, showInactive, suppliers],
+  );
+
+  const totalPages = Math.max(1, Math.ceil(filteredSuppliers.length / PAGE_SIZE));
+  const safePage = Math.min(currentPage, totalPages);
+  const start = (safePage - 1) * PAGE_SIZE;
+  const paginatedSuppliers = filteredSuppliers.slice(start, start + PAGE_SIZE);
+  const showingEnd = Math.min(start + PAGE_SIZE, filteredSuppliers.length);
+  const activeSupplierCount = suppliers.filter((supplier) => supplier.isActive).length;
+
+  function handleSearchChange(value: string) {
+    setSearch(value);
+    setCurrentPage(1);
+  }
+
+  function handleShowInactiveChange(value: boolean) {
+    setShowInactive(value);
+    setCurrentPage(1);
+  }
+
+  function handleAddSupplier() {
+    setEditingSupplier(null);
+    setFormOpen(true);
+  }
+
+  function handleEditSupplier(supplier: PlatformSupplierSummary) {
+    setEditingSupplier(supplier);
+    setFormOpen(true);
+  }
+
+  function handleSupplierSaved(record: PlatformSupplierRecord, mode: "create" | "edit") {
+    const summary = toPlatformSupplierSummary(record);
+
+    startTransition(() => {
+      setSuppliers((current) => {
+        if (mode === "create") {
+          return [...current, summary];
+        }
+
+        return current.map((supplier) => (supplier.id === summary.id ? summary : supplier));
+      });
+      setCurrentPage(1);
+    });
+  }
+
+  function handleSupplierDeleted(supplierId: number) {
+    startTransition(() => {
+      setSuppliers((current) => current.filter((supplier) => supplier.id !== supplierId));
+      setCurrentPage(1);
+    });
+    setDeleteTarget(null);
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-10">
+      <SuppliersHeader
+        activeSuppliers={activeSupplierCount}
+        totalSuppliers={suppliers.length}
+        onAddSupplier={handleAddSupplier}
+      />
+
+      <SuppliersToolbar
+        search={search}
+        onSearchChange={handleSearchChange}
+        showInactive={showInactive}
+        onShowInactiveChange={handleShowInactiveChange}
+      />
+
+      {suppliers.length === 0 ? (
+        <Card>
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Package aria-hidden="true" />
+              </EmptyMedia>
+              <EmptyTitle>No suppliers yet</EmptyTitle>
+              <EmptyDescription>
+                Add the first supplier record to support shipment imports and tracking.
+              </EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button onClick={handleAddSupplier}>Add Supplier</Button>
+            </EmptyContent>
+          </Empty>
+        </Card>
+      ) : filteredSuppliers.length === 0 ? (
+        <Card>
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Package aria-hidden="true" />
+              </EmptyMedia>
+              <EmptyTitle>No matching suppliers</EmptyTitle>
+              <EmptyDescription>
+                Try a different search term or show inactive suppliers.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        </Card>
+      ) : (
+        <>
+          <SuppliersCards
+            suppliers={paginatedSuppliers}
+            onEdit={handleEditSupplier}
+            onDelete={setDeleteTarget}
+          />
+          <SuppliersTable
+            suppliers={paginatedSuppliers}
+            onEdit={handleEditSupplier}
+            onDelete={setDeleteTarget}
+          />
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-muted-foreground text-sm">
+              Showing {start + 1}-{showingEnd} of {filteredSuppliers.length}{" "}
+              {filteredSuppliers.length === 1 ? "supplier" : "suppliers"}
+            </p>
+
+            {filteredSuppliers.length > PAGE_SIZE && (
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+                  disabled={safePage === 1}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+                  disabled={safePage === totalPages}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      <SupplierFormDialog
+        key={editingSupplier?.id ?? "create"}
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        supplier={editingSupplier}
+        onSaved={handleSupplierSaved}
+      />
+
+      <SupplierDeleteDialog
+        supplier={deleteTarget}
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteTarget(null);
+          }
+        }}
+        onDeleted={handleSupplierDeleted}
+      />
+    </div>
+  );
+}

--- a/src/components/platform/suppliers/suppliers-header.tsx
+++ b/src/components/platform/suppliers/suppliers-header.tsx
@@ -1,0 +1,34 @@
+import { Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface SuppliersHeaderProps {
+  activeSuppliers: number;
+  totalSuppliers: number;
+  onAddSupplier: () => void;
+}
+
+export default function SuppliersHeader({
+  activeSuppliers,
+  totalSuppliers,
+  onAddSupplier,
+}: SuppliersHeaderProps) {
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h1 className="text-2xl font-bold">Suppliers</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Manage the global supplier catalog used by shipment imports and tenant records.
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm">
+          {activeSuppliers} active of {totalSuppliers} total suppliers
+        </p>
+      </div>
+
+      <Button onClick={onAddSupplier}>
+        <Plus aria-hidden="true" className="size-4" />
+        Add Supplier
+      </Button>
+    </div>
+  );
+}

--- a/src/components/platform/suppliers/suppliers-table-row.tsx
+++ b/src/components/platform/suppliers/suppliers-table-row.tsx
@@ -1,0 +1,57 @@
+import { Pencil, Trash2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { TableCell, TableRow } from "@/components/ui/table";
+
+import type { PlatformSupplierSummary } from "./suppliers.utils";
+
+interface SuppliersTableRowProps {
+  supplier: PlatformSupplierSummary;
+  onEdit: (supplier: PlatformSupplierSummary) => void;
+  onDelete: (supplier: PlatformSupplierSummary) => void;
+}
+
+export default function SuppliersTableRow({ supplier, onEdit, onDelete }: SuppliersTableRowProps) {
+  return (
+    <TableRow>
+      <TableCell className="max-w-[18rem]">
+        <div className="flex flex-col">
+          <span className="font-medium break-words whitespace-normal">{supplier.name}</span>
+          <span className="text-muted-foreground text-xs break-words whitespace-normal">
+            {supplier.code}
+          </span>
+        </div>
+      </TableCell>
+
+      <TableCell>{supplier.country}</TableCell>
+
+      <TableCell>
+        <Badge variant={supplier.isActive ? "default" : "secondary"}>
+          {supplier.isActive ? "Active" : "Inactive"}
+        </Badge>
+      </TableCell>
+
+      <TableCell className="max-w-[16rem]">
+        {supplier.websiteUrl ? (
+          <span className="block truncate text-sm">{supplier.websiteUrl}</span>
+        ) : (
+          <span className="text-muted-foreground text-sm">None</span>
+        )}
+      </TableCell>
+
+      <TableCell className="w-[1%] whitespace-nowrap">
+        <div className="flex items-center justify-end gap-2">
+          <Button size="sm" variant="outline" onClick={() => onEdit(supplier)}>
+            <Pencil aria-hidden="true" className="size-4" />
+            Edit
+          </Button>
+          <Button size="sm" variant="outline" onClick={() => onDelete(supplier)}>
+            <Trash2 aria-hidden="true" className="size-4" />
+            Delete
+          </Button>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/components/platform/suppliers/suppliers-table.tsx
+++ b/src/components/platform/suppliers/suppliers-table.tsx
@@ -1,0 +1,57 @@
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+import SuppliersTableRow from "./suppliers-table-row";
+import type { PlatformSupplierSummary } from "./suppliers.utils";
+
+interface SuppliersTableProps {
+  suppliers: PlatformSupplierSummary[];
+  onEdit: (supplier: PlatformSupplierSummary) => void;
+  onDelete: (supplier: PlatformSupplierSummary) => void;
+}
+
+export default function SuppliersTable({ suppliers, onEdit, onDelete }: SuppliersTableProps) {
+  return (
+    <Card className="hidden md:block">
+      <CardContent className="space-y-4">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Supplier</TableHead>
+              <TableHead>Country</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Website</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+
+          <TableBody>
+            {suppliers.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-muted-foreground py-8 text-center text-sm">
+                  No suppliers found.
+                </TableCell>
+              </TableRow>
+            ) : (
+              suppliers.map((supplier) => (
+                <SuppliersTableRow
+                  key={supplier.id}
+                  supplier={supplier}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                />
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/platform/suppliers/suppliers-toolbar.tsx
+++ b/src/components/platform/suppliers/suppliers-toolbar.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Search } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+interface SuppliersToolbarProps {
+  search: string;
+  onSearchChange: (value: string) => void;
+  showInactive: boolean;
+  onShowInactiveChange: (value: boolean) => void;
+}
+
+export default function SuppliersToolbar({
+  search,
+  onSearchChange,
+  showInactive,
+  onShowInactiveChange,
+}: SuppliersToolbarProps) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <div className="relative flex-1">
+        <Search
+          aria-hidden="true"
+          className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2"
+        />
+        <Input
+          aria-label="Search suppliers"
+          placeholder="Search by supplier name, code, country, or website..."
+          value={search}
+          onChange={(event) => onSearchChange(event.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      <div className="border-border bg-card flex items-center justify-between gap-3 rounded-md border px-3 py-2 sm:justify-start">
+        <Label htmlFor="show-inactive-suppliers" className="text-sm whitespace-nowrap">
+          Show inactive
+        </Label>
+        <Switch
+          id="show-inactive-suppliers"
+          checked={showInactive}
+          onCheckedChange={onShowInactiveChange}
+          aria-label="Show inactive suppliers"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/platform/suppliers/suppliers.utils.ts
+++ b/src/components/platform/suppliers/suppliers.utils.ts
@@ -1,0 +1,86 @@
+export interface PlatformSupplierSummary {
+  id: number;
+  name: string;
+  code: string;
+  country: string;
+  websiteUrl: string | null;
+  isActive: boolean;
+  createdAt: string;
+}
+
+export type PlatformSupplierRecord = PlatformSupplierSummary;
+
+type SupplierApiRecord = {
+  id: number;
+  name: string;
+  code: string;
+  country: string;
+  websiteUrl: string | null;
+  isActive: boolean;
+  createdAt: string | Date;
+};
+
+export function normalizePlatformSupplier(record: SupplierApiRecord): PlatformSupplierRecord {
+  return {
+    id: record.id,
+    name: record.name,
+    code: record.code,
+    country: record.country,
+    websiteUrl: record.websiteUrl,
+    isActive: record.isActive,
+    createdAt: toIsoString(record.createdAt),
+  };
+}
+
+export function toPlatformSupplierSummary(record: PlatformSupplierRecord): PlatformSupplierSummary {
+  return {
+    id: record.id,
+    name: record.name,
+    code: record.code,
+    country: record.country,
+    websiteUrl: record.websiteUrl,
+    isActive: record.isActive,
+    createdAt: record.createdAt,
+  };
+}
+
+export function filterSuppliers(
+  suppliers: PlatformSupplierSummary[],
+  search: string,
+  showInactive: boolean,
+) {
+  const normalizedSearch = search.trim().toLowerCase();
+
+  return [...suppliers]
+    .filter((supplier) => {
+      if (!showInactive && !supplier.isActive) {
+        return false;
+      }
+
+      if (!normalizedSearch) {
+        return true;
+      }
+
+      return [supplier.name, supplier.code, supplier.country, supplier.websiteUrl ?? ""].some(
+        (value) => value.toLowerCase().includes(normalizedSearch),
+      );
+    })
+    .sort(compareSuppliers);
+}
+
+export function compareSuppliers(a: PlatformSupplierSummary, b: PlatformSupplierSummary) {
+  if (a.isActive !== b.isActive) {
+    return a.isActive ? -1 : 1;
+  }
+
+  const codeCompare = a.code.localeCompare(b.code);
+  if (codeCompare !== 0) {
+    return codeCompare;
+  }
+
+  return a.name.localeCompare(b.name);
+}
+
+function toIsoString(value: string | Date) {
+  return value instanceof Date ? value.toISOString() : value;
+}

--- a/src/lib/validation/suppliers.ts
+++ b/src/lib/validation/suppliers.ts
@@ -2,6 +2,28 @@ import { z } from "zod";
 
 import { sanitizeText, sanitizedNonEmpty } from "@/lib/validation/sanitize";
 
+const supplierWebsiteSchema = z
+  .string()
+  .trim()
+  .max(300)
+  .refine((value) => isValidSupplierWebsite(value), {
+    message: "Enter a valid website",
+  })
+  .transform((v) => sanitizeText(v));
+
+function isValidSupplierWebsite(value: string) {
+  if (!value || /\s/.test(value)) return false;
+
+  const candidate = /^[a-z][a-z\d+\-.]*:\/\//i.test(value) ? value : `https://${value}`;
+
+  try {
+    const url = new URL(candidate);
+    return url.hostname.includes(".");
+  } catch {
+    return false;
+  }
+}
+
 /**
  * ---------------------------
  * Params: Supplier ID
@@ -36,12 +58,7 @@ export const createSupplierBodySchema = z
     name: sanitizedNonEmpty(200),
     code: sanitizedNonEmpty(50),
     country: sanitizedNonEmpty(100),
-    website_url: z
-      .string()
-      .trim()
-      .url()
-      .transform((v) => sanitizeText(v))
-      .optional(),
+    website_url: supplierWebsiteSchema.optional(),
     is_active: z.boolean().optional(),
   })
   .strict();
@@ -60,13 +77,7 @@ export const updateSupplierBodySchema = z
     name: sanitizedNonEmpty(200).optional(),
     code: sanitizedNonEmpty(50).optional(),
     country: sanitizedNonEmpty(100).optional(),
-    website_url: z
-      .string()
-      .trim()
-      .url()
-      .transform((v) => sanitizeText(v))
-      .nullable()
-      .optional(),
+    website_url: supplierWebsiteSchema.nullable().optional(),
     is_active: z.boolean().optional(),
   })
   .strict()

--- a/src/lib/validation/suppliers.ts
+++ b/src/lib/validation/suppliers.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { sanitizeText, sanitizedNonEmpty } from "@/lib/validation/sanitize";
 
-const supplierWebsiteSchema = z
+export const supplierWebsiteSchema = z
   .string()
   .trim()
   .max(300)


### PR DESCRIPTION
## Summary

Adds a platform suppliers management page for maintaining the global supplier catalog used by shipment imports and tenant shipment records.

## Changes

- Added a suppliers dashboard with searchable, paginated supplier listings.
- Added desktop table and mobile card views for supplier records.
- Added create and edit supplier dialogs for name, code, country, website, and active status.
- Added delete confirmation flow with API error handling for suppliers referenced by shipments.
- Shows supplier websites as plain text instead of clickable links.
- Allows supplier websites to be saved without requiring https://.
- Added API test coverage for platform supplier create, update, delete, validation, conflicts, and protocol-less websites.
